### PR TITLE
Add `mix hex.user whoami`

### DIFF
--- a/lib/mix/tasks/hex/user.ex
+++ b/lib/mix/tasks/hex/user.ex
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Hex.User do
 
   defp whoami?(opts) do
     case Keyword.fetch(Hex.Util.read_config, :username) do
-       {:ok, value} -> Mix.shell.info(value)
+       {:ok, value} -> Mix.Shell.IO.info(value)
        :error       -> Mix.raise "Config does not contain a username!"
     end
   end

--- a/test/mix/tasks/hex/user_test.exs
+++ b/test/mix/tasks/hex/user_test.exs
@@ -26,24 +26,6 @@ defmodule Mix.Tasks.Hex.UserTest do
     assert HexWeb.User.get(username: "eric").email == "mail@mail.com"
   end
 
-  test "whoami" do
-    in_tmp fn ->
-      Hex.home(System.cwd!)
-
-      send self, {:mix_shell_input, :prompt, "eric"}
-      send self, {:mix_shell_input, :prompt, "mail@mail.com"}
-      send self, {:mix_shell_input, :yes?, false}
-
-      capture_io "hunter42\nhunter42\n", fn ->
-        Mix.Tasks.Hex.User.run(["register", "--no-clean-pass"])
-      end
-
-      assert capture_io fn ->
-         Mix.Tasks.Hex.User.run(["whoami"])
-      end =="eric\n"
-    end
-  end
-
   test "auth" do
     in_tmp fn ->
       Hex.home(System.cwd!)
@@ -95,4 +77,19 @@ defmodule Mix.Tasks.Hex.UserTest do
       assert is_binary(Hex.Util.read_config[:key])
     end
   end
+
+  test "whoami" do
+    in_tmp fn ->
+      Hex.home(System.cwd!)
+
+      Hex.Util.update_config([username: "ausername"])
+
+      assert Hex.Util.read_config[:username] == "ausername"
+
+      assert capture_io(fn ->
+         Mix.Tasks.Hex.User.run(["whoami"])
+      end) == (Hex.Util.read_config[:username] <> "\n")
+    end
+  end
+
 end


### PR DESCRIPTION
This PR adds the mix task `mix hex.user whoami` which simply prints the authenticated users username.

Tests included :smile:

:dancer:
