### PR TITLE
Support for revocation of all keys and removal from local config

### DIFF
--- a/lib/hex/api/key.ex
+++ b/lib/hex/api/key.ex
@@ -12,4 +12,8 @@ defmodule Hex.API.Key do
   def delete(name, auth) do
     API.request(:delete, API.api_url("keys/#{name}"), API.auth(auth))
   end
+
+  def delete_all(auth) do
+    API.request(:delete, API.api_url("keys"), API.auth(auth))
+  end
 end

--- a/lib/mix/tasks/hex/key.ex
+++ b/lib/mix/tasks/hex/key.ex
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Hex.Key do
   defp remove_key(key, auth) do
     Hex.Shell.info "Removing key #{key}..."
     case Hex.API.Key.delete(key, auth) do
-      {200, %{"name" => ^key, "revoked_at" => _}, _headers} ->
+      {200, %{"name" => ^key, "authing_key" => true}, _headers} ->
         Mix.Tasks.Hex.User.run(["deauth"])
         :ok
       {code, _body, _headers} when code in 200..299 ->
@@ -67,7 +67,7 @@ defmodule Mix.Tasks.Hex.Key do
   defp remove_all_keys(auth) do
     Hex.Shell.info "Removing all keys..."
     case Hex.API.Key.delete_all(auth) do
-      {code, %{"name" => _, "revoked_at" => _}, _headers} when code in 200..299 ->
+      {code, %{"name" => _, "authing_key" => true}, _headers} when code in 200..299 ->
         Mix.Tasks.Hex.User.run(["deauth"])
         :ok
       {code, body, _headers} ->

--- a/test/mix/tasks/hex/key_test.exs
+++ b/test/mix/tasks/hex/key_test.exs
@@ -21,16 +21,57 @@ defmodule Mix.Tasks.Hex.KeyTest do
     in_tmp fn ->
       Hex.State.put(:home, System.cwd!)
 
-      auth = HexTest.HexWeb.new_user("remove_key", "remove_key@mail.com", "password", "remove_key")
-      Hex.Config.update(auth)
+      auth_a = HexTest.HexWeb.new_user("remove_key", "remove_key@mail.com", "password", "remove_key_a")
+      auth_b = HexTest.HexWeb.new_key("remove_key", "password", "remove_key_b")
+      Hex.Config.update(auth_a)
 
-      assert {200, _, _} = Hex.API.Key.get(auth)
+      assert {200, _, _} = Hex.API.Key.get(auth_a)
+      assert {200, _, _} = Hex.API.Key.get(auth_b)
 
       send self(), {:mix_shell_input, :prompt, "password"}
-      Mix.Tasks.Hex.Key.run(["remove", "remove_key"])
-      assert_received {:mix_shell, :info, ["Removing key remove_key..."]}
+      Mix.Tasks.Hex.Key.run(["remove", "remove_key_b"])
+      assert_received {:mix_shell, :info, ["Removing key remove_key_b..."]}
 
-      assert {401, _, _} = Hex.API.Key.get(auth)
+      assert {200, _, _} = Hex.API.Key.get(auth_a)
+      assert {401, _, _} = Hex.API.Key.get(auth_b)
+
+      send self(), {:mix_shell_input, :prompt, "password"}
+      Mix.Tasks.Hex.Key.run(["remove", "remove_key_a"])
+      assert_received {:mix_shell, :info, ["Removing key remove_key_a..."]}
+      assert_received {:mix_shell, :info, ["User `remove_key` removed from the local machine. To authenticate again, run `mix hex.user auth` or create a new user with `mix hex.user register`"]}
+
+      assert {401, _, _} = Hex.API.Key.get(auth_a)
+
+      config = Hex.Config.read
+      refute config[:username]
+      refute config[:key]
+      refute config[:encrypted_key]
+    end
+  end
+
+  test "remove all keys" do
+    in_tmp fn ->
+      Hex.State.put(:home, System.cwd!)
+
+      auth_a = HexTest.HexWeb.new_user("remove_all_keys", "remove_all_keys@mail.com", "password", "remove_all_keys_a")
+      auth_b = HexTest.HexWeb.new_key("remove_all_keys", "password", "remove_all_keys_b")
+      Hex.Config.update(auth_a)
+
+      assert {200, _, _} = Hex.API.Key.get(auth_a)
+      assert {200, _, _} = Hex.API.Key.get(auth_b)
+
+      send self(), {:mix_shell_input, :prompt, "password"}
+      Mix.Tasks.Hex.Key.run(["remove", "--all"])
+      assert_received {:mix_shell, :info, ["Removing all keys..."]}
+      assert_received {:mix_shell, :info, ["User `remove_all_keys` removed from the local machine. To authenticate again, run `mix hex.user auth` or create a new user with `mix hex.user register`"]}
+
+      assert {401, _, _} = Hex.API.Key.get(auth_a)
+      assert {401, _, _} = Hex.API.Key.get(auth_b)
+
+      config = Hex.Config.read
+      refute config[:username]
+      refute config[:key]
+      refute config[:encrypted_key]
     end
   end
 end

--- a/test/support/hex_web.ex
+++ b/test/support/hex_web.ex
@@ -191,6 +191,11 @@ defmodule HexTest.HexWeb do
     [key: secret]
   end
 
+  def new_key(username, password, key) do
+    {201, %{"secret" => secret}, _} = Hex.API.Key.new(key, [user: username, pass: password])
+    [username: username, key: secret] ++ Mix.Hex.Utils.generate_encrypted_key(password, secret)
+  end
+
   def new_package(name, version, deps, meta, auth) do
     reqs =
       Enum.filter(deps, fn


### PR DESCRIPTION
This pull request should hopefully resolve #251, #252, and #253.

**Note:** These changes are dependent on pull requests #255 and hexpm/hex_web#378, so I expect travis to throw a fit over the tests.

### Summary of changes

1. Support for `mix hex.key remove --all` added (see #251)
2. If the current key is being removed from the server, the key is also removed from the local configuration (see #253)
3. An error message is displayed to the user if their key has been revoked (see #252)

##### Design Discussion

1. Removing the current key from the server has the same effect as `mix hex.key remove KEY` followed by `mix hex.user deauth`.  There's nothing really left in the config file related to authentication other than `username` at that point.
2. There is no global handling for the "API key revoked" error sent back from the server.  Would it be better to detect whenever that error is present and automatically deauthenticate or prompt the user for their password again?