### PR TITLE
WIP: Better error messages when dependency resolution fails

### DIFF
--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -95,12 +95,14 @@ defmodule Hex.RemoteConverger do
 
     if unlocked != [] do
       Mix.shell.info "Running dependency resolution"
-      Mix.shell.info "Unlocked:   " <> Enum.join(unlocked, ", ")
+      Mix.shell.info "Unlocked: " <> Enum.join(unlocked, ", ")
 
       if overridden != [],
         do: Mix.shell.info "Overridden: " <> Enum.join(overridden, ", ")
       if skipping != [],
-        do: Mix.shell.info "Skipping:   " <> Enum.join(skipping, ", ")
+        do: Mix.shell.info "Skipping: " <> Enum.join(skipping, ", ")
+
+      Mix.shell.info ""
     end
   end
 


### PR DESCRIPTION
I have been thinking for a long time on how we can give good error messages when the dependency resolution fails. It's very tricky to do because of the resolution algorithm we use (we try every possible combination of all packages, with some shortcuts and optimizations). Because of this we cannot directly tell the user where the resolution failed (there were potentially many failures that we backtracked from) or how to fix it.

The approach I do here is to print every time we backtrack and say on which package we backtracked on and why. The advantage of this approach is that if resolution failed we will always print why. The drawback is that the backtracks can be hard for users to understand (looking for feedback on this) and if you have many unlocked dependencies and is unlucky there can potentially be very many backtracks.

Below is an example of `mix deps.get` that failed because the ecto requirement was changed from "~> 0.7.0" to "~> 0.8.1" in the user's mixfile, but the locked package "scrivener" has the requirement "~> 0.7.2" on ecto. The algorithm only did a single backtrack before failing.

```
Running dependency resolution
Unlocked: ecto
Backtracking on already activated request "ecto" because new requirement didn't match activated version
  From parent: mix.exs with requirement "~> 0.8.1"
  Activated version: "0.7.2
  Activated from parents: "scrivener" with requirement "~> 0.7.2"
** (Mix) Hex dependency resolution failed, relax the version requirements or unlock dependencies
```

TODO:
 * [ ] Only show backtrack output when resolution actually failed (a successful resolution can have backtracks).
 * [ ] Only show backtrack output if the user added `--verbose-backtracks` flag and document the option in the resolution error message.
 * [x] Improve the backtrack messages.

/cc @josevalim 