### PR TITLE
Performance improvements

### DIFF
--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -18,11 +18,11 @@ defmodule Hex do
     Mix.SCM.append(Hex.SCM)
     Mix.RemoteConverger.register(Hex.RemoteConverger)
 
+    Hex.Version.start
     start_httpc()
 
     children = [
       worker(Hex.State, []),
-      worker(Hex.Version, []),
       worker(Hex.Registry, []),
       worker(Hex.Parallel, [:hex_fetcher, [max_parallel: 8]]),
     ]

--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -22,6 +22,7 @@ defmodule Hex do
 
     children = [
       worker(Hex.State, []),
+      worker(Hex.Version, []),
       worker(Hex.Registry, []),
       worker(Hex.Parallel, [:hex_fetcher, [max_parallel: 8]]),
     ]

--- a/lib/hex/mix.ex
+++ b/lib/hex/mix.ex
@@ -10,7 +10,7 @@ defmodule Hex.Mix do
   """
   @spec version_match?(String.t, String.t) :: boolean
   def version_match?(_version, nil), do: true
-  def version_match?(version, req),  do: Version.match?(version, req)
+  def version_match?(version, req),  do: Hex.Version.match?(version, req)
 
   @doc """
   Given a tree of dependencies return a flat list of all dependencies in

--- a/lib/hex/mix.ex
+++ b/lib/hex/mix.ex
@@ -23,11 +23,8 @@ defmodule Hex.Mix do
   in the original list of dependencies as they were likely filtered out
   due to options like `:only`.
   """
-  @spec flatten_deps([Mix.Dep.t]) :: [Mix.Dep.t]
-  def flatten_deps(deps) do
-    apps = Enum.map(deps, & &1.app)
-    top_level = top_level(deps)
-
+  @spec flatten_deps([Mix.Dep.t], [atom]) :: [Mix.Dep.t]
+  def flatten_deps(deps, top_level) do
     deps ++
       for(dep <- deps,
           overridden_map = overridden_parents(top_level, deps, dep.app),

--- a/lib/hex/mix.ex
+++ b/lib/hex/mix.ex
@@ -73,12 +73,31 @@ defmodule Hex.Mix do
   end
 
   @doc """
