### PR TITLE
RFC: Hex registry plugins

### DIFF
--- a/lib/hex/package_registry.ex
+++ b/lib/hex/package_registry.ex
@@ -1,0 +1,194 @@
+defmodule Hex.PackageRegistry do
+  @name __MODULE__
+
+  @callback open(Keyword.t)                           :: {:ok, term} | {:error, String.t}
+  @callback close(term)                               :: boolean
+  @callback version(term)                             :: String.t
+  @callback installs(term)                            :: [{String.t, String.t}]
+  @callback stat(term)                                :: {non_neg_integer, non_neg_integer}
+  @callback search(term, String.t)                    :: [String.t]
+  @callback all_packages(term)                        :: [String.t]
+  @callback get_versions(term, String.t)              :: [String.t]
+  @callback get_deps(term, String.t, String.t)        :: [{String.t, String.t, String.t, boolean}]
+  @callback get_checksum(term, String.t, String.t)    :: binary
+  @callback get_build_tools(term, String.t, String.t) :: [String.t]
+  @callback to_lock(term, tuple)                      :: map
+  @callback from_lock(term, map)                      :: [tuple]
+
+  options = quote do [
+    version(),
+    installs(),
+    stat(),
+    search(term),
+    all_packages(),
+    get_versions(package),
+    get_deps(package, version),
+    get_checksum(package, version),
+    get_build_tools(package, version)]
+  end
+
+  Enum.each(options, fn {function, _, args} ->
+    def unquote(function)(unquote_splicing(args)) do
+      call_registry(unquote(function), [unquote_splicing(args)])
+    end
+  end)
+
+  def pdict_clean do
+    Agent.update(@name, &Enum.map(&1, fn {registry, _} -> {registry, nil} end))
+  end
+
+  def start_link do
+    Agent.start_link(fn -> [] end, name: @name)
+  end
+
+  def append(registry) do
+    Agent.update(@name, &(&1 ++ [{registry, nil}]))
+  end
+
+  def open!(opts \\ []) do
+    case open(opts) do
+      :ok -> :ok
+      {:error, reason} ->
+        Mix.raise "Failed to open Hex registry (#{reason})"
+    end
+  end
+
+  def open(opts \\ []) do
+    registries = Agent.get(@name, & &1)
+    # TODO: close succeeded on a failure?
+    {opened, failed} =
+      registries
+      |> Enum.map(fn {module, _name} -> {module, module.open(opts)} end)
+      |> Enum.partition(fn
+        {_, {:ok, _name}} -> true
+        {_, {:error, _reason}} -> false
+      end)
+
+    registries =
+      opened
+      |> Enum.map(fn {module, {:ok, name}} -> {module, name} end)
+
+    Agent.update(@name, fn _ -> registries end)
+    if Enum.any?(failed) do
+      {_, {:error, reason}} = List.first(failed)
+      {:error, reason}
+    else
+      :ok
+    end
+  end
+
+  def close do
+    did_close =
+      @name
+      |> Agent.get(& &1)
+      |> Enum.any?(fn {module, name} -> module.close(name) end)
+
+    pdict_clean()
+    did_close
+  end
+
+  @spec to_lock(%{}) :: %{}
+  def to_lock(result) do
+    items = Enum.map(result, &call_registry(:to_lock, [&1]))
+
+    failure = Enum.find(items, fn
+      {:error, _error} -> true
+      _ -> false
+    end)
+
+    if failure do
+      failure
+    else
+      Enum.into(items, %{})
+    end
+  end
+
+  def from_lock(lock) do
+    items = Enum.flat_map(lock, &call_registry(:from_lock, [&1]))
+
+    failure = Enum.find(items, fn
+      {:error, _error} -> true
+      _ -> false
+    end)
+
+    if failure do
+      failure
+    else
+      items
+    end
+  end
+
+
+  def info_installs do
+    installs = installs()
+    if version = latest_version(installs) do
+      Hex.Shell.warn "A new Hex version is available (#{version}), " <>
+                     "please update with `mix local.hex`"
+    else
+      check_elixir_version(installs)
+    end
+  end
+
+  defp call_registry(function, args) do
+    result =
+      @name
+      |> Agent.get(& &1)
+      |> Stream.map(fn {module, name} -> apply(module, function, [name | args]) end)
+      |> Enum.find(fn
+        {:ok, _result} -> true
+        {:error, :no_package} -> false
+        {:error, _reason} -> true
+      end)
+
+    case result do
+      {:ok, value} -> value
+      {:error, reason} -> Mix.raise reason
+    end
+  end
+
+  defp latest_version(versions) do
+    current_elixir = System.version
+    current_hex    = Hex.version
+
+    versions
+    |> Enum.filter(fn {hex, _} -> Hex.Version.compare(hex, current_hex) == :gt end)
+    |> Enum.filter(fn {_, elixirs} -> Hex.Version.compare(hd(elixirs), current_elixir) != :gt end)
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.sort(&(Hex.Version.compare(&1, &2) == :gt))
+    |> List.first
+  end
+
+  defp check_elixir_version(versions) do
+    {:ok, built}   = Hex.Version.parse(Hex.elixir_version())
+    {:ok, current} = Hex.Version.parse(System.version)
+
+    unless match_minor?(current, built) do
+      case :lists.keyfind(Hex.version, 1, versions) do
+        {_, elixirs} ->
+          if match_elixir_version?(elixirs, current) do
+            Hex.Shell.warn "Hex was built against against Elixir #{Hex.elixir_version} " <>
+              "and you are running #{System.version}, please run `mix local.hex` " <>
+              "to update to a matching version"
+          end
+
+        false ->
+          :ok
+      end
+    end
+  end
+
+  defp match_elixir_version?(elixirs, current) do
+    Enum.any?(elixirs, fn elixir ->
+      {:ok, elixir} = Hex.Version.parse(elixir)
+      elixir.major == current.major and elixir.minor == current.minor
+    end)
+  end
+
+  defp match_minor?(current, %Version{major: major, minor: minor}) do
+    lower = %Version{major: major, minor: minor,     patch: 0, pre: [],  build: nil}
+    upper = %Version{major: major, minor: minor + 1, patch: 0, pre: [0], build: nil}
+
+    Hex.Version.compare(current, lower) in [:gt, :eq] and
+      Hex.Version.compare(current, upper) == :lt
+  end
+end

--- a/lib/hex/package_registry_supervisor.ex
+++ b/lib/hex/package_registry_supervisor.ex
@@ -1,0 +1,20 @@
+defmodule Hex.PackageRegistrySupervisor do
+  use Supervisor
+
+  @name __MODULE__
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: @name)
+  end
+
+  def start_registry(module) do
+    Supervisor.start_child(@name, worker(module, []))
+  end
+
+  def init([]) do
+    children = [
+    ]
+
+    supervise(children, strategy: :one_for_one)
+  end
+end

--- a/lib/hex/plugin.ex
+++ b/lib/hex/plugin.ex
@@ -1,0 +1,8 @@
+defmodule Hex.Plugin do
+  @callback init :: any
+
+  def init do
+    :ok = Hex.Registry.append({:hex, Hex.Registry.ETS, Hex.SCM})
+    Mix.SCM.append(Hex.SCM)
+  end
+end

--- a/lib/hex/registry.ex
+++ b/lib/hex/registry.ex
@@ -1,125 +1,47 @@
 defmodule Hex.Registry do
-  @pdict_id :"$hex_registry"
+  @name __MODULE__
 
-  @callback open(Keyword.t)                           :: {:ok, term} | {:error, String.t}
-  @callback close(term)                               :: boolean
-  @callback version(term)                             :: String.t
-  @callback installs(term)                            :: [{String.t, String.t}]
-  @callback stat(term)                                :: {non_neg_integer, non_neg_integer}
-  @callback search(term, String.t)                    :: [String.t]
-  @callback all_packages(term)                        :: [String.t]
-  @callback get_versions(term, String.t)              :: [String.t]
-  @callback get_deps(term, String.t, String.t)        :: [{String.t, String.t, String.t, boolean}]
-  @callback get_checksum(term, String.t, String.t)    :: binary
-  @callback get_build_tools(term, String.t, String.t) :: [String.t]
-
-  options = quote do [
-    version(),
-    installs(),
-    stat(),
-    search(term),
-    all_packages(),
-    get_versions(package),
-    get_deps(package, version),
-    get_checksum(package, version),
-    get_build_tools(package, version)]
+  def start_link do
+    Agent.start_link(fn -> [] end, name: @name)
   end
 
