### PR TITLE
Add root task (mix hex)

### DIFF
--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -1,0 +1,39 @@
+defmodule Mix.Tasks.Hex do
+  use Mix.Task
+
+  @shortdoc "Print hex help information"
+
+  @moduledoc """
+  Prints hex tasks and their information.
+
+  `mix hex`
+  """
+
+  def run(args) do
+    {_opts, args, _} = OptionParser.parse(args)
+    Hex.start
+
+    case args do
+      [] -> general()
+      _ ->
+        Mix.raise "Invalid arguments, expected: mix hex"
+    end
+  end
+
+  defp general() do
+    Mix.shell.info("Hex v" <> Hex.version)
+    Mix.shell.info("Hex is a package manager for the Erlang ecosystem.")
+    line_break()
+
+    if Version.match?(System.version, ">= 1.1.0-dev") do
+      Mix.shell.info("Available tasks:")
+      line_break()
+      Mix.Task.run("help", ["--search", "hex."])
+      line_break()
+    end
+
+    Mix.shell.info("Further information can be found here: https://hex.pm/docs/tasks")
+  end
+
+  def line_break(), do: Mix.shell.info("")
+end


### PR DESCRIPTION
This is in reference to #79. It adds a root task to hex (e.g. `mix hex`)

The output is as follows:

Elixir <1.1.0:

```shell
$ mix hex
Hex v0.7.2-dev
Hex is a package manager for the Erlang ecosystem.

Further information can be found here: https://hex.pm/docs/tasks
```

Elixir >=1.1.0
```shell
$ mix hex
Hex v0.7.2-dev
Hex is a package manager for the Erlang ecosystem.

Available tasks:
mix hex.config  # Read or update hex config
mix hex.docs    # Publish docs for package
mix hex.info    # Print hex information
mix hex.key     # Hex API key tasks
mix hex.owner   # Hex package ownership tasks
mix hex.publish # Publish a new package version
mix hex.search  # Search for package names
mix hex.user    # Hex user tasks

Further information can be found here: https://hex.pm/docs/tasks
```

Output is always the same, as it will never change, except between releases. (e.g. version numbers and task docs).