### PR TITLE
Add support for yellow error messages

### DIFF
--- a/lib/hex/api.ex
+++ b/lib/hex/api.ex
@@ -177,9 +177,8 @@ defmodule Hex.API do
 
   defp warn_ssl_version(version) do
     if version < @secure_ssl_version do
-      # TODO: print yellow
-      Mix.shell.error("Insecure HTTPS request (peer verification disabled), " <>
-                      "please update to OTP 17.4 or later")
+      Hex.Util.yellow_error("Insecure HTTPS request (peer verification disabled), " <>
+                            "please update to OTP 17.4 or later")
     end
   end
 

--- a/lib/hex/registry.ex
+++ b/lib/hex/registry.ex
@@ -48,8 +48,7 @@ defmodule Hex.Registry do
     case :ets.lookup(get_tid(), :"$$installs2$$") do
       [{:"$$installs2$$", installs}] ->
         if version = latest_version(installs) do
-          # TODO: print yellow
-          Mix.shell.error("A new Hex version is available (v#{version}), please update with `mix local.hex`")
+          Hex.Util.yellow_error("A new Hex version is available (v#{version}), please update with `mix local.hex`")
         else
           check_elixir_version(installs)
         end

--- a/lib/hex/util.ex
+++ b/lib/hex/util.ex
@@ -201,4 +201,8 @@ defmodule Hex.Util do
   def hexdocs_url(package, version) do
     "http://hexdocs.pm/#{package}/#{version}/"
   end
+
+  def yellow_error(msg) do
+    Mix.shell.error [IO.ANSI.yellow, msg, IO.ANSI.reset]
+  end
 end

--- a/test/hex/registry_test.exs
+++ b/test/hex/registry_test.exs
@@ -18,10 +18,10 @@ defmodule Hex.RegistryTest do
 
       Hex.Registry.start!
       Hex.Util.ensure_registry!(fetch: false)
-      assert_received {:mix_shell, :error, ["A new Hex version is available" <> _]}
+      assert_received {:mix_shell, :error, ["\e[33mA new Hex version is available" <> _]}
 
       Hex.Util.ensure_registry!(fetch: false)
-      refute_received {:mix_shell, :error, ["A new Hex version is available" <> _]}
+      refute_received {:mix_shell, :error, ["\e[33mA new Hex version is available" <> _]}
     end
   end
 
@@ -37,7 +37,7 @@ defmodule Hex.RegistryTest do
 
       Hex.Registry.start!
       Hex.Util.ensure_registry!(fetch: false)
-      assert_received {:mix_shell, :error, ["A new Hex version is available (v100.0.0), please update with `mix local.hex`"]}
+      assert_received {:mix_shell, :error, ["\e[33mA new Hex version is available (v100.0.0), please update with `mix local.hex`\e[0m"]}
     end
   end
 


### PR DESCRIPTION
As *TODO*ed in f006fda.

Adds function `Hex.Util.yellow_error`, which does as it describes: Formats a Mix.shell.error to be displayed in yellow.