### PR TITLE
Raise error if package description is missing

### DIFF
--- a/lib/mix/hex/build.ex
+++ b/lib/mix/hex/build.ex
@@ -2,8 +2,8 @@ defmodule Mix.Hex.Build do
   @default_files ~w(lib priv mix.exs README* readme* LICENSE*
                     license* CHANGELOG* changelog* src)
 
-  @error_fields ~w(files app name version build_tools)a
-  @warn_fields ~w(description licenses maintainers links)a
+  @error_fields ~w(files app name description version build_tools)a
+  @warn_fields ~w(licenses maintainers links)a
   @meta_fields @error_fields ++ @warn_fields ++ ~w(elixir)a
 
   def prepare_package! do

--- a/lib/mix/tasks/hex/publish.ex
+++ b/lib/mix/tasks/hex/publish.ex
@@ -81,6 +81,7 @@ defmodule Mix.Tasks.Hex.Publish do
     build = Build.prepare_package!
 
     meta = build[:meta]
+    raise_if_missing_description!(meta)
     package = build[:package]
     exclude_deps = build[:exclude_deps]
 
@@ -99,6 +100,12 @@ defmodule Mix.Tasks.Hex.Publish do
         progress? = Keyword.get(opts, :progress, true)
         create_release(meta, auth, progress?)
       end
+    end
+  end
+
+  defp raise_if_missing_description!(meta) do
+    unless is_binary(meta[:description]) and meta[:description] != "" do
+      Mix.raise "Failed to publish package (missing description)."
     end
   end
 

--- a/lib/mix/tasks/hex/publish.ex
+++ b/lib/mix/tasks/hex/publish.ex
@@ -81,7 +81,6 @@ defmodule Mix.Tasks.Hex.Publish do
     build = Build.prepare_package!
 
     meta = build[:meta]
-    raise_if_missing_description!(meta)
     package = build[:package]
     exclude_deps = build[:exclude_deps]
 
@@ -100,12 +99,6 @@ defmodule Mix.Tasks.Hex.Publish do
         progress? = Keyword.get(opts, :progress, true)
         create_release(meta, auth, progress?)
       end
-    end
-  end
-
-  defp raise_if_missing_description!(meta) do
-    unless is_binary(meta[:description]) and meta[:description] != "" do
-      Mix.raise "Failed to publish package (missing description)."
     end
   end
 

--- a/test/mix/tasks/hex/build_test.exs
+++ b/test/mix/tasks/hex/build_test.exs
@@ -75,7 +75,7 @@ defmodule Mix.Tasks.Hex.BuildTest do
       Mix.Tasks.Hex.Build.run([])
 
       assert_received {:mix_shell, :info, ["\e[33m  WARNING! No files\e[0m"]}
-      assert_received {:mix_shell, :info, ["\e[33m  WARNING! Missing metadata fields: description, licenses, maintainers, links\e[0m"]}
+      assert_received {:mix_shell, :info, ["\e[33m  WARNING! Missing metadata fields: licenses, maintainers, links\e[0m"]}
       assert package_created?("releaseb-0.0.2")
     end
   after
@@ -99,4 +99,19 @@ defmodule Mix.Tasks.Hex.BuildTest do
       assert package_created?("releasec-0.0.3")
     end
   end
+
+  #test "reject package if description is missing" do
+    #Mix.Project.push ReleaseSimple.Mixfile
+
+    #in_tmp fn ->
+      #Hex.State.put(:home, tmp_path())
+
+      #Mix.Tasks.Hex.Build.run([])
+
+      #assert_received {:mix_shell, :info, ["Building releasea v0.0.1"]}
+      #assert_received {:mix_shell, :error, ["  ERROR! Missing metadata fields: description"]}
+          
+      #refute package_created?("releasea-0.0.1")
+    #end
+  #end
 end

--- a/test/mix/tasks/hex/build_test.exs
+++ b/test/mix/tasks/hex/build_test.exs
@@ -4,13 +4,13 @@ defmodule Mix.Tasks.Hex.BuildTest do
 
   defmodule ReleaseSimple.Mixfile do
     def project do
