### PR TITLE
Catch an empty search result

### DIFF
--- a/lib/mix/tasks/hex/search.ex
+++ b/lib/mix/tasks/hex/search.ex
@@ -9,6 +9,20 @@ defmodule Mix.Tasks.Hex.Search do
   `mix hex.search PACKAGE`
   """
 
+  defp lookup_packages(packages) when length(packages) > 0 do
+    pkg_max_length = Enum.max_by(packages, &byte_size/1) |> byte_size
+
+    Enum.each(packages, fn pkg ->
+      vsn = Hex.Registry.get_versions(pkg) |> List.last
+      pkg_name = String.ljust(pkg, pkg_max_length)
+      Hex.Shell.info "#{pkg_name} #{vsn}"
+    end)
+  end
+
+  defp lookup_packages(packages) do
+    Hex.Shell.info "No packages found"
+  end
+
   def run(args) do
     {_opts, args, _} = OptionParser.parse(args)
     Hex.start
@@ -17,14 +31,9 @@ defmodule Mix.Tasks.Hex.Search do
       [package] ->
         Hex.Utils.ensure_registry!()
 
-        packages = Hex.Registry.search(package)
-        pkg_max_length = Enum.max_by(packages, &byte_size/1) |> byte_size
+        Hex.Registry.search(package)
+        |> lookup_packages
 
-        Enum.each(packages, fn pkg ->
-          vsn = Hex.Registry.get_versions(pkg) |> List.last
-          pkg_name = String.ljust(pkg, pkg_max_length)
-          Hex.Shell.info "#{pkg_name} #{vsn}"
-        end)
       _ ->
         Mix.raise "Invalid arguments, expected: mix hex.search PACKAGE"
     end

--- a/test/mix/tasks/hex/search_test.exs
+++ b/test/mix/tasks/hex/search_test.exs
@@ -13,4 +13,9 @@ defmodule Mix.Tasks.Hex.SearchTest do
     assert_received {:mix_shell, :info, ["ex_plex  0.2.0"]}
     assert_received {:mix_shell, :info, ["postgrex 0.2.1"]}
   end
+
+  test "empty search" do
+    Mix.Tasks.Hex.Search.run(["bloopdoopbloop"])
+    assert_received {:mix_shell, :info, ["No packages found"]}
+  end
 end


### PR DESCRIPTION
Instead of throwing an Enum.EmptyError, return a message about no packages found.