### PR TITLE
Fix build on Elixir < 1.3

### DIFF
--- a/test/support/hex_web.ex
+++ b/test/support/hex_web.ex
@@ -112,7 +112,12 @@ defmodule HexTest.HexWeb do
   end
 
   defp hexweb_mix_archives do
-    (System.get_env("HEXWEB_MIX_ARCHIVES") || Mix.Local.path_for(:archive))
+    archives_path =
+      if function_exported?(Mix.Local, :path_for, 1),
+        do: Mix.Local.path_for(:archive),
+      else: Mix.Local.archives_path
+
+    (System.get_env("HEXWEB_MIX_ARCHIVES") || archives_path)
     |> Path.expand
   end
 


### PR DESCRIPTION
This should fix hex_web build, see failure: https://travis-ci.org/hexpm/hex_web/builds/137178925.

Not sure why CI didn't catch this. When I tried cloning hex locally and running tests on v1.2.1, it did fail with the same error though.