### PR TITLE
Print a link to the CoC when publishing packages

### DIFF
--- a/lib/mix/tasks/hex/publish.ex
+++ b/lib/mix/tasks/hex/publish.ex
@@ -111,6 +111,7 @@ defmodule Mix.Tasks.Hex.Publish do
     else
 
       print_info(meta, exclude_deps)
+      print_link_to_coc()
 
       if Hex.Shell.yes?("Proceed?") and create_package?(meta, auth) do
         progress? = Keyword.get(opts, :progress, true)
@@ -157,6 +158,11 @@ defmodule Mix.Tasks.Hex.Publish do
       value = meta_value(value)
       Hex.Shell.info("  #{key}: #{value}")
     end
+  end
+
+  defp print_link_to_coc() do
+    Hex.Shell.info "Before publishing the package, make sure you've read " <>
+      "the Hex Code of Conduct, available at https://hex.pm/docs/codeofconduct."
   end
 
   defp meta_value(list) when is_list(list),

--- a/test/mix/tasks/hex/publish_test.exs
+++ b/test/mix/tasks/hex/publish_test.exs
@@ -58,6 +58,10 @@ defmodule Mix.Tasks.Hex.PublishTest do
       Mix.Tasks.Hex.Publish.run(["--no-progress"])
       assert HexWeb.Release.get(HexWeb.Package.get("releasea"), "0.0.1")
 
+      msg = "Before publishing the package, make sure you've read the Hex " <>
+        "Code of Conduct, available at https://hex.pm/docs/codeofconduct."
+      assert_received {:mix_shell, :info, [^msg]}
+
       send self, {:mix_shell_input, :yes?, true}
       Mix.Tasks.Hex.Publish.run(["--revert", "0.0.1"])
       refute HexWeb.Release.get(HexWeb.Package.get("releasea"), "0.0.1")


### PR DESCRIPTION
Took a stab at #105, just to get a feeling of Hex's codebase so that I can try to be more helpful in the future :). Let me know what you think, thanks!