### PR TITLE
Fix typo in Remote Converger

### DIFF
--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -38,7 +38,7 @@ defmodule Hex.RemoteConverger do
         Dict.merge(lock, new_lock)
 
       {:error, messages} ->
-        HexShell.error messages
+        Hex.Shell.error messages
         Mix.raise "Hex dependency resolution failed, relax the version requirements or unlock dependencies"
     end
   end


### PR DESCRIPTION
Fixes typo in 7ab3426, as shown [here](https://github.com/hexpm/hex/commit/7ab342663dd5e1818b9b7b1464c1bc505ecfa62f#diff-2a62a3004b2824bb336a176595988caaR41) (`HexShell` --> `Hex.Shell`)

:apple: 