-      [ app: :releasea, version: "0.0.1" ]
+      [ app: :releasea, description: "baz", version: "0.0.1" ]
     end
   end
 
   defmodule ReleaseDeps.Mixfile do
     def project do
-      [ app: :releaseb, version: "0.0.2",
+      [ app: :releaseb, description: "bar", version: "0.0.2",
         deps: [{:ex_doc, "0.0.1", package: true}] ]
     end
   end
@@ -28,8 +28,14 @@ defmodule Mix.Tasks.Hex.BuildTest do
 
   defmodule ReleaseName.Mixfile do
     def project do
-      [ app: :released, version: "0.0.1",
+      [ app: :released, description: "Whatever", version: "0.0.1",
         package: [name: :released_name] ]
+    end
+  end
+
+  defmodule ReleaseNoDescription.Mixfile do
+    def project do
+      [ app: :releasee, version: "0.0.1" ]
     end
   end
 
@@ -100,18 +106,20 @@ defmodule Mix.Tasks.Hex.BuildTest do
     end
   end
 
-  #test "reject package if description is missing" do
-    #Mix.Project.push ReleaseSimple.Mixfile
+  test "reject package if description is missing" do
+    Mix.Project.push ReleaseNoDescription.Mixfile
 
-    #in_tmp fn ->
-      #Hex.State.put(:home, tmp_path())
+    in_tmp fn ->
+      Hex.State.put(:home, tmp_path())
 
-      #Mix.Tasks.Hex.Build.run([])
+      assert_raise Mix.Error, "Stopping package build due to errors", fn ->
+        Mix.Tasks.Hex.Build.run([])
 
-      #assert_received {:mix_shell, :info, ["Building releasea v0.0.1"]}
-      #assert_received {:mix_shell, :error, ["  ERROR! Missing metadata fields: description"]}
-          
-      #refute package_created?("releasea-0.0.1")
-    #end
-  #end
+        assert_received {:mix_shell, :info, ["Building releasee v0.0.1"]}
+        assert_received {:mix_shell, :error, ["  ERROR! Missing metadata fields: description"]}
+
+        refute package_created?("releasee-0.0.1")
+      end
+    end
+  end
 end

--- a/test/mix/tasks/hex/publish_test.exs
+++ b/test/mix/tasks/hex/publish_test.exs
@@ -4,13 +4,13 @@ defmodule Mix.Tasks.Hex.PublishTest do
 
   defmodule ReleaseSimple.Mixfile do
     def project do
-      [ app: :releasea, version: "0.0.1" ]
+      [ app: :releasea, description: "baz", version: "0.0.1" ]
     end
   end
 
   defmodule ReleaseDeps.Mixfile do
     def project do
-      [ app: :releaseb, version: "0.0.2",
+      [ app: :releaseb, description: "bar", version: "0.0.2",
         deps: [{:ex_doc, "0.0.1", package: true}] ]
     end
   end
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
 
   defmodule ReleaseName.Mixfile do
     def project do
-      [ app: :released, version: "0.0.1",
+      [ app: :released, description: "baz", version: "0.0.1",
         package: [name: :released_name] ]
     end
   end
@@ -110,7 +110,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       Mix.Tasks.Hex.Publish.run(["--no-progress"])
 
       assert_received {:mix_shell, :info, ["\e[33m  WARNING! No files\e[0m"]}
-      assert_received {:mix_shell, :info, ["\e[33m  WARNING! Missing metadata fields: description, licenses, maintainers, links\e[0m"]}
+      assert_received {:mix_shell, :info, ["\e[33m  WARNING! Missing metadata fields: licenses, maintainers, links\e[0m"]}
       assert HexWeb.Release.get(HexWeb.Package.get("releaseb"), "0.0.2")
     end
   after


### PR DESCRIPTION
Related to discussion in: https://github.com/hexpm/hex_web/pull/166 and https://github.com/hexpm/hex_web/issues/162

Notes:
- Not sure about all the checks in ```raise_if_missing_description!/1```. 
- I got a bit creative with the error message. :) Happy to change it if needed.