### PR TITLE
Standardize docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [hex.pm](https://hex.pm) for installation instructions and other documentati
 
 ## Contributing
 
-Install hex locally for development with: `mix install`.
+Install Hex locally for development with: `mix install`.
 
 ### Bundled CA certs
 

--- a/lib/hex/parallel.ex
+++ b/lib/hex/parallel.ex
@@ -1,7 +1,7 @@
 defmodule Hex.Parallel do
   @moduledoc """
-  Run a number of jobs (with an upper bound) in parallel and
-  await their finish.
+  Runs a number of jobs (with an upper bound) in parallel and
+  awaits them to finish.
   """
 
   use GenServer

--- a/lib/hex/registry.ex
+++ b/lib/hex/registry.ex
@@ -30,7 +30,7 @@ defmodule Hex.Registry do
   def open!(opts \\ []) do
     case open(opts) do
       {:error, reason} ->
-        Mix.raise "Failed to open hex registry file (#{inspect reason})"
+        Mix.raise "Failed to open Hex registry file (#{inspect reason})"
       _ ->
         :ok
     end

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Hex do
   @shortdoc "Prints Hex help information"
 
   @moduledoc """
-  Prints hex tasks and their information.
+  Prints Hex tasks and their information.
 
   `mix hex`
 

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Hex do
   use Mix.Task
 
-  @shortdoc "Print hex help information"
+  @shortdoc "Prints Hex help information"
 
   @moduledoc """
   Prints hex tasks and their information.

--- a/lib/mix/tasks/hex/build.ex
+++ b/lib/mix/tasks/hex/build.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Hex.Build do
   use Mix.Task
   alias Mix.Hex.Build
 
-  @shortdoc "Build a new package version locally"
+  @shortdoc "Builds a new package version locally"
 
   @moduledoc """
   Build a new local version of your package.

--- a/lib/mix/tasks/hex/build.ex
+++ b/lib/mix/tasks/hex/build.ex
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Hex.Build do
   @shortdoc "Builds a new package version locally"
 
   @moduledoc """
-  Build a new local version of your package.
+  Builds a new local version of your package.
 
   The package .tar file is created in the current directory, but is not pushed
   to the repository. An app named `foo` at version `1.2.3` will be built as

--- a/lib/mix/tasks/hex/config.ex
+++ b/lib/mix/tasks/hex/config.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Hex.Config do
   use Mix.Task
 
-  @shortdoc "Read or update hex config"
+  @shortdoc "Reads or updates Hex config"
 
   @moduledoc """
   Reads or updates hex configuration file.

--- a/lib/mix/tasks/hex/config.ex
+++ b/lib/mix/tasks/hex/config.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Hex.Config do
   @shortdoc "Reads or updates Hex config"
 
   @moduledoc """
-  Reads or updates hex configuration file.
+  Reads or updates Hex configuration file.
 
   `mix hex.config KEY [VALUE]`
 

--- a/lib/mix/tasks/hex/docs.ex
+++ b/lib/mix/tasks/hex/docs.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Hex.Docs do
   use Mix.Task
   alias Mix.Hex.Utils
 
-  @shortdoc "Publish docs for package"
+  @shortdoc "Publishes docs for package"
 
   @moduledoc """
   Publishes documentation for the current project and version.

--- a/lib/mix/tasks/hex/info.ex
+++ b/lib/mix/tasks/hex/info.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Hex.Info do
   use Mix.Task
 
-  @shortdoc "Print hex information"
+  @shortdoc "Prints Hex information"
 
   @moduledoc """
   Prints hex package or system information.

--- a/lib/mix/tasks/hex/info.ex
+++ b/lib/mix/tasks/hex/info.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Hex.Info do
   @shortdoc "Prints Hex information"
 
   @moduledoc """
-  Prints hex package or system information.
+  Prints Hex package or system information.
 
   `mix hex.info [PACKAGE [VERSION]]`
 
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Hex.Info do
     Hex.Shell.info "Hex v" <> Hex.version
     Hex.Shell.info ""
 
-    # Make sure to fetch registry after showing hex version. Issues with the
+    # Make sure to fetch registry after showing Hex version. Issues with the
     # registry should not prevent printing the version.
     Hex.Utils.ensure_registry(cache: false)
     path = Hex.Registry.path()

--- a/lib/mix/tasks/hex/key.ex
+++ b/lib/mix/tasks/hex/key.ex
@@ -5,11 +5,11 @@ defmodule Mix.Tasks.Hex.Key do
   @shortdoc "Hex API key tasks"
 
   @moduledoc """
-  Remove or list API keys associated with your account.
+  Removes or lists API keys associated with your account.
 
   ### Remove key
 
-  Remove given API key from account.
+  Removes given API key from account.
 
   The key can no longer be used to authenticate API requests.
 
@@ -17,7 +17,7 @@ defmodule Mix.Tasks.Hex.Key do
 
   ### List keys
 
-  List all API keys associated with your account.
+  Lists all API keys associated with your account.
 
   `mix hex.key list`
   """

--- a/lib/mix/tasks/hex/outdated.ex
+++ b/lib/mix/tasks/hex/outdated.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Hex.Outdated do
   use Mix.Task
 
-  @shortdoc "Shows outdated hex deps for the current project"
+  @shortdoc "Shows outdated Hex deps for the current project"
 
   @moduledoc """
   Shows all packages that have a version mismatch between the registry and

--- a/lib/mix/tasks/hex/owner.ex
+++ b/lib/mix/tasks/hex/owner.ex
@@ -5,28 +5,28 @@ defmodule Mix.Tasks.Hex.Owner do
   @shortdoc "Hex package ownership tasks"
 
   @moduledoc """
-  Add, remove or list package owners.
+  Adds, removes or lists package owners.
 
-  A package owner have full permissions to the package. They can publish and
+  Package owners have full permissions to the package. They can publish and
   revert releases and even remove other package owners.
 
   ### Add owner
 
-  Add an owner to package by specifying the package name and email of the new
+  Adds an owner to package by specifying the package name and email of the new
   owner.
 
   `mix hex.owner add PACKAGE EMAIL`
 
   ### Remove owner
 
-  Remove an owner to package by specifying the package name and email of the new
+  Removes an owner to package by specifying the package name and email of the new
   owner.
 
   `mix hex.owner remove PACKAGE EMAIL`
 
   ### List owners
 
-  List all owners of given package.
+  Lists all owners of given package.
 
   `mix hex.owner list PACKAGE`
   """

--- a/lib/mix/tasks/hex/publish.ex
+++ b/lib/mix/tasks/hex/publish.ex
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Hex.Publish do
   alias Mix.Hex.Utils
   alias Mix.Hex.Build
 
-  @shortdoc "Publish a new package version"
+  @shortdoc "Publishes a new package version"
 
   @moduledoc """
   Publish a new version of your package and update the package.

--- a/lib/mix/tasks/hex/publish.ex
+++ b/lib/mix/tasks/hex/publish.ex
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Hex.Publish do
   @shortdoc "Publishes a new package version"
 
   @moduledoc """
-  Publish a new version of your package and update the package.
+  Publishes a new version of your package and update the package.
 
   `mix hex.publish`
 

--- a/lib/mix/tasks/hex/search.ex
+++ b/lib/mix/tasks/hex/search.ex
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Hex.Search do
   @shortdoc "Searches for package names"
 
   @moduledoc """
-  Display packages matching the given search query.
+  Displays packages matching the given search query.
 
   `mix hex.search PACKAGE`
   """

--- a/lib/mix/tasks/hex/search.ex
+++ b/lib/mix/tasks/hex/search.ex
@@ -1,7 +1,7 @@
 defmodule Mix.Tasks.Hex.Search do
   use Mix.Task
 
-  @shortdoc "Search for package names"
+  @shortdoc "Searches for package names"
 
   @moduledoc """
   Display packages matching the given search query.

--- a/lib/mix/tasks/hex/user.ex
+++ b/lib/mix/tasks/hex/user.ex
@@ -7,25 +7,25 @@ defmodule Mix.Tasks.Hex.User do
   @moduledoc """
   Hex user tasks.
 
-  ### Registers a new user
+  ### Register a new user
 
   `mix hex.user register`
 
-  ### Prints the current user
+  ### Print the current user
 
   `mix hex.user whoami`
 
   ### Authorize a new user
 
   Authorizes a new user on the local machine by generating a new API key and
-  storing it in the hex config.
+  storing it in the Hex config.
 
   `mix hex.user auth`
 
   ### Deauthorize the user
 
   Deauthorizes the user from the local machine by removing the API key from the
-  hex config.
+  Hex config.
 
   `mix hex.user deauth`
 


### PR DESCRIPTION
this is mainly to have a unified `mix help` command,
and also when we do `mix help TASK`

It introduces the latest standardization in the Elixir codebase 