### PR TITLE
Correct invalid arguments list in mix hex.user

### DIFF
--- a/lib/mix/tasks/hex/user.ex
+++ b/lib/mix/tasks/hex/user.ex
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Hex.User do
         update(opts)
       _ ->
         Mix.raise "Invalid arguments, expected one of:\nmix hex.user register\n" <>
-                  "mix hex.user auth\nmix hex.user update'"
+                  "mix hex.user auth\nmix hex.user update\nmix hex.user whoami'"
     end
   end
 


### PR DESCRIPTION
``` text
** (Mix) Invalid arguments, expected one of:
mix hex.user register
mix hex.user auth
mix hex.user update
```

to

``` text
** (Mix) Invalid arguments, expected one of:
mix hex.user register
mix hex.user auth
mix hex.user update
mix hex.user whoami
```

:dancer:
