### PR TITLE
Ensure http proxy authentication is supplied in httpc calls

### DIFF
--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -198,7 +198,7 @@ defmodule Hex.SCM do
       headers = headers ++ [{'if-none-match', etag}]
     end
 
-    http_opts = [ssl: Hex.API.ssl_opts(url), relaxed: true]
+    http_opts = [ssl: Hex.API.ssl_opts(url), relaxed: true] ++ Hex.Utils.proxy_config(url)
     url = String.to_char_list(url)
 
     case :httpc.request(:get, {url, headers}, http_opts, opts, :hex) do

--- a/test/hex/utils_test.exs
+++ b/test/hex/utils_test.exs
@@ -1,0 +1,42 @@
+defmodule Hex.UtilsTest do
+  use HexTest.Case, async: false
+
+  setup do
+    on_exit fn ->
+      Enum.map([:http_proxy, :https_proxy], &(Hex.State.put(&1, nil)))
+      Enum.map([:proxy, :https_proxy], fn opt ->
+        :httpc.set_options([{opt, {{'localhost', 80}, ['localhost']}}], :hex)
+      end)
+    end
+
+    :ok
+  end
+
+  test "proxy_config returns no credentials when no proxy supplied" do
+    assert Hex.Utils.proxy_config("http://hex.pm") == []
+  end
+
+  test "proxy_config returns http_proxy credentials when supplied" do
+    Hex.State.put(:http_proxy, "http://hex:test@example.com")
+
+    assert Hex.Utils.proxy_config("http://hex.pm") == [proxy_auth: {'hex', 'test'}]
+  end
+
+  test "proxy_config returns http_proxy credentials when only username supplied" do
+    Hex.State.put(:http_proxy, "http://nopass@example.com")
+
+    assert Hex.Utils.proxy_config("http://hex.pm") == [proxy_auth: {'nopass', ''}]
+  end
+
+  test "proxy_config returns credentials when the protocol is https" do
+    Hex.State.put(:https_proxy, "https://test:hex@example.com")
+
+    assert Hex.Utils.proxy_config("https://hex.pm") == [proxy_auth: {'test', 'hex'}]
+  end
+
+  test "proxy_config returns empty list when no credentials supplied" do
+    Hex.State.put(:http_proxy, "http://example.com")
+
+    assert Hex.Utils.proxy_config("http://hex.pm") == []
+  end
+end


### PR DESCRIPTION
This PR ensures that calls to `:httpc.request` using the `:hex` profile supply `proxy_auth` as a `http_option()`

My use case is deploying elixir apps to an internal deployment of Cloud Foundry behind a firewall, limiting external connections to proxies. Hopefully others will find this useful!