### PR TITLE
fix(Hex.Mix): ensure app exists for dependency resolution

### DIFF
--- a/lib/hex/mix.ex
+++ b/lib/hex/mix.ex
@@ -25,11 +25,12 @@ defmodule Hex.Mix do
   """
   @spec flatten_deps([Mix.Dep.t], [atom]) :: [Mix.Dep.t]
   def flatten_deps(deps, top_level) do
+    apps = Enum.map(deps, & &1.app)
     deps ++
       for(dep <- deps,
           overridden_map = overridden_parents(top_level, deps, dep.app),
           %{app: app} = child <- dep.deps,
-          !overridden_map[app],
+          app in deps and !overridden_map[app],
           do: child)
   end
 


### PR DESCRIPTION
This fixes a regression as a result of
cacc652e0b6c2fb80579e2ce448d25c2cc94ae37