-  Enum.each(options, fn {function, _, args} ->
-    def unquote(function)(unquote_splicing(args)) do
-      {module, name} = pdict_get()
-      module.unquote(function)(name, unquote_splicing(args))
-    end
-  end)
-
-  def  pdict_clean,               do: Process.delete(@pdict_id)
-  defp pdict_setup(module, name), do: Process.put(@pdict_id, {module, name})
-  defp pdict_get,                 do: Process.get(@pdict_id)
-
-  def open(module, opts \\ []) do
-    case module.open(opts) do
-      {:ok, name} ->
-        pdict_setup(module, name)
-        :ok
-      {:error, reason} ->
-        {:error, reason}
+  def append({key, registry, scm}) do
+    case Hex.PackageRegistrySupervisor.start_registry(registry) do
+      {:ok, _pid} ->
+        Agent.update(@name, &(&1 ++ [{key, registry, scm, nil}]))
+        Hex.PackageRegistry.append(registry)
+      {:error, reason} -> {:error, reason}
     end
   end
 
-  def open!(module, opts \\ []) do
-    case module.open(opts) do
-      {:ok, name} ->
-        pdict_setup(module, name)
-        :ok
-      {:error, reason} ->
-        Mix.raise "Failed to open Hex registry (#{reason})"
-    end
-  end
-
-  def close do
-    case pdict_get() do
-      {module, name} ->
-        result = module.close(name)
-        pdict_clean()
-        result
-      nil ->
-        false
-    end
-  end
-
-  def info_installs do
-    installs = installs()
-    if version = latest_version(installs) do
-      Hex.Shell.warn "A new Hex version is available (#{version}), " <>
-                     "please update with `mix local.hex`"
-    else
-      check_elixir_version(installs)
-    end
-  end
-
-  defp latest_version(versions) do
-    current_elixir = System.version
-    current_hex    = Hex.version
-
-    versions
-    |> Enum.filter(fn {hex, _} -> Hex.Version.compare(hex, current_hex) == :gt end)
-    |> Enum.filter(fn {_, elixirs} -> Hex.Version.compare(hd(elixirs), current_elixir) != :gt end)
+  def keys do
+    Agent.get(@name, & &1)
     |> Enum.map(&elem(&1, 0))
-    |> Enum.sort(&(Hex.Version.compare(&1, &2) == :gt))
-    |> List.first
   end
 
-  defp check_elixir_version(versions) do
-    {:ok, built}   = Hex.Version.parse(Hex.elixir_version())
-    {:ok, current} = Hex.Version.parse(System.version)
+  def has_scm?(scm), do: !is_nil(by_scm(scm))
 
