### PR TITLE
Allow setting CDN, API URL and HTTP proxy settings in Hex config

### DIFF
--- a/lib/mix/tasks/hex/config.ex
+++ b/lib/mix/tasks/hex/config.ex
@@ -7,6 +7,14 @@ defmodule Mix.Tasks.Hex.Config do
   Reads or updates hex configuration file.
 
   `mix hex.config KEY [VALUE]`
+
+ ## Config keys
+  - `username` - Hex username
+  - `key` - Hex API key
+  - `api_url` - Hex API base URL (without trailing slash)
+  - `cdn_url` - Hex CDN base URL (without trailing slash)
+  - `http_proxy` - HTTP proxy server
+  - `https_proxy` - HTTPS proxy server
   """
 
   def run(args) do
@@ -21,6 +29,7 @@ defmodule Mix.Tasks.Hex.Config do
         end
       [key, value] ->
         Hex.Config.update([{:"#{key}", value}])
+        Mix.shell.info("#{key}: #{inspect(value, pretty: true)}")
       _ ->
         Mix.raise "Invalid arguments, expected: mix hex.config KEY [VALUE]"
     end

--- a/lib/mix/tasks/hex/user.ex
+++ b/lib/mix/tasks/hex/user.ex
@@ -60,7 +60,8 @@ defmodule Mix.Tasks.Hex.User do
   end
 
   defp whoami() do
-    case Keyword.fetch(Hex.Config.read, :username) do
+    config = Hex.Config.read
+    case Keyword.fetch(config, :username) do
        {:ok, username} ->
         Mix.shell.info(username)
        :error ->


### PR DESCRIPTION
This pull request allows users to set the following configuration settings from the config file:

- API URL
- CDN URL
- HTTP proxy
- HTTPS proxy

>Note: Sadly, setting the home directory from the config file is impossible.

This allows users to do the following:
```shell
$ mix hex.config api_url http://hex.internal.corporation.com
$ mix hex.config cdn_url http://cdn.hex.internal.corporation.com
```

:christmas_tree: :fireworks: Merry Christmas and a Happy New Year!