### PR TITLE
improve locked dep error message

### DIFF
--- a/test/hex/resolver_test.exs
+++ b/test/hex/resolver_test.exs
@@ -4,7 +4,7 @@ defmodule Hex.ResolverTest do
   defp resolve(reqs, locked \\ []) do
     case Hex.Resolver.resolve(reqs(reqs), deps(reqs), locked(locked)) do
       {:ok, dict} -> dict
-      {:error, _} -> nil
+      {:error, messages} -> messages
     end
   end
 
@@ -43,10 +43,10 @@ defmodule Hex.ResolverTest do
     assert Dict.equal? locked([foo: "0.2.0", bar: "0.2.0"]), resolve(deps)
 
     deps = [foo: "~> 0.3.0", bar: nil]
-    assert nil = resolve(deps)
+    assert resolve(deps) == "Looking up alternatives for conflicting requirements on foo\n  From mix.exs: ~> 0.3.0"
 
     deps = [foo: nil, bar: "~> 0.3.0"]
-    assert nil = resolve(deps)
+    assert resolve(deps) == "Looking up alternatives for conflicting requirements on bar\n  From mix.exs: ~> 0.3.0"
   end
 
   test "backtrack" do
@@ -63,10 +63,10 @@ defmodule Hex.ResolverTest do
     assert Dict.equal? locked([decimal: "0.1.0", ex_plex: "0.0.1"]), resolve(deps)
 
     deps = [decimal: "0.1.0", ex_plex: "~> 0.0.2"]
-    assert nil = resolve(deps)
+    assert resolve(deps) == "Looking up alternatives for conflicting requirements on decimal\n  Activated version: 0.1.0\n  From ex_plex v0.0.2: 0.1.1\n  From mix.exs: 0.1.0"
 
     deps = [decimal: nil, ex_plex: "0.0.2"]
-    assert nil = resolve(deps)
+    assert resolve(deps) == "Looking up alternatives for conflicting requirements on decimal\n  Activated version: 0.2.1\n  From ex_plex v0.0.2: 0.1.1\n  From mix.exs: "
   end
 
   test "complete backtrack" do
@@ -102,6 +102,16 @@ defmodule Hex.ResolverTest do
     locked = [ex_plex: "0.1.0", decimal: "0.1.0"]
     deps = []
     assert Dict.equal? [], resolve(deps, locked)
+  end
+
+  test "failure due to locked dep" do
+    locked = [decimal: "0.0.1"]
+    deps = [decimal: nil, ex_plex: "0.1.0" ]
+    assert resolve(deps, locked) == "Looking up alternatives for conflicting requirements on decimal\n  Activated version: 0.0.1\n  From ex_plex v0.1.0: ~> 0.1.0\n  From mix.exs: \n  From mix.lock: 0.0.1"
+
+    locked = [decimal: "0.0.1"]
+    deps = [decimal: "~> 0.0.1", ex_plex: "0.1.0" ]
+    assert resolve(deps, locked) == "Looking up alternatives for conflicting requirements on decimal\n  Activated version: 0.0.1\n  From ex_plex v0.1.0: ~> 0.1.0\n  From mix.exs: ~> 0.0.1\n  From mix.lock: 0.0.1"
   end
 
   test "optional" do


### PR DESCRIPTION
Addresses #109.

I used `ExUnit.CaptureIO` to test this as I developed, but removed it because I wasn't sure what the policy was on testing user-facing output. Testing the output also required some reworking of unrelated test code.

I'm happy to add the test code back in and test the output of the other error messages in this PR or in a separate one. Let me know.