### PR TITLE
Mix task for hex.outdated.

### DIFF
--- a/lib/mix/tasks/hex/outdated.ex
+++ b/lib/mix/tasks/hex/outdated.ex
@@ -1,0 +1,71 @@
+defmodule Mix.Tasks.Hex.Outdated do
+  use Mix.Task
+
+  @shortdoc "Shows outdated hex deps for the current project"
+
+  @moduledoc """
+  Shows all packages that have a version mismatch between the
+  hex.pm registry and your mix.lock file.
+
+  By default, it only shows (top-level) packages explicitly listed in the `mix.exs` file.
+  All outdated packages can be displayed by using the `--all` command line option.
+
+  ## Command line options
+
+    * `--all` - shows all outdated packages, including packages in `mix.lock` not specified in `mix.exs`.
+
+  `mix hex.outdated`
+  `mix hex.outdated --all`
+  """
+
+  def run(args) do
+    {opts, _args, _} = OptionParser.parse(args, switches: [all: :boolean])
+    Hex.start
+
+    Hex.Util.ensure_registry!()
+
+    case opts[:all] do
+      true -> Mix.Dep.Lock.read
+      _ -> Mix.Dep.Lock.read |> Enum.filter(&top_level?/1)
+    end
+    |> Enum.into(%{})
+    |> Hex.Mix.from_lock
+    |> Enum.map(&get_versions/1)
+    |> Enum.filter(&outdated?/1)
+    |> print_results
+  end
+
+  defp top_level?({app, _details}) do
+    Mix.Dep.loaded([])
+    |> Hex.Mix.top_level
+    |> Enum.map(fn(dep) -> dep.app end)
+    |> Enum.member?(app)
+  end
+
+  defp get_versions({package, _name, lock_version}) do
+    latest_version = package
+    |> Hex.Registry.get_versions
+    |> Enum.reverse
+    |> hd
+
+    {package, lock_version, latest_version}
+  end
+
+  defp outdated?({_package, lock_version, latest_version}) do
+    latest_version != lock_version
+  end
+
+  defp print_results([]) do
+    Mix.shell.info "All packages are up-to-date."
+  end
+  defp print_results(packages) when is_list(packages) do
+    Mix.shell.info "Outdated packages:"
+
+    packages
+    |> Enum.each(&print_package/1)
+  end
+
+  defp print_package({package, lock_version, latest_version}) do
+    Mix.shell.info " * #{package} (#{latest_version} > #{lock_version})"
+  end
+end

--- a/test/mix/tasks/hex/outdated_test.exs
+++ b/test/mix/tasks/hex/outdated_test.exs
@@ -1,0 +1,61 @@
+defmodule Mix.Tasks.Hex.OutdatedTest do
+  use HexTest.Case
+  @moduletag :integration
+
+  defmodule OutdatedDeps.Mixfile do
+    def project do
+      [ app: :outdated_app,
+        version: "0.0.2",
+        deps: [ {:bar, "0.0.1"},
+                {:eric, "0.2.0"} ]]
+    end
+  end
+
+  setup do
+    Hex.Registry.start!(registry_path: tmp_path("registry.ets"))
+    :ok
+  end
+
+  test "outdated" do
+    Mix.Project.push OutdatedDeps.Mixfile
+
+    in_tmp fn ->
+      Hex.home(tmp_path())
+      Mix.Dep.Lock.write %{bar: {:hex, :bar, "0.1.0"}, foo: {:hex, :foo, "0.1.0"}}
+
+      Mix.Task.run "hex.outdated"
+
+      assert_received {:mix_shell, :info, ["Outdated packages:"]}
+      assert_received {:mix_shell, :info, [" * bar (0.2.0 > 0.1.0)"]}
+      refute_received {:mix_shell, :info, [" * foo (0.2.1 > 0.1.0)"]}
+    end
+  end
+
+  test "non outdated" do
+    Mix.Project.push OutdatedDeps.Mixfile
+
+    in_tmp fn ->
+      Hex.home(tmp_path())
+      Mix.Dep.Lock.write %{eric: "0.2.0"}
+
+      Mix.Task.run "hex.outdated"
+
+      assert_received {:mix_shell, :info, ["All packages are up-to-date."]}
+    end
+  end
+
+  test "outdated --all" do
+    Mix.Project.push OutdatedDeps.Mixfile
+
+    in_tmp fn ->
+      Hex.home(tmp_path())
+      Mix.Dep.Lock.write %{bar: {:hex, :bar, "0.1.0"}, foo: {:hex, :foo, "0.1.0"}}
+
+      Mix.Task.run "hex.outdated", ["--all"]
+
+      assert_received {:mix_shell, :info, ["Outdated packages:"]}
+      assert_received {:mix_shell, :info, [" * bar (0.2.0 > 0.1.0)"]}
+      assert_received {:mix_shell, :info, [" * foo (0.2.1 > 0.1.0)"]}
+    end
+  end
+end


### PR DESCRIPTION
Note: I don't think this is ready for merging yet, but I'd love to get some feedback.

This is a task that:
  Shows all packages that have a version mismatch between the
  hex.pm registry and your mix.lock file.

  `mix hex.outdated`

I mainly wrote it because it's a pain to check out hex.pm for every package that I have in my mix.exs every other day to see if something was updated.
This will only print out packages that are specified as a top-level dependency.

The output looks like:
```
ecto is outdated. Latest is 0.10.0, your mix.lock specifies 0.9.0.
kalecto is outdated. Latest is 0.2.1, your mix.lock specifies 0.1.2.
kalends is outdated. Latest is 0.6.1, your mix.lock specifies 0.5.2.
```

The other thing I was having trouble with was how I could write a test for this feature... Any tips would be greatly appreciated!