### PR TITLE
Allow extra searchable metadata in package

### DIFF
--- a/lib/mix/hex/build.ex
+++ b/lib/mix/hex/build.ex
@@ -4,7 +4,7 @@ defmodule Mix.Hex.Build do
 
   @error_fields ~w(files app name description version build_tools)a
   @warn_fields ~w(licenses maintainers links)a
-  @meta_fields @error_fields ++ @warn_fields ++ ~w(elixir)a
+  @meta_fields @error_fields ++ @warn_fields ++ ~w(elixir extra)a
   @max_description_length 300
 
   def prepare_package! do

--- a/test/mix/tasks/hex/publish_test.exs
+++ b/test/mix/tasks/hex/publish_test.exs
@@ -101,6 +101,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert_received {:mix_shell, :info, ["  Files:"]}
       assert_received {:mix_shell, :info, ["    myfile.txt"]}
       assert_received {:mix_shell, :info, ["\e[33m  WARNING! Missing files: missing.txt, missing/*" <> _]}
+      assert_received {:mix_shell, :info, ["  Extra: \n    c: d"]}
       refute_received {:mix_shell, :info, ["\e[33m  WARNING! Missing metadata fields" <> _]}
     end
   after

--- a/test/support/release_samples.ex
+++ b/test/support/release_samples.ex
@@ -22,7 +22,8 @@ defmodule ReleaseMeta.Mixfile do
      package: [files: ["myfile.txt", "missing.txt", "missing/*"],
        licenses: ["Apache"],
        links: %{"a" => "b"},
-       maintainers: ["maintainers"]]]
+       maintainers: ["maintainers"],
+       extra: %{"c" => "d"}]]
   end
 end
 


### PR DESCRIPTION
WIP. This needs to get tracked alongside associated commits in hex_web.

The idea is that we would like to allow passing extra metadata about the package which can be searched upon using the search api on hex_web.

For example, 
```elixir
defmodule ReleaseMeta.Mixfile do
  def project do
    [app: :release_c, version: "0.0.3",
     description: "foo",
     package: [files: ["myfile.txt", "missing.txt", "missing/*"],
       licenses: ["Apache"],
       links: %{"a" => "b"},
       maintainers: ["maintainers"],
       extra: %{"bar" => "baz"}]]
  end
end
```

It seems that in order to apply a search index to additional meta keys, we would have to apply it to a known key like `:extra`. This also reduces complexity of the top level spec. 

To search this data we would construct a search path like path: "extra/bar", search: "baz". 

Tracked alongside
https://github.com/hexpm/specifications/pull/6