-    unless match_minor?(current, built) do
-      case :lists.keyfind(Hex.version, 1, versions) do
-        {_, elixirs} ->
-          if match_elixir_version?(elixirs, current) do
-            Hex.Shell.warn "Hex was built against against Elixir #{Hex.elixir_version} " <>
-              "and you are running #{System.version}, please run `mix local.hex` " <>
-              "to update to a matching version"
-          end
-
-        false ->
-          :ok
-      end
-    end
-  end
-
-  defp match_elixir_version?(elixirs, current) do
-    Enum.any?(elixirs, fn elixir ->
-      {:ok, elixir} = Hex.Version.parse(elixir)
-      elixir.major == current.major and elixir.minor == current.minor
+  def by_scm(scm) do
+    Agent.get(@name, & &1)
+    |> Enum.find(fn
+      {_, _, ^scm, _} -> true
+      _ -> false
     end)
   end
 
-  defp match_minor?(current, %Version{major: major, minor: minor}) do
-    lower = %Version{major: major, minor: minor,     patch: 0, pre: [],  build: nil}
-    upper = %Version{major: major, minor: minor + 1, patch: 0, pre: [0], build: nil}
-
-    Hex.Version.compare(current, lower) in [:gt, :eq] and
-      Hex.Version.compare(current, upper) == :lt
+  def prefetch(lock) do
+    @name
+    |> Agent.get(& &1)
+    |> Enum.each(fn {_, _, scm, _} -> scm.prefetch(lock) end)
   end
+
+  def verify_lock_tuple(lock_tuple, default \\ nil, callback)
+  def verify_lock_tuple({key, name, version}, default, callback) do
+    if key in keys do
+      callback.({key, name, version})
+    else
+      default
+    end
+  end
+  def verify_lock_tuple(_lock_tuple, default, _callback), do: default
 end

--- a/lib/hex/registry_supervisor.ex
+++ b/lib/hex/registry_supervisor.ex
@@ -1,0 +1,19 @@
+defmodule Hex.RegistrySupervisor do
+  use Supervisor
+
+  @name __MODULE__
+
+  def start_link do
+    Supervisor.start_link(__MODULE__, [], name: @name)
+  end
+
+  def init([]) do
+    children = [
+      worker(Hex.Registry, []),
+      worker(Hex.PackageRegistry, []),
+      supervisor(Hex.PackageRegistrySupervisor, []),
+    ]
+
+    supervise(children, strategy: :rest_for_one)
+  end
+end

--- a/lib/hex/resolver.ex
+++ b/lib/hex/resolver.ex
@@ -1,7 +1,7 @@
 defmodule Hex.Resolver do
   import Hex.Mix
   require Record
-  alias Hex.Registry
+  alias Hex.PackageRegistry
   alias Hex.Resolver.Backtracks
 
   Record.defrecordp :info, [:deps, :top_level]
@@ -138,7 +138,7 @@ defmodule Hex.Resolver do
   end
 
   defp get_versions(package, requests) do
-    if versions = Registry.get_versions(package) do
+    if versions = PackageRegistry.get_versions(package) do
       Enum.reduce(requests, versions, fn request, versions ->
         req = request(request, :req)
         Enum.filter(versions, &version_match?(&1, req))
@@ -150,7 +150,7 @@ defmodule Hex.Resolver do
   end
 
   defp get_deps(app, package, version, info(top_level: top_level, deps: all_deps), activated) do
-    if deps = Registry.get_deps(package, version) do
+    if deps = PackageRegistry.get_deps(package, version) do
       all_deps = attach_dep_and_children(all_deps, app, deps)
       overridden_map = overridden_parents(top_level, all_deps, app)
 

--- a/lib/hex/resolver/backtracks.ex
+++ b/lib/hex/resolver/backtracks.ex
@@ -189,7 +189,7 @@ defmodule Hex.Resolver.Backtracks do
 
   defp merge_versions?(_package, []), do: false
   defp merge_versions?(package, versions) do
-    all_versions = Hex.Registry.get_versions(package)
+    all_versions = Hex.PackageRegistry.get_versions(package)
     sub_range?(all_versions, versions)
   end
 

--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -59,22 +59,22 @@ defmodule Hex.SCM do
   end
 
   def managers(opts) do
-    Hex.Registry.open!(Hex.Registry.ETS)
+    Hex.PackageRegistry.open!
 
     case opts[:lock] do
       {:hex, name, version} ->
         name        = Atom.to_string(name)
-        build_tools = Hex.Registry.get_build_tools(name, version) || []
+        build_tools = Hex.PackageRegistry.get_build_tools(name, version) || []
         Enum.map(build_tools, &String.to_atom/1)
       _ ->
         []
     end
   after
-    Hex.Registry.pdict_clean
+    Hex.PackageRegistry.pdict_clean
   end
 
   def checkout(opts) do
-    Hex.Registry.open!(Hex.Registry.ETS)
+    Hex.PackageRegistry.open!
 
     {:hex, _name, version} = opts[:lock]
     name     = opts[:hex]
@@ -107,7 +107,7 @@ defmodule Hex.SCM do
 
     opts[:lock]
   after
-    Hex.Registry.pdict_clean
+    Hex.PackageRegistry.pdict_clean
   end
 
   def update(opts) do

--- a/lib/hex/tar.ex
+++ b/lib/hex/tar.ex
@@ -86,7 +86,7 @@ defmodule Hex.Tar do
       {:ok, tar_checksum} ->
         meta = metadata(tar_version, files)
         blob = files['VERSION'] <> meta <> files['contents.tar.gz']
-        registry_checksum = Hex.Registry.get_checksum(to_string(name), version)
+        registry_checksum = Hex.PackageRegistry.get_checksum(to_string(name), version)
         checksum = :crypto.hash(:sha256, blob)
 
         if checksum != tar_checksum do

--- a/lib/hex/utils.ex
+++ b/lib/hex/utils.ex
@@ -7,11 +7,11 @@ defmodule Hex.Utils do
     if update_result == :error and not File.exists?(Hex.Registry.ETS.path) do
       {:error, :update_failed}
     else
-      start_result = Hex.Registry.open(Hex.Registry.ETS)
+      start_result = Hex.PackageRegistry.open
 
       # Show available newer versions
       if update_result in [{:ok, :new}, {:ok, :no_fetch}] and start_result == :ok do
-        Hex.Registry.info_installs
+        Hex.PackageRegistry.info_installs
       end
 
       start_result
@@ -25,11 +25,11 @@ defmodule Hex.Utils do
       Mix.raise "Failed to fetch registry"
     end
 
-    Hex.Registry.open!(Hex.Registry.ETS)
+    Hex.PackageRegistry.open!
 
     # Show available newer versions
     if update_result in [{:ok, :new}, {:ok, :no_fetch}] do
-      Hex.Registry.info_installs
+      Hex.PackageRegistry.info_installs
     end
   end
 
@@ -42,7 +42,7 @@ defmodule Hex.Utils do
       true ->
         Hex.State.put(:registry_updated, true)
 
-        closed? = Hex.Registry.close
+        closed? = Hex.PackageRegistry.close
         path    = Hex.Registry.ETS.path
         path_gz = path <> ".gz"
         fetch?  = Keyword.get(opts, :fetch, true) and
@@ -75,7 +75,7 @@ defmodule Hex.Utils do
           end
         after
           # Open registry if it was already open when update began
-          if closed?, do: Hex.Registry.open!(Hex.Registry.ETS)
+          if closed?, do: Hex.PackageRegistry.open!
         end
     end
   end

--- a/lib/mix/tasks/hex/info.ex
+++ b/lib/mix/tasks/hex/info.ex
@@ -44,7 +44,7 @@ defmodule Mix.Tasks.Hex.Info do
     compressed_stat = File.stat!(path <> ".gz", time: :local)
     size            = stat.size |> div(1024)
     compressed_size = compressed_stat.size |> div(1024)
-    {packages, releases} = Hex.Registry.stat()
+    {packages, releases} = Hex.PackageRegistry.stat()
 
     Hex.Shell.info "Registry file available (last updated: #{format_date(stat.mtime)})"
     Hex.Shell.info "Size: #{size}kB (compressed #{compressed_size}kb)"

--- a/lib/mix/tasks/hex/search.ex
+++ b/lib/mix/tasks/hex/search.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.Hex.Search do
       [package] ->
         Hex.Utils.ensure_registry!()
 
-        Hex.Registry.search(package)
+        Hex.PackageRegistry.search(package)
         |> lookup_packages
 
       _ ->
@@ -31,7 +31,7 @@ defmodule Mix.Tasks.Hex.Search do
     pkg_max_length = Enum.max_by(packages, &byte_size/1) |> byte_size
 
     Enum.each(packages, fn pkg ->
-      vsn = Hex.Registry.get_versions(pkg) |> List.last
+      vsn = Hex.PackageRegistry.get_versions(pkg) |> List.last
       pkg_name = String.ljust(pkg, pkg_max_length)
       Hex.Shell.info "#{pkg_name} #{vsn}"
     end)

--- a/test/hex/registry_test.exs
+++ b/test/hex/registry_test.exs
@@ -2,14 +2,14 @@ defmodule Hex.RegistryTest do
   use HexTest.Case
 
   test "stat" do
-    Hex.Registry.open!(Hex.Registry.ETS, registry_path: tmp_path("registry.ets"))
-    assert Hex.Registry.stat == {18, 46}
-    assert Hex.Registry.close == true
+    Hex.PackageRegistry.open!(registry_path: tmp_path("registry.ets"))
+    assert Hex.PackageRegistry.stat == {18, 46}
+    assert Hex.PackageRegistry.close == true
 
     # Multiple open and close should yield the same result
-    Hex.Registry.open!(Hex.Registry.ETS, registry_path: tmp_path("registry.ets"))
-    assert Hex.Registry.stat == {18, 46}
-    assert Hex.Registry.close == true
+    Hex.PackageRegistry.open!(registry_path: tmp_path("registry.ets"))
+    assert Hex.PackageRegistry.stat == {18, 46}
+    assert Hex.PackageRegistry.close == true
   end
 
   test "install info output once" do
@@ -21,7 +21,7 @@ defmodule Hex.RegistryTest do
       versions = [{"100.0.0", ["0.0.1"]}]
       create_registry(path, 3, versions, [], [])
 
-      Hex.Registry.open!(Hex.Registry.ETS)
+      Hex.PackageRegistry.open!
       Hex.Utils.ensure_registry!(fetch: false)
       assert_received {:mix_shell, :info, ["\e[33mA new Hex version is available" <> _]}
 
@@ -40,7 +40,7 @@ defmodule Hex.RegistryTest do
                   {"100.0.0", ["0.0.1"]}, {"98.0.0", ["0.0.1"]}]
       create_registry(path, 3, versions, [], [])
 
-      Hex.Registry.open!(Hex.Registry.ETS)
+      Hex.PackageRegistry.open!
       Hex.Utils.ensure_registry!(fetch: false)
       assert_received {:mix_shell, :info, ["\e[33mA new Hex version is available (100.0.0), please update with `mix local.hex`\e[0m"]}
     end
@@ -55,7 +55,7 @@ defmodule Hex.RegistryTest do
       versions = [{"100.0.0", ["100.0.0"]}]
       create_registry(path, 3, versions, [], [])
 
-      Hex.Registry.open!(Hex.Registry.ETS)
+      Hex.PackageRegistry.open!
       Hex.Utils.ensure_registry!(fetch: false)
       refute_received {:mix_shell, :info, ["A new Hex version is available" <> _]}
     end
@@ -70,7 +70,7 @@ defmodule Hex.RegistryTest do
       versions = [{"0.0.1", ["0.0.1"]}]
       create_registry(path, 3, versions, [], [])
 
-      Hex.Registry.open!(Hex.Registry.ETS)
+      Hex.PackageRegistry.open!
       Hex.Utils.ensure_registry!(fetch: false)
       refute_received {:mix_shell, :info, ["A new Hex version is available" <> _]}
     end

--- a/test/hex/resolver/backtracks_test.exs
+++ b/test/hex/resolver/backtracks_test.exs
@@ -3,7 +3,7 @@ defmodule Hex.Resolver.BacktracksTest do
   import Hex.Resolver.Backtracks, only: [message: 1]
 
   setup do
-    Hex.Registry.open!(Hex.Registry.ETS, registry_path: tmp_path("registry.ets"))
+    Hex.PackageRegistry.open!(registry_path: tmp_path("registry.ets"))
   end
 
   test "merge versions" do

--- a/test/hex/resolver_test.exs
+++ b/test/hex/resolver_test.exs
@@ -35,7 +35,7 @@ defmodule Hex.ResolverTest do
   end
 
   setup do
-    Hex.Registry.open!(Hex.Registry.ETS, registry_path: tmp_path("registry.ets"))
+    Hex.PackageRegistry.open!(registry_path: tmp_path("registry.ets"))
   end
 
   test "simple" do

--- a/test/mix/tasks/hex/search_test.exs
+++ b/test/mix/tasks/hex/search_test.exs
@@ -4,7 +4,7 @@ defmodule Mix.Tasks.Hex.SearchTest do
 
   setup do
     Hex.State.put(:registry_updated, true)
-    Hex.Registry.open!(Hex.Registry.ETS, registry_path: tmp_path("registry.ets"))
+    Hex.PackageRegistry.open!(registry_path: tmp_path("registry.ets"))
   end
 
   test "search" do


### PR DESCRIPTION
Hello, I'm hoping to get some feedback on a plugin system I've been working on for Hex before I do too much more work on it. The code presented here is meant as a proof of concept only; it needs tests, documentation, refactoring, and so on. Still, hopefully it's readable enough for others to tell me if this is a viable approach (or even if it's something Hex should support).

