### PR TITLE
Add root task (mix hex), replaces hex.info

### DIFF
--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -1,0 +1,65 @@
+defmodule Mix.Tasks.Hex do
+  use Mix.Task
+
+  @shortdoc "Print hex system information"
+
+  @moduledoc """
+  Prints hex system information. This includes when
+  registry was last updated and current system version.
+
+  `mix hex`
+  """
+
+  def run(args) do
+    {_opts, args, _} = OptionParser.parse(args)
+    Hex.start
+    Hex.Util.ensure_registry(cache: false)
+
+    case args do
+      [] -> general()
+      _ ->
+        Mix.raise "Invalid arguments, expected: mix hex"
+    end
+  end
+
+  defp general() do
+    Mix.shell.info("Hex v" <> Hex.version)
+    line_break()
+
+    path = Hex.Registry.path()
+    stat = File.stat!(path)
+    {packages, releases} = Hex.Registry.stat()
+
+    Mix.shell.info("Registry file available (last updated: #{pretty_date(stat.mtime)})")
+    Mix.shell.info("Size: #{div stat.size, 1024}kB")
+    Mix.shell.info("Packages #: #{packages}")
+    Mix.shell.info("Versions #: #{releases}")
+
+    if Version.match?(System.version, ">= 1.1.0-dev") do
+      line_break()
+      Mix.shell.info("Available tasks:")
+      line_break()
+      Mix.Task.run("help", ["--search", "hex."])
+    end
+
+    line_break()
+    Mix.shell.info("Further information can be found here: https://hex.pm/docs/tasks")
+  end
+
+  defp pretty_date({{year, month, day}, {hour, min, sec}}) do
+    "#{pad(year, 4)}-#{pad(month, 2)}-#{pad(day, 2)} " <>
+    "#{pad(hour, 2)}:#{pad(min, 2)}:#{pad(sec, 2)}"
+  end
+
+  defp pad(int, padding) do
+    str = to_string(int)
+    padding = max(padding-byte_size(str), 0)
+    do_pad(str, padding)
+  end
+
+  defp do_pad(str, 0), do: str
+  defp do_pad(str, n), do: do_pad("0" <> str, n-1)
+
+  defp line_break(), do: Mix.shell.info("")
+end
+

--- a/lib/mix/tasks/hex/info.ex
+++ b/lib/mix/tasks/hex/info.ex
@@ -1,15 +1,12 @@
 defmodule Mix.Tasks.Hex.Info do
   use Mix.Task
 
