### PR TITLE
Fix hex.user update: should compare new_password with confirmed password

### DIFF
--- a/lib/mix/tasks/hex/user.ex
+++ b/lib/mix/tasks/hex/user.ex
@@ -98,7 +98,7 @@ defmodule Mix.Tasks.Hex.User do
 
     unless is_nil(new_password) do
       confirm = Util.password_get("Password (confirm):", clean?) |> String.strip |> nillify
-      if password != confirm do
+      if new_password != confirm do
         Mix.raise "Entered passwords do not match"
       end
     end


### PR DESCRIPTION
Bug: when updating user details, it compares current password with confirm password.

It should instead compare new password with confirmed password.