The motivation for this is to allow for external registries to work seamlessly with Hex packages and Hex's remote converger. My current use case is to support proprietary packages deployed to an internal [Artifactory](https://www.jfrog.com/artifactory/) repository, allow them to be declared similarly to other dependencies in a Mix file, and have all dependencies (whether from Artifactory or Hex) resolve successfully. You can see the prototype of this plugin here: https://github.com/childss/ex_artifactory_prototype

The idea is that a plugin can register with Hex, declaring an SCM key, package registry, and SCM module. For example, Hex itself declares `{:hex, Hex.Registry.ETS, Hex.SCM}`. When resolving packages and dependencies, Hex will try any plugin registries before falling back to the primary (`Hex.Registry.ETS`). The main changes then are:

1. `Hex.Registry` -> `Hex.PackageRegistry`; `Hex.Registry` is now the registry for the key-registry-scm tuples described previously.
2. `from_lock`/`to_lock` have moved to the package registry impls so that locks can be matched up correctly with their registry and SCM.
3. Varied changes throughout the code to make sure lock tuples from any plugin (or Hex) are handled.

I'm not particularly tied to any part of this implementation and I'm willing to put in the work necessary to complete it well. In other words, I won't be offended to hear "we might like to see this feature for Hex but your approach is all wrong" :)

Thanks for your consideration and any feedback/ideas for improvement you might have.