### PR TITLE
move mix/tasks/hex/utils.ex to mix/hex/utils.ex

### DIFF
--- a/lib/mix/hex/utils.ex
+++ b/lib/mix/hex/utils.ex
@@ -1,4 +1,4 @@
-defmodule Mix.Tasks.Hex.Utils do
+defmodule Mix.Hex.Utils do
   def generate_key(username, password) do
     Hex.Shell.info("Generating API key...")
     {:ok, name} = :inet.gethostname()

--- a/lib/mix/tasks/hex/build.ex
+++ b/lib/mix/tasks/hex/build.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.Hex.Build do
   use Mix.Task
-  alias Mix.Tasks.Hex.Utils
+  alias Mix.Hex.Utils
   alias Mix.Hex.Build
 
   @shortdoc "Build a new package version locally"

--- a/lib/mix/tasks/hex/docs.ex
+++ b/lib/mix/tasks/hex/docs.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.Hex.Docs do
   use Mix.Task
-  alias Mix.Tasks.Hex.Utils
+  alias Mix.Hex.Utils
 
   @shortdoc "Publish docs for package"
 

--- a/lib/mix/tasks/hex/key.ex
+++ b/lib/mix/tasks/hex/key.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.Hex.Key do
   use Mix.Task
-  alias Mix.Tasks.Hex.Utils
+  alias Mix.Hex.Utils
 
   @shortdoc "Hex API key tasks"
 

--- a/lib/mix/tasks/hex/owner.ex
+++ b/lib/mix/tasks/hex/owner.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.Hex.Owner do
   use Mix.Task
-  alias Mix.Tasks.Hex.Utils
+  alias Mix.Hex.Utils
 
   @shortdoc "Hex package ownership tasks"
 

--- a/lib/mix/tasks/hex/publish.ex
+++ b/lib/mix/tasks/hex/publish.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.Hex.Publish do
   use Mix.Task
-  alias Mix.Tasks.Hex.Utils
+  alias Mix.Hex.Utils
   alias Mix.Hex.Build
 
   @shortdoc "Publish a new package version"

--- a/lib/mix/tasks/hex/user.ex
+++ b/lib/mix/tasks/hex/user.ex
@@ -1,6 +1,6 @@
 defmodule Mix.Tasks.Hex.User do
   use Mix.Task
-  alias Mix.Tasks.Hex.Utils
+  alias Mix.Hex.Utils
 
   @shortdoc "Hex user tasks"
 


### PR DESCRIPTION
As discussed briefly with @lexmag in #129, this is a small follow-up PR to move `mix/tasks/hex/utils.ex` into `mix/hex/utils.ex` for consistency. This way, all files inside `mix/tasks/` will be hex tasks.