### PR TITLE
Move documentation API code into a separate module

### DIFF
--- a/lib/hex/api/release.ex
+++ b/lib/hex/api/release.ex
@@ -15,19 +15,4 @@ defmodule Hex.API.Release do
     url = API.api_url("packages/#{name}/releases/#{version}")
     API.request(:delete, url, API.auth(auth))
   end
-
-  def get_docs(name, version) do
-    url = API.api_url("packages/#{name}/releases/#{version}/docs")
-    API.request(:get, url, [])
-  end
-
-  def new_docs(name, version, tar, auth, progress \\ fn _ -> end) do
-    url = API.api_url("packages/#{name}/releases/#{version}/docs")
-    API.request_tar(:post, url, API.auth(auth), tar, progress)
-  end
-
-  def delete_docs(name, version, auth) do
-    url = API.api_url("packages/#{name}/releases/#{version}/docs")
-    API.request(:delete, url, API.auth(auth))
-  end
 end

--- a/lib/hex/api/release_docs.ex
+++ b/lib/hex/api/release_docs.ex
@@ -1,0 +1,18 @@
+defmodule Hex.API.ReleaseDocs do
+  alias Hex.API
+
+  def get(name, version) do
+    url = API.api_url("packages/#{name}/releases/#{version}/docs")
+    API.request(:get, url, [])
+  end
+
+  def new(name, version, tar, auth, progress \\ fn _ -> end) do
+    url = API.api_url("packages/#{name}/releases/#{version}/docs")
+    API.request_tar(:post, url, API.auth(auth), tar, progress)
+  end
+
+  def delete(name, version, auth) do
+    url = API.api_url("packages/#{name}/releases/#{version}/docs")
+    API.request(:delete, url, API.auth(auth))
+  end
+end

--- a/lib/mix/tasks/hex/docs.ex
+++ b/lib/mix/tasks/hex/docs.ex
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.Hex.Docs do
       progress = Util.progress(nil)
     end
 
-    case Hex.API.Release.new_docs(app, version, tarball, auth, progress) do
+    case Hex.API.ReleaseDocs.new(app, version, tarball, auth, progress) do
       {code, _} when code in [200, 201] ->
         Mix.shell.info("")
         Mix.shell.info("Published docs for #{app} v#{version}")
@@ -81,7 +81,7 @@ defmodule Mix.Tasks.Hex.Docs do
   defp revert(app, version, auth) do
     version = Util.clean_version(version)
 
-    case Hex.API.Release.delete_docs(app, version, auth) do
+    case Hex.API.ReleaseDocs.delete(app, version, auth) do
       {204, _} ->
         Mix.shell.info("Reverted docs for #{app} v#{version}")
       {code, body} ->

--- a/test/hex/api_test.exs
+++ b/test/hex/api_test.exs
@@ -56,11 +56,11 @@ defmodule Hex.APITest do
     :ok = :erl_tar.create(tarball, [{'index.html', "heya"}], [:compressed])
     tar = File.read!(tarball)
 
-    assert {201, _} = Hex.API.Release.new_docs("tangerine", "0.0.1", tar, auth)
-    assert {200, ^tar} = Hex.API.Release.get_docs("tangerine", "0.0.1")
+    assert {201, _} = Hex.API.ReleaseDocs.new("tangerine", "0.0.1", tar, auth)
+    assert {200, ^tar} = Hex.API.ReleaseDocs.get("tangerine", "0.0.1")
 
-    assert {204, _} = Hex.API.Release.delete_docs("tangerine", "0.0.1", auth)
-    assert {404, _} = Hex.API.Release.get_docs("tangerine", "0.0.1")
+    assert {204, _} = Hex.API.ReleaseDocs.delete("tangerine", "0.0.1", auth)
+    assert {404, _} = Hex.API.ReleaseDocs.get("tangerine", "0.0.1")
   end
 
   test "registry" do


### PR DESCRIPTION
Simply moves documentation API from `Hex.API.Release` to `Hex.API.ReleaseDocs`, changing the method call names as such:

`API.Release.get_docs/2` -> `API.ReleaseDocs.get/2`
`API.Release.new_docs/5` -> `API.ReleaseDocs.new/5`
`API.Release.delete_docs/3` -> `API.ReleaseDocs.delete/3`

Unit tests and mix tasks calling the old methods have been changed accordingly, and all pass.

:heart: 

> edit: get_docs/2, new_docs/5 and delete_docs/3; not get/2, new/5 and delete/3
