### PR TITLE
Fixed typo: Hex.shell => Hex.Shell

### DIFF
--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -88,7 +88,7 @@ defmodule Hex.RemoteConverger do
       if dep.app in top_level and
          is_nil(dep.requirement) and
          dep.scm == Hex.SCM do
-        Hex.shell.warn "#{dep.app} is missing its version requirement, " <>
+        Hex.Shell.warn "#{dep.app} is missing its version requirement, " <>
                        "use \">= 0.0.0\" if it should match any version"
       end
     end)

--- a/test/hex/mix_task_test.exs
+++ b/test/hex/mix_task_test.exs
@@ -111,6 +111,14 @@ defmodule Hex.MixTaskTest do
     end
   end
 
+  defmodule WithMissingDepVersion do
+    def project do
+      [app: :with_missing_dep_version,
+       version: "0.1.0",
+       deps: [{:ex_doc, []}]]
+    end
+  end
+
   test "deps.get" do
     Mix.Project.push Simple
 
@@ -437,6 +445,17 @@ defmodule Hex.MixTaskTest do
       assert_raise Mix.Error, message, fn ->
         Mix.Task.run "deps.get"
       end
+    end
+  end
+
+  test "deps.get with missing version" do
+    Mix.Project.push WithMissingDepVersion
+
+    in_tmp fn ->
+      Hex.State.put(:home, System.cwd!)
+
+      Mix.Task.run "deps.get"
+      assert_received {:mix_shell, :info, ["\e[33mex_doc is missing its version requirement, use \">= 0.0.0\"" <> _]}
     end
   end
 end


### PR DESCRIPTION
Introduced in b2937c181295653559dad5c0d5eacd5ed7e16baa

This crashes hex on missing dependency requirement.