-  Returns true if the dependency was overridden in any of the upper breadths.
+  Add a potentially new dependency and its children.
+  This function is used to add Hex packages to the dependency tree which
+  we use in overridden_parents to check overridden status.
   """
-  @spec was_overridden?([Mix.Dep.t], atom) :: boolean
-  def was_overridden?(upper_breadths, app) do
-    Enum.any?(upper_breadths, fn dep ->
-      app == dep.app && dep.opts[:override]
+  def attach_dep_and_children(deps, app, children) do
+    app = String.to_atom(app)
+    dep = Enum.find(deps, &(&1.app == app))
+
+    children =
+      Enum.map(children, fn {name, app, _req, _optional} ->
+        app = String.to_atom(app)
+        name = String.to_atom(name)
+        %Mix.Dep{app: app, opts: [hex: name]}
+      end)
+
+    new_dep = %{dep | deps: children}
+
+    put_dep(deps, new_dep) ++ children
+  end
+
+  # Replace a dependency in the tree
+  defp put_dep(deps, new_dep) do
+    app = new_dep.app
+    Enum.map(deps, fn dep ->
+      if dep.app == app, do: new_dep, else: dep
     end)
   end
 

--- a/lib/hex/registry.ex
+++ b/lib/hex/registry.ex
@@ -170,16 +170,16 @@ defmodule Hex.Registry do
     current_hex    = Hex.version
 
     versions
-    |> Enum.filter(fn {hex, _} -> Version.compare(hex, current_hex) == :gt end)
-    |> Enum.filter(fn {_, elixirs} -> Version.compare(hd(elixirs), current_elixir) != :gt end)
+    |> Enum.filter(fn {hex, _} -> Hex.Version.compare(hex, current_hex) == :gt end)
+    |> Enum.filter(fn {_, elixirs} -> Hex.Version.compare(hd(elixirs), current_elixir) != :gt end)
     |> Enum.map(&elem(&1, 0))
-    |> Enum.sort(&(Version.compare(&1, &2) == :gt))
+    |> Enum.sort(&(Hex.Version.compare(&1, &2) == :gt))
     |> List.first
   end
 
   defp check_elixir_version(versions) do
-    {:ok, built}   = Version.parse(Hex.elixir_version())
-    {:ok, current} = Version.parse(System.version)
+    {:ok, built}   = Hex.Version.parse(Hex.elixir_version())
+    {:ok, current} = Hex.Version.parse(System.version)
 
     if built.major != current.major or built.minor != current.minor do
       case :lists.keyfind(Hex.version, 1, versions) do
@@ -198,7 +198,7 @@ defmodule Hex.Registry do
 
   defp match_elixir_version?(elixirs, current) do
     Enum.any?(elixirs, fn elixir ->
-      {:ok, elixir} = Version.parse(elixir)
+      {:ok, elixir} = Hex.Version.parse(elixir)
       elixir.major == current.major and elixir.minor == current.minor
     end)
   end

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -106,7 +106,7 @@ defmodule Hex.RemoteConverger do
 
   defp check_package_req(name, req, from) do
     if versions = Registry.get_versions(name) do
-      if req != nil and Version.parse_requirement(req) == :error do
+      if req != nil and Hex.Version.parse_requirement(req) == :error do
         Mix.raise "Required version #{inspect req} for package #{name} is incorrectly specified (from: #{from})"
       end
       versions = Enum.filter(versions, &Hex.Mix.version_match?(&1, req))
@@ -186,7 +186,7 @@ defmodule Hex.RemoteConverger do
           # Make sure to handle deps that were previously locked as Git
           case Map.fetch(old_lock, app) do
             {:ok, {:hex, name, version}} ->
-              req && !Version.match?(version, req) && name == opts[:hex]
+              req && !Hex.Version.match?(version, req) && name == opts[:hex]
 
             _ ->
               true

--- a/lib/hex/resolver.ex
+++ b/lib/hex/resolver.ex
@@ -17,7 +17,7 @@ defmodule Hex.Resolver do
 
       optional =
         Enum.into(locked, %{}, fn {name, app, version} ->
-          {:ok, req} = Version.parse_requirement(version)
+          {:ok, req} = Hex.Version.parse_requirement(version)
           parent     = parent(name: "mix.lock", requirement: req)
           request    = request(app: app, name: name, req: req, parent: parent)
           {name, [request]}
@@ -187,7 +187,7 @@ defmodule Hex.Resolver do
   end
 
   defp compile_requirement(req, package) when is_binary(req) do
-    case Version.parse_requirement(req) do
+    case Hex.Version.parse_requirement(req) do
       {:ok, req} ->
         req
       :error ->
@@ -242,8 +242,8 @@ defmodule Hex.Resolver do
   defp sort_backtracks(backtracks) do
     backtracks
     |> Enum.map(fn {name, versions, parents} ->
-         versions = Enum.sort(versions, &(Version.compare(&1, &2) != :lt))
          parents  = Enum.sort(parents, &sort_parents/2)
+         versions = Enum.sort(versions, &(Hex.Version.compare(&1, &2) != :lt))
          {name, versions, parents}
        end)
     |> Enum.sort()

--- a/lib/hex/resolver.ex
+++ b/lib/hex/resolver.ex
@@ -8,11 +8,10 @@ defmodule Hex.Resolver do
   Record.defrecordp :active, [:app, :name, :version, :parents]
   Record.defrecordp :parent, [:name, :version, :requirement]
 
-  def resolve(requests, deps, locked) do
+  def resolve(requests, deps, top_level, locked) do
     {:ok, backtrack} = Agent.start_link(fn -> [] end)
 
     try do
-      top_level = top_level(deps)
       info = info(deps: deps, top_level: top_level, backtrack: backtrack)
 
       optional =
@@ -122,7 +121,6 @@ defmodule Hex.Resolver do
   defp get_deps(app, package, version, info(top_level: top_level, deps: all_deps), activated) do
     if deps = Registry.get_deps(package, version) do
       all_deps = attach_dep_and_children(all_deps, app, deps)
-
       overridden_map = overridden_parents(top_level, all_deps, String.to_atom(app))
 
       {reqs, opts} =

--- a/lib/hex/resolver/backtracks.ex
+++ b/lib/hex/resolver/backtracks.ex
@@ -19,7 +19,6 @@ defmodule Hex.Resolver.Backtracks do
 
     case :ets.lookup(@ets, {name, parents}) do
       [{_, old_versions}] ->
-        # TODO: Check this
         unless is_nil(version) or version in old_versions do
           :ets.insert(@ets, {{name, parents}, new_versions ++ old_versions})
         end

--- a/lib/hex/resolver/backtracks.ex
+++ b/lib/hex/resolver/backtracks.ex
@@ -1,0 +1,51 @@
+defmodule Hex.Resolver.Backtracks do
+  require Record
+
+  Record.defrecordp :parent, [:name, :version, :requirement]
+
+  @ets :hex_backtracks
+
+  def start do
+    :ets.new(@ets, [:named_table])
+  end
+
+  def stop do
+    :ets.delete(@ets)
+  end
+
+  def add(name, version, parents) do
+    parents = Enum.sort(parents, &parent_cmp/2)
+    new_versions = if version, do: [version], else: []
+
+    case :ets.lookup(@ets, {name, parents}) do
+      [{_, old_versions}] ->
+        # TODO: Check this
+        unless is_nil(version) or version in old_versions do
+          :ets.insert(@ets, {{name, parents}, new_versions ++ old_versions})
+        end
+      [] ->
+        :ets.insert(@ets, {{name, parents}, new_versions})
+    end
+  end
+
+  def collect do
+    :ets.tab2list(@ets)
+    |> sort_backtracks
+  end
+
+  defp sort_backtracks(backtracks) do
+    backtracks
+    |> Enum.map(fn {{name, parents}, versions} ->
+         versions = Enum.sort(versions, &(Hex.Version.compare(&1, &2) != :lt))
+         {name, versions, parents}
+       end)
+    |> Enum.sort()
+  end
+
+  # TODO: Handle sorting of mix.exs from umbrellas
+  defp parent_cmp(parent(name: "mix.exs"), _),  do: true
+  defp parent_cmp(_, parent(name: "mix.exs")),  do: false
+  defp parent_cmp(parent(name: "mix.lock"), _), do: true
+  defp parent_cmp(_, parent(name: "mix.lock")), do: false
+  defp parent_cmp(parent1, parent2),            do: parent1 <= parent2
+end

--- a/lib/hex/resolver/experimental.ex
+++ b/lib/hex/resolver/experimental.ex
@@ -1,0 +1,207 @@
+defmodule Hex.Resolver.Experimental do
+  import Hex.Mix
+  require Record
+  alias Hex.Registry
+  alias Hex.Resolver.Backtracks
+
+  Record.defrecordp :info, [:deps, :top_level]
+  Record.defrecordp :request, [:app, :name, :req, :parent]
+  Record.defrecordp :active, [:app, :name, :version, :versions, :parents, :state]
+  Record.defrecordp :parent, [:name, :version, :requirement]
+  Record.defrecordp :state, [:activated, :requests, :optional, :deps]
+
+  def resolve(requests, deps, top_level, locked) do
+    Backtracks.start
+    info = info(deps: deps, top_level: top_level)
+
+    optional =
+      Enum.into(locked, %{}, fn {name, app, version} ->
+        {:ok, req} = Hex.Version.parse_requirement(version)
+        parent     = parent(name: "mix.lock", requirement: req)
+        request    = request(app: app, name: name, req: req, parent: parent)
+        {name, [request]}
+      end)
+
+    pending =
+      Enum.map(requests, fn {name, app, req, from} ->
+        req    = compile_requirement(req, name)
+        parent = parent(name: from, requirement: req)
+        request(name: name, app: app, req: req, parent: parent)
+      end)
+      |> Enum.uniq
+
+    if activated = do_resolve(pending, optional, info, %{}) do
+      {:ok, activated}
+    else
+      {:error, error_message()}
+    end
+  after
+    Backtracks.stop
+  end
+
+  defp do_resolve([], _optional, _info, activated) do
+    Enum.map(activated, fn {name, active(app: app, version: version)} ->
+      {name, app, version}
+    end) |> Enum.reverse
+  end
+
+  defp do_resolve([request(name: name, req: req, parent: parent) = request|pending], optional, info, activated) do
+    case activated[name] do
+      active(version: version, parents: parents) = active ->
+        parents = [parent|parents]
+        active  = active(active, parents: parents)
+
+        if version_match?(version, req) do
+          activated = Map.put(activated, name, active)
+          do_resolve(pending, optional, info, activated)
+        else
+          add_backtrack_info(name, version, parents)
+          backtrack_parents(parents, info, activated)
+            || backtrack(name, info, activated)
+        end
+
+      nil ->
+        {opts, optional} = Map.pop(optional, name, [])
+        requests         = [request|opts]
+        parents          = Enum.map(requests, &request(&1, :parent))
+
+        case get_versions(name, requests) do
+          [] ->
+            add_backtrack_info(name, nil, parents)
+            backtrack_parents(parents, info, activated)
+          versions ->
+            activate(request, pending, versions, optional, info, activated, parents)
+        end
+    end
+  end
+
+  defp activate(request(app: app, name: name), pending, [version|versions],
+                optional, info, activated, parents) do
+
+    {new_pending, new_optional, new_deps} = get_deps(app, name, version, info, activated)
+    new_pending = new_pending ++ pending
+    new_optional = merge_optional(optional, new_optional)
+
+    state = state(activated: activated, requests: pending, optional: optional, deps: info(info, :deps))
+    new_active = active(app: app, name: name, version: version, versions: versions, parents: parents, state: state)
+    activated = Map.put(activated, name, new_active)
+
+    info = info(info, deps: new_deps)
+
+    do_resolve(new_pending, new_optional, info, activated)
+  end
+
+  defp activate(_request, _pending, [], _optional, info, activated, parents) do
+    backtrack_parents(parents, info, activated)
+  end
+
+  defp backtrack(name, info, activated) do
+    case activated[name] do
+      active(state: state, app: app, name: name, versions: versions, parents: parents) ->
+        state(activated: activated, requests: requests, optional: optional, deps: deps) = state
+
+        info    = info(info, deps: deps)
+        request = request(app: app, name: name)
+
+        activate(request, requests, versions, optional, info, activated, parents)
+      nil ->
+        nil
+    end
+  end
+
+  defp backtrack_parents(parents, info, activated) do
+    Enum.find_value(parents, fn parent(name: name) ->
+      backtrack(name, info, activated)
+    end)
+  end
+
+  defp get_versions(package, requests) do
+    if versions = Registry.get_versions(package) do
+      Enum.reduce(requests, versions, fn request, versions ->
+        req = request(request, :req)
+        Enum.filter(versions, &version_match?(&1, req))
+      end)
+      |> Enum.reverse
+    else
+      Mix.raise "Unable to find package #{package} in registry"
+    end
+  end
+
+  defp get_deps(app, package, version, info(top_level: top_level, deps: all_deps), activated) do
+    if deps = Registry.get_deps(package, version) do
+      all_deps = attach_dep_and_children(all_deps, app, deps)
+      overridden_map = overridden_parents(top_level, all_deps, String.to_atom(app))
+
+      {reqs, opts} =
+        Enum.reduce(deps, {[], []}, fn {name, app, req, optional}, {reqs, opts} ->
+          req     = compile_requirement(req, name)
+          parent  = parent(name: package, version: version, requirement: req)
+          request = request(app: app, name: name, req: req, parent: parent)
+
+          cond do
+            overridden_map[String.to_atom(app)] ->
+              {reqs, opts}
+            optional && !activated[name] ->
+              {reqs, [request|opts]}
+            true ->
+              {[request|reqs], opts}
+          end
+        end)
+
+      {Enum.reverse(reqs), Enum.reverse(opts), all_deps}
+    else
+      Mix.raise "Unable to find package version #{package} #{version} in registry"
+    end
+  end
+
+  defp merge_optional(optional, new_optional) do
+    new_optional =
+      Enum.into(new_optional, %{}, fn request(name: name) = request ->
+        {name, [request]}
+      end)
+    Map.merge(optional, new_optional, fn _, v1, v2 -> v1 ++ v2 end)
+  end
+
+  defp compile_requirement(nil, _package) do
+    nil
+  end
+
+  defp compile_requirement(req, package) when is_binary(req) do
+    case Hex.Version.parse_requirement(req) do
+      {:ok, req} ->
+        req
+      :error ->
+        Mix.raise "Invalid requirement #{inspect req} defined for package #{package}"
+    end
+  end
+
+  defp compile_requirement(req, package) do
+    Mix.raise "Invalid requirement #{inspect req} defined for package #{package}"
+  end
+
+  defp error_message do
+    Backtracks.collect
+    |> Enum.map_join("\n\n", &backtrack_message/1)
+    |> Kernel.<>("\n")
+  end
+
+  defp add_backtrack_info(name, version, parents) do
+    Backtracks.add(name, version, parents)
+  end
+
+  defp backtrack_message({name, versions, parents}) do
+    versions = if versions != [] do
+      " " <> Enum.join(versions, ", ")
+    end
+    "Conflict on #{name}#{versions}" <>
+    "\n  " <> Enum.map_join(parents, "\n  ", &parent_message/1)
+  end
+
+  defp parent_message(parent(name: path, version: nil, requirement: req)),
+    do: "From #{path}: #{requirement(req)}"
+  defp parent_message(parent(name: parent, version: version, requirement: req)),
+    do: "From #{parent} #{version}: #{requirement(req)}"
+
+  defp requirement(nil), do: ">= 0.0.0"
+  defp requirement(req), do: req.source
+end

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -16,8 +16,9 @@ defmodule Hex.State do
       cdn: load_config(config, ["HEX_CDN"], :cdn_url) || @default_cdn,
       http_proxy: load_config(config, ["http_proxy", "HTTP_PROXY"], :http_proxy),
       https_proxy: load_config(config, ["https_proxy", "HTTPS_PROXY"], :https_proxy),
-      offline?: !!System.get_env("HEX_OFFLINE"),
-      cert_check?: !System.get_env("HEX_UNSAFE_HTTPS"),
+      offline?: System.get_env("HEX_OFFLINE") == "1",
+      cert_check?: System.get_env("HEX_UNSAFE_HTTPS") != "1",
+      resolver: resolver(System.get_env("HEX_EXPERIMENTAL_RESOLVER")),
       registry_updated: false}
   end
 
@@ -73,4 +74,8 @@ defmodule Hex.State do
       Hex.Shell.info "Using #{key} = #{value}"
     end
   end
+
+  defp resolver("1"), do: :experimental
+  defp resolver("2"), do: :both
+  defp resolver(_), do: :standard
 end

--- a/lib/hex/version.ex
+++ b/lib/hex/version.ex
@@ -1,0 +1,73 @@
+defmodule Hex.Version do
+  use GenServer
+
+  @ets :hex_version
+
+  def start_link do
+    GenServer.start_link(__MODULE__, [])
+  end
+
+  def init([]) do
+    :ets.new(@ets, [:named_table, :public])
+    {:ok, []}
+  end
+
+  def match?(version, requirement) do
+    cache({:match?, version, requirement}, fn ->
+      version     = parse!(version)
+      requirement = parse_requirement!(requirement)
+      Version.match?(version, requirement)
+    end)
+  end
+
+  def compare(version1, version2) do
+    cache({:compare, version1, version2}, fn ->
+      version1 = parse!(version1)
+      version2 = parse!(version2)
+      Version.compare(version1, version2)
+    end)
+  end
+
+  def parse(%Version{} = version), do: {:ok, version}
+  def parse(version) do
+    cache({:version, version}, fn ->
+      Version.parse(version)
+    end)
+  end
+
+  def parse!(version) do
+    case parse(version) do
+      {:ok, version} ->
+        version
+      :error ->
+        raise InvalidVersionError, message: version
+    end
+  end
+
+  def parse_requirement(%Version.Requirement{} = requirement), do: {:ok, requirement}
+  def parse_requirement(requirement) do
+    cache({:req, requirement}, fn ->
+      Version.parse_requirement(requirement)
+    end)
+  end
+
+  def parse_requirement!(requirement) do
+    case parse_requirement(requirement) do
+      {:ok, requirement} ->
+        requirement
+      :error ->
+        raise InvalidRequirementError, message: requirement
+    end
+  end
+
+  defp cache(key, fun) do
+    case :ets.lookup(@ets, key) do
+      [{_, value}] ->
+        value
+      [] ->
+        value = fun.()
+        :ets.insert(@ets, {key, value})
+        value
+    end
+  end
+end

--- a/lib/hex/version.ex
+++ b/lib/hex/version.ex
@@ -3,11 +3,7 @@ defmodule Hex.Version do
 
   @ets :hex_version
 
-  def start_link do
-    GenServer.start_link(__MODULE__, [])
-  end
-
-  def init([]) do
+  def start do
     :ets.new(@ets, [:named_table, :public])
     {:ok, []}
   end

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Hex do
     Hex.Shell.info "Hex is a package manager for the Erlang ecosystem."
     line_break()
 
-    if Version.match?(System.version, ">= 1.1.0-dev") do
+    if Hex.Version.match?(System.version, ">= 1.1.0-dev") do
       Hex.Shell.info "Available tasks:"
       line_break()
       Mix.Task.run("help", ["--search", "hex."])

--- a/lib/mix/tasks/hex/info.ex
+++ b/lib/mix/tasks/hex/info.ex
@@ -124,7 +124,7 @@ defmodule Mix.Tasks.Hex.Info do
 
   defp print_config(name, release) do
     app_name = release["meta"]["app"] || name
-    {:ok, version} = Version.parse(release["version"])
+    {:ok, version} = Hex.Version.parse(release["version"])
     snippet =
       format_version(version)
       |> format_config_snippet(name, app_name)

--- a/lib/mix/tasks/hex/outdated.ex
+++ b/lib/mix/tasks/hex/outdated.ex
@@ -94,7 +94,7 @@ defmodule Mix.Tasks.Hex.Outdated do
   end
 
   defp print_row([{package, p1}, {lock, p2}, {latest, p3}, {req, _p4}]) do
-    outdated? = Version.compare(lock, latest) == :lt
+    outdated? = Hex.Version.compare(lock, latest) == :lt
     latest_color = if outdated?, do: :red, else: :green
 
     req_matches? = version_match?(latest, req)
@@ -122,5 +122,5 @@ defmodule Mix.Tasks.Hex.Outdated do
   defp size(str), do: byte_size(str)
 
   defp version_match?(_version, nil), do: true
-  defp version_match?(version, req),  do: Version.match?(version, req)
+  defp version_match?(version, req),  do: Hex.Version.match?(version, req)
 end

--- a/test/hex/resolver_test.exs
+++ b/test/hex/resolver_test.exs
@@ -2,7 +2,10 @@ defmodule Hex.ResolverTest do
   use HexTest.Case
 
   defp resolve(reqs, locked \\ []) do
-    case Hex.Resolver.resolve(reqs(reqs), deps(reqs), locked(locked)) do
+    deps      = deps(reqs)
+    top_level = Hex.Mix.top_level(deps)
+
+    case Hex.Resolver.resolve(reqs(reqs), deps, top_level, locked(locked)) do
       {:ok, dict} -> dict
       {:error, messages} -> messages
     end

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -176,6 +176,7 @@ defmodule HexTest.Case do
   setup do
     Hex.State.put(:home, tmp_path("hex_home"))
     Hex.State.put(:registry_updated, false)
+    Hex.State.put(:resolver, :both)
     Hex.Parallel.clear(:hex_fetcher)
     Hex.Registry.close
 


### PR DESCRIPTION
The following dependencies shows performance problems in the resolver:

```elixir
[{:phoenix, "~> 0.14"},
 {:phoenix_ecto, "~> 0.5"},
 {:postgrex, ">= 0.0.0"},
 {:phoenix_html, "~> 1.1"},
 {:phoenix_live_reload, "~> 0.4"},
 {:cowboy, "~> 1.0"}]
```

Before this PR resolving the dependencies would take ~15min and use several GB of memory with OTP 18.2.1 and Elixir 1.2.1 on a Macbook Pro Late 2013. After this PR it takes ~1min40sec and uses ~50mb of memory.

Some of the wins comes from caching values in ETS that are recalculated a lot. Most of the wins including the memory reduction comes from moving the backtrack store from an Agent to ETS and immediately removing duplicates.

I am stuck right now because I think that reducing the current time will require algorithm changes and I don't know how to that without making the resolver failing to find some solutions.

/cc @josevalim @lexmag 