-  @shortdoc "Print hex information"
+  @shortdoc "Print hex package information"
 
   @moduledoc """
-  Prints hex package or system information.
+  Prints hex package information.
 
-  `mix hex.info [PACKAGE [VERSION]]`
-
-  If `package` is not given, print system information. This includes when
-  registry was last updated and current system version.
+  `mix hex.info PACKAGE [VERSION]`
 
   If `package` is given, print information about the package. This includes all
   released versions and package metadata.
@@ -24,26 +21,11 @@ defmodule Mix.Tasks.Hex.Info do
     Hex.Util.ensure_registry(cache: false)
 
     case args do
-      [] -> general()
       [package] -> package(package)
       [package, version] -> release(package, version)
       _ ->
-        Mix.raise "Invalid arguments, expected: mix hex.info [PACKAGE [VERSION]]"
+        Mix.raise "Invalid arguments, expected: mix hex.info PACKAGE [VERSION]"
     end
-  end
-
-  defp general() do
-    Mix.shell.info("Hex v" <> Hex.version)
-    Mix.shell.info("")
-
-    path = Hex.Registry.path()
-    stat = File.stat!(path)
-    {packages, releases} = Hex.Registry.stat()
-
-    Mix.shell.info("Registry file available (last updated: #{pretty_date(stat.mtime)})")
-    Mix.shell.info("Size: #{div stat.size, 1024}kB")
-    Mix.shell.info("Packages #: #{packages}")
-    Mix.shell.info("Versions #: #{releases}")
   end
 
   defp package(package) do
@@ -75,7 +57,7 @@ defmodule Mix.Tasks.Hex.Info do
   defp pretty_package(package) do
     Mix.shell.info(package["name"])
     Mix.shell.info("  Releases: " <> Enum.map_join(package["releases"], ", ", &(&1["version"])))
-    Mix.shell.info("")
+    line_break()
     pretty_meta(package["meta"])
   end
 
@@ -85,7 +67,7 @@ defmodule Mix.Tasks.Hex.Info do
     pretty_dict(meta, "links")
 
     if descr = meta["description"] do
-      Mix.shell.info("")
+      line_break()
       Mix.shell.info(descr)
     end
   end
@@ -126,17 +108,6 @@ defmodule Mix.Tasks.Hex.Info do
     end
   end
 
-  defp pretty_date({{year, month, day}, {hour, min, sec}}) do
-    "#{pad(year, 4)}-#{pad(month, 2)}-#{pad(day, 2)} " <>
-    "#{pad(hour, 2)}:#{pad(min, 2)}:#{pad(sec, 2)}"
-  end
-
-  defp pad(int, padding) do
-    str = to_string(int)
-    padding = max(padding-byte_size(str), 0)
-    do_pad(str, padding)
-  end
-
-  defp do_pad(str, 0), do: str
-  defp do_pad(str, n), do: do_pad("0" <> str, n-1)
+  defp line_break(), do: Mix.shell.info("")
 end
+

--- a/test/mix/tasks/hex/info_test.exs
+++ b/test/mix/tasks/hex/info_test.exs
@@ -8,13 +8,13 @@ defmodule Mix.Tasks.Hex.InfoTest do
       Hex.home(System.cwd!)
       HexWeb.RegistryBuilder.rebuild
 
-      Mix.Tasks.Hex.Info.run(["ex_doc"])
+      Mix.Tasks.Hex.run(["ex_doc"])
 
       assert_received {:mix_shell, :info, ["ex_doc"]}
       assert_received {:mix_shell, :info, ["  Contributors: John Doe, Jane Doe"]}
       assert_received {:mix_shell, :info, ["builds docs"]}
 
-      Mix.Tasks.Hex.Info.run(["no_package"])
+      Mix.Tasks.Hex.run(["no_package"])
       assert_received {:mix_shell, :error, ["No package with name no_package"]}
     end
   end
@@ -25,30 +25,11 @@ defmodule Mix.Tasks.Hex.InfoTest do
       Hex.home(System.cwd!)
       HexWeb.RegistryBuilder.rebuild
 
-      Mix.Tasks.Hex.Info.run(["ex_doc", "0.0.1"])
+      Mix.Tasks.Hex.run(["ex_doc", "0.0.1"])
       assert_received {:mix_shell, :info, ["ex_doc v0.0.1"]}
 
-      Mix.Tasks.Hex.Info.run(["ex_doc", "1.2.3"])
+      Mix.Tasks.Hex.run(["ex_doc", "1.2.3"])
       assert_received {:mix_shell, :error, ["No release with name ex_doc v1.2.3"]}
-    end
-  end
-
-  test "general" do
-    in_tmp fn ->
-      Hex.Registry.start!(registry_path: tmp_path("registry.ets"))
-      Hex.home(System.cwd!)
-      HexWeb.RegistryBuilder.rebuild
-
-      assert {200, data} = Hex.API.Registry.get
-      File.write!(Hex.Registry.path, :zlib.gunzip(data))
-      Mix.Tasks.Hex.Info.run([])
-
-      message = "Hex v" <> Hex.version
-      assert_received {:mix_shell, :info, [^message]}
-      assert_received {:mix_shell, :info, ["Registry file available (last updated: " <> _]}
-      assert_received {:mix_shell, :info, ["Size: " <> _]}
-      assert_received {:mix_shell, :info, ["Packages #: " <> _]}
-      assert_received {:mix_shell, :info, ["Versions #: " <> _]}
     end
   end
 end

--- a/test/mix/tasks/hex/root_test.exs
+++ b/test/mix/tasks/hex/root_test.exs
@@ -1,0 +1,23 @@
+defmodule Mix.Tasks.Hex.RootTest do
+  use HexTest.Case
+  @moduletag :integration
+
+  test "general" do
+    in_tmp fn ->
+      Hex.Registry.start!(registry_path: tmp_path("registry.ets"))
+      Hex.home(System.cwd!)
+      HexWeb.RegistryBuilder.rebuild
+
+      assert {200, data} = Hex.API.Registry.get
+      File.write!(Hex.Registry.path, :zlib.gunzip(data))
+      Mix.Tasks.Hex.run([])
+
+      message = "Hex v" <> Hex.version
+      assert_received {:mix_shell, :info, [^message]}
+      assert_received {:mix_shell, :info, ["Registry file available (last updated: " <> _]}
+      assert_received {:mix_shell, :info, ["Size: " <> _]}
+      assert_received {:mix_shell, :info, ["Packages #: " <> _]}
+      assert_received {:mix_shell, :info, ["Versions #: " <> _]}
+    end
+  end
+end


### PR DESCRIPTION
Closes #65

Changes:

- Adds root task (`mix hex`); delegates to `hex.info`.
- Improves `hex.info`
  - Adds CLI spinner when waiting for the registry (also includes `hex.search`)
  - Replace all `Mix.shell.info("")` calls with a more meaningful function call (`line_break`)

Originally #74, but I've opened a new pull request because of the merge conflict.