### PR TITLE
Improve task shortdocs

### DIFF
--- a/lib/mix/tasks/hex/key.ex
+++ b/lib/mix/tasks/hex/key.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Hex.Key do
   use Mix.Task
   alias Mix.Hex.Utils
 
-  @shortdoc "Hex API key tasks"
+  @shortdoc "Manages Hex API key"
 
   @moduledoc """
   Removes or lists API keys associated with your account.

--- a/lib/mix/tasks/hex/outdated.ex
+++ b/lib/mix/tasks/hex/outdated.ex
@@ -4,8 +4,7 @@ defmodule Mix.Tasks.Hex.Outdated do
   @shortdoc "Shows outdated Hex deps for the current project"
 
   @moduledoc """
-  Shows all packages that have a version mismatch between the registry and
-  your mix.lock file.
+  Shows all Hex dependencies that have newer versions in the registry.
 
   By default, it only shows top-level packages explicitly listed in the
   `mix.exs` file. All outdated packages can be displayed by using the `--all`

--- a/lib/mix/tasks/hex/owner.ex
+++ b/lib/mix/tasks/hex/owner.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Hex.Owner do
   use Mix.Task
   alias Mix.Hex.Utils
 
-  @shortdoc "Hex package ownership tasks"
+  @shortdoc "Manages Hex package ownership"
 
   @moduledoc """
   Adds, removes or lists package owners.

--- a/lib/mix/tasks/hex/registry.ex
+++ b/lib/mix/tasks/hex/registry.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Hex.Registry do
   use Mix.Task
 
-  @shortdoc "Hex registry tasks"
+  @shortdoc "Manages the local Hex registry"
 
   @moduledoc """
-  Tasks for working with the locally cached registry file. 
+  Tasks for working with the locally cached registry file.
 
   ### Fetch registry
 

--- a/lib/mix/tasks/hex/user.ex
+++ b/lib/mix/tasks/hex/user.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Hex.User do
   use Mix.Task
   alias Mix.Hex.Utils
 
-  @shortdoc "Hex user tasks"
+  @shortdoc "Registers or manages Hex user"
 
   @moduledoc """
   Hex user tasks.


### PR DESCRIPTION
I want to remove "tasks" from the shortdoc because it's redundant but not sure if this is an improvement.

/cc @josevalim 