### PR TITLE
tests(Hex.Mix): add tests for flatten_deps

### DIFF
--- a/test/hex/mix_test.exs
+++ b/test/hex/mix_test.exs
@@ -7,4 +7,19 @@ defmodule Hex.MixTest do
     assert Hex.Mix.from_lock(lock) ==
            [{"ex_doc", "ex_doc", "0.1.0"}, {"fork", "postgrex", "0.2.1"}]
   end
+
+  test "flatten_deps with only dependencies" do
+    child_dep_1 = %Mix.Dep{app: :child_dep_1, deps: [], top_level: false}
+    child_dep_2 = %Mix.Dep{app: :child_dep_2, deps: [], top_level: false}
+    dev_child_dep = %Mix.Dep{app: :dev_child_dep, deps: [], top_level: false, opts: [only: :dev]}
+    dep = %Mix.Dep{app: :dep, deps: [child_dep_1, child_dep_2, dev_child_dep], top_level: true}
+
+    deps = [dep, child_dep_1, child_dep_2]
+
+    flattened_deps = Hex.Mix.flatten_deps(deps, [:dep])
+    assert dep in flattened_deps
+    assert child_dep_1 in flattened_deps
+    assert child_dep_2 in flattened_deps
+    refute dev_child_dep in flattened_deps
+  end
 end


### PR DESCRIPTION
This tests shows that a child should not be included in the flattened
dependencies if it not specified in the deps list.