### PR TITLE
Add 'mix hex.user reset'; remove 'mix hex.user update'

### DIFF
--- a/lib/hex/api/user.ex
+++ b/lib/hex/api/user.ex
@@ -10,13 +10,7 @@ defmodule Hex.API.User do
             %{username: username, email: email, password: password})
   end
 
-  def update(email, password, auth) do
-    body = %{}
-    if email, do: body = Map.merge(body, %{email: email})
-    if password, do: body = Map.merge(body, %{password: password})
-
-    headers = Dict.merge(API.auth(auth), %{'x-http-method-override' => 'PATCH'})
-
-    API.request(:post, API.api_url("users/#{auth[:user]}"), headers, body)
+  def password_reset(name) do
+    API.request(:post, API.api_url("/users/#{name}/reset"), [], %{})
   end
 end

--- a/lib/mix/tasks/hex/user.ex
+++ b/lib/mix/tasks/hex/user.ex
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Hex.User do
 
   ### Reset user password
 
-  `mix hex.user update`
+  `mix hex.user reset password`
   """
 
   @switches [clean_pass: :boolean]
@@ -51,11 +51,11 @@ defmodule Mix.Tasks.Hex.User do
         create_key(opts)
       ["deauth"] ->
         deauth()
-      ["reset"] ->
-        reset()
+      ["reset", "password"] ->
+        reset_password()
       _ ->
         Mix.raise "Invalid arguments, expected one of:\nmix hex.user register\n" <>
-                  "mix hex.user auth\nmix hex.user whoami\nmix hex.user deauth\nmix hex.user reset"
+                  "mix hex.user auth\nmix hex.user whoami\nmix hex.user deauth\nmix hex.user reset password"
     end
   end
 
@@ -70,7 +70,7 @@ defmodule Mix.Tasks.Hex.User do
     end
   end
 
-  defp reset() do
+  defp reset_password() do
     name = Mix.shell.prompt("Username or Email:") |> String.strip
 
     case Hex.API.User.password_reset(name) do

--- a/lib/mix/tasks/hex/user.ex
+++ b/lib/mix/tasks/hex/user.ex
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Hex.User do
 
   `mix hex.user deauth`
 
-  ### Update user configuration
+  ### Reset user password
 
   `mix hex.user update`
   """
@@ -51,11 +51,11 @@ defmodule Mix.Tasks.Hex.User do
         create_key(opts)
       ["deauth"] ->
         deauth()
-      ["update"] ->
-        update(opts)
+      ["reset"] ->
+        reset()
       _ ->
         Mix.raise "Invalid arguments, expected one of:\nmix hex.user register\n" <>
-                  "mix hex.user auth\nmix hex.user update\nmix hex.user whoami\nmix hex.user deauth"
+                  "mix hex.user auth\nmix hex.user whoami\nmix hex.user deauth\nmix hex.user reset"
     end
   end
 
@@ -67,6 +67,20 @@ defmodule Mix.Tasks.Hex.User do
        :error ->
         Mix.raise "No user authorised on the local machine. Run `mix hex.user auth` " <>
                   "or create a new user with `mix hex.user register`"
+    end
+  end
+
+  defp reset() do
+    name = Mix.shell.prompt("Username or Email:") |> String.strip
+
+    case Hex.API.User.password_reset(name) do
+      {code, _} when code in 200..299 ->
+        Mix.shell.info "We’ve sent you an email containing a link that will allow you to reset your password for the next 24 hours. " <>
+                       "Please check your spam folder if the email doesn’t appear within a few minutes."
+      {code, body} ->
+        Mix.shell.error("Initiating password reset for #{name} failed")
+        Hex.Util.print_http_code(code)
+        Hex.Util.print_error_result(code, body)
     end
   end
 
@@ -84,39 +98,6 @@ defmodule Mix.Tasks.Hex.User do
       :error ->
         Mix.raise "No user authorised on the local machine. Run `mix hex.user auth` " <>
                   "or create a new user with `mix hex.user register`"
-    end
-  end
-
-  defp update(opts) do
-    clean? = Keyword.get(opts, :clean_pass, true)
-
-    username = Mix.shell.prompt("Username:")          |> String.strip
-    password = Util.password_get("Password:", clean?) |> String.strip
-
-    Mix.shell.info("Update user options (leave blank to not change an option)")
-    new_email    = Mix.shell.prompt("New email:")             |> String.strip |> nillify
-    new_password = Util.password_get("New password:", clean?) |> String.strip |> nillify
-
-    unless is_nil(new_password) do
-      confirm = Util.password_get("New password (confirm):", clean?) |> String.strip |> nillify
-      if new_password != confirm do
-        Mix.raise "Entered passwords do not match"
-      end
-    end
-
-    update_user(username, password, new_email, new_password)
-  end
-
-  defp update_user(username, password, new_email, new_password) do
-    auth = [user: username, pass: password]
-
-    case Hex.API.User.update(new_email, new_password, auth) do
-      {code, _} when code in 200..299 ->
-        Hex.Config.update([username: username])
-      {code, body} ->
-        Mix.shell.error("Updating user options for #{auth[:user]} failed")
-        Hex.Util.print_http_code(code)
-        Hex.Util.print_error_result(code, body)
     end
   end
 
@@ -159,7 +140,4 @@ defmodule Mix.Tasks.Hex.User do
 
     Util.generate_key(username, password)
   end
-
-  defp nillify(""), do: nil
-  defp nillify(str), do: str
 end

--- a/test/hex/api_test.exs
+++ b/test/hex/api_test.exs
@@ -12,10 +12,6 @@ defmodule Hex.APITest do
     auth = [user: "test_user", pass: "hunter42"]
     assert {200, body} = Hex.API.User.get("test_user", auth)
     assert body["username"] == "test_user"
-
-    assert {200, _} = Hex.API.User.update("new_mail@mail.com", nil, auth)
-    assert {200, body} = Hex.API.User.get("test_user", auth)
-    assert body["email"] == "new_mail@mail.com"
   end
 
   test "package" do

--- a/test/mix/tasks/hex/user_test.exs
+++ b/test/mix/tasks/hex/user_test.exs
@@ -58,21 +58,6 @@ defmodule Mix.Tasks.Hex.UserTest do
     end
   end
 
-  test "update" do
-    {:ok, _} = HexWeb.User.create("update_user", "old@mail.com", "hunter42", true)
-
-    send self, {:mix_shell_input, :prompt, "update_user"}
-
-    send self, {:mix_shell_input, :prompt, "new@mail.com"}
-    send self, {:mix_shell_input, :yes?, false}
-
-    capture_io "hunter42\n\n", fn ->
-      Mix.Tasks.Hex.User.run(["update", "--no-clean-pass"])
-    end
-
-    assert HexWeb.User.get(username: "update_user").email == "new@mail.com"
-  end
-
   test "update config" do
     in_tmp fn ->
       Hex.home(System.cwd!)


### PR DESCRIPTION
Related to hexpm/hex_web#89;

Changes:
- Adds the mix task `mix hex.user reset`. This accepts either a username *or* email address belonging to an account.
- Removes `mix hex.user reset`

:closed_lock_with_key: :key: 
