### PR TITLE
Warn about long package descriptions

### DIFF
--- a/lib/mix/hex/build.ex
+++ b/lib/mix/hex/build.ex
@@ -5,6 +5,7 @@ defmodule Mix.Hex.Build do
   @error_fields ~w(files app name description version build_tools)a
   @warn_fields ~w(licenses maintainers links)a
   @meta_fields @error_fields ++ @warn_fields ++ ~w(elixir)a
+  @max_description_length 300
 
   def prepare_package! do
     Hex.start
@@ -36,6 +37,7 @@ defmodule Mix.Hex.Build do
     Enum.each(@meta_fields, &print_meta(meta, &1))
 
     warn_missing(meta)
+    warn_long_description(meta)
     warn_missing_files(package_files)
     error_missing!(meta)
 
@@ -169,6 +171,14 @@ defmodule Mix.Hex.Build do
       fields = Enum.join(missing_fields, ", ")
       Hex.Shell.error("  ERROR! Missing metadata fields: #{fields}")
       Mix.raise("Stopping package build due to errors")
+    end
+  end
+
+  defp warn_long_description(meta) do
+    description = meta[:description] || ""
+
+    if String.length(description) > @max_description_length do
+      Hex.Shell.warn("  WARNING! Package description is very long (exceeds #{@max_description_length} characters)")
     end
   end
 

--- a/test/mix/tasks/hex/build_test.exs
+++ b/test/mix/tasks/hex/build_test.exs
@@ -88,4 +88,19 @@ defmodule Mix.Tasks.Hex.BuildTest do
   after
     purge [ReleaseNoDescription.Mixfile]
   end
+
+  test "warn if description is too long" do
+    Mix.Project.push ReleaseTooLongDescription.Mixfile
+
+    in_tmp fn ->
+      Hex.State.put(:home, tmp_path())
+
+      Mix.Tasks.Hex.Build.run([])
+
+      assert_received {:mix_shell, :info, ["\e[33m  WARNING! Package description is very long (exceeds " <> _]}
+      assert package_created?("release_f-0.0.1")
+    end
+  after
+    purge [ReleaseTooLongDescription.Mixfile]
+  end
 end

--- a/test/support/release_samples.ex
+++ b/test/support/release_samples.ex
@@ -34,3 +34,10 @@ defmodule ReleaseNoDescription.Mixfile do
     [app: :release_e, version: "0.0.1"]
   end
 end
+
+defmodule ReleaseTooLongDescription.Mixfile do
+  def project do
+    [app: :release_f, description: String.duplicate("w", 301),
+     version: "0.0.1"]
+  end
+end


### PR DESCRIPTION
Warns the user during `mix hex.publish` if the package description exceeds 300 characters.

Fixes #229 :grin:
