### PR TITLE
Change mix hex.info package output

### DIFF
--- a/lib/mix/tasks/hex/info.ex
+++ b/lib/mix/tasks/hex/info.ex
@@ -85,6 +85,7 @@ defmodule Mix.Tasks.Hex.Info do
 
   defp pretty_package(package) do
     Hex.Shell.info package["name"]
+    pretty_package_string(package["name"], package["releases"])
     Hex.Shell.info "  Releases: " <> Enum.map_join(package["releases"], ", ", &(&1["version"]))
     Hex.Shell.info ""
     pretty_meta(package["meta"])
@@ -105,6 +106,7 @@ defmodule Mix.Tasks.Hex.Info do
   defp pretty_release(package, release) do
     version = release["version"]
     Hex.Shell.info package <> " v" <> version
+    pretty_package_string(package, release)
 
     if release["has_docs"] do
       # TODO: Only print this URL if we use the default API URL
@@ -118,6 +120,39 @@ defmodule Mix.Tasks.Hex.Info do
         Hex.Shell.info "    #{name}: #{req["requirement"]}#{optional}"
       end)
     end
+  end
+
+  defp pretty_package_string(name, [latest_release | _]) do
+    pretty_package_string(name, latest_release)
+  end
+
+  defp pretty_package_string(name, release) do
+    app_name = release["meta"]["app"] || name
+    {:ok, version} = Version.parse(release["version"])
+    snippet  = mix_snippet_version(version)
+
+    Hex.Shell.info "Config:"
+    if name == app_name do
+      Hex.Shell.info "{:#{name}, \"#{snippet}\"}"
+    else
+      Hex.Shell.info "{:#{app_name}, \"#{snippet}\", hex: :#{name}}"
+    end
+  end
+
+  defp mix_snippet_version(%Version{major: 0, minor: minor, patch: patch, pre: []}),
+    do: "~> 0.#{minor}.#{patch}"
+  defp mix_snippet_version(%Version{major: major, minor: minor, pre: []}),
+    do: "~> #{major}.#{minor}"
+  defp mix_snippet_version(%Version{major: major, minor: minor, patch: patch, pre: pre}),
+    do: "~> #{major}.#{minor}.#{patch}#{pre_snippet(pre)}"
+
+  defp pre_snippet([]), do: ""
+  defp pre_snippet(pre) do
+    "-" <>
+      Enum.map_join(pre, ".", fn
+        int when is_integer(int) -> Integer.to_string(int)
+        string when is_binary(string) -> string
+      end)
   end
 
   defp pretty_list(meta, name) do

--- a/test/mix/tasks/hex/info_test.exs
+++ b/test/mix/tasks/hex/info_test.exs
@@ -5,6 +5,8 @@ defmodule Mix.Tasks.Hex.InfoTest do
   test "package" do
     Mix.Tasks.Hex.Info.run(["ex_doc"])
     assert_received {:mix_shell, :info, ["ex_doc"]}
+    assert_received {:mix_shell, :info, ["Config:"]}
+    assert_received {:mix_shell, :info, ["{:ex_doc, \"~> 0.1.0\"}"]}
     assert_received {:mix_shell, :info, ["  Maintainers: John Doe, Jane Doe"]}
     assert_received {:mix_shell, :info, ["builds docs"]}
 
@@ -15,6 +17,13 @@ defmodule Mix.Tasks.Hex.InfoTest do
   test "release" do
     Mix.Tasks.Hex.Info.run(["ex_doc", "0.0.1"])
     assert_received {:mix_shell, :info, ["ex_doc v0.0.1"]}
+    assert_received {:mix_shell, :info, ["Config:"]}
+    assert_received {:mix_shell, :info, ["{:ex_doc, \"~> 0.0.1\"}"]}
+
+    Mix.Tasks.Hex.Info.run(["ex_doc", "0.1.0-rc1"])
+    assert_received {:mix_shell, :info, ["ex_doc v0.1.0-rc1"]}
+    assert_received {:mix_shell, :info, ["Config:"]}
+    assert_received {:mix_shell, :info, ["{:ex_doc, \"~> 0.1.0-rc1\"}"]}
 
     Mix.Tasks.Hex.Info.run(["ex_doc", "1.2.3"])
     assert_received {:mix_shell, :error, ["No release with name ex_doc v1.2.3"]}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -26,6 +26,7 @@ unless :integration in ExUnit.configuration[:exclude] do
 
   HexWeb.new_package("ex_doc", "0.0.1", [], pkg_meta, auth)
   HexWeb.new_package("ex_doc", "0.1.0", [], pkg_meta, auth)
+  HexWeb.new_package("ex_doc", "0.1.0-rc1", [], pkg_meta, auth)
   HexWeb.new_package("postgrex", "0.2.1", [ex_doc: "~> 0.1.0"], pkg_meta, auth)
   HexWeb.new_package("postgrex", "0.2.0", [ex_doc: "0.0.1"], pkg_meta, auth)
   HexWeb.new_package("ecto", "0.2.0", [postgrex: "~> 0.2.0", ex_doc: "~> 0.0.1"], pkg_meta, auth)


### PR DESCRIPTION
This PR changes first string on `mix hex.info {package_name}` command output.

Example of output
```
$ mix hex.info httpoison
{:httpoison, "~> 0.8.0}
  Releases: 0.8.0, 0.7.5, 0.7.4, 0.7.3, 0.7.2, 0.7.1, 0.7.0, 0.6.2, 0.6.1, 0.6.0, 0.5.0, 0.4.3, 0.4.2, 0.4.1, 0.4.0, 0.3.2, 0.3.1, 0.3.0, 0.2.0

  Maintainers: Eduardo Gurgel Pinho
  Licenses: MIT
  Links:
    Github: https://github.com/edgurgel/httpoison

Yet Another HTTP client for Elixir powered by hackney
```