### PR TITLE
update code of conduct links

### DIFF
--- a/lib/mix/tasks/hex/publish.ex
+++ b/lib/mix/tasks/hex/publish.ex
@@ -102,7 +102,7 @@ defmodule Mix.Tasks.Hex.Publish do
   end
 
   defp print_link_to_coc() do
-    Hex.Shell.info "Before publishing, please read Hex Code of Conduct: https://hex.pm/docs/codeofconduct"
+    Hex.Shell.info "Before publishing, please read Hex Code of Conduct: https://hex.pm/policies/codeofconduct"
   end
 
   defp revert(meta, version, auth) do

--- a/test/mix/tasks/hex/publish_test.exs
+++ b/test/mix/tasks/hex/publish_test.exs
@@ -24,7 +24,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       Mix.Tasks.Hex.Publish.run(["--no-progress"])
       assert {200, _, _} = Hex.API.Release.get("release_a", "0.0.1")
 
-      msg = "Before publishing, please read Hex Code of Conduct: https://hex.pm/docs/codeofconduct"
+      msg = "Before publishing, please read Hex Code of Conduct: https://hex.pm/policies/codeofconduct"
       assert_received {:mix_shell, :info, [^msg]}
 
       send self, {:mix_shell_input, :yes?, true}


### PR DESCRIPTION
today in the elixir mastery class we found that the code of conduct links were no longer correct. this should update them to the correct endpoints.