### PR TITLE
Do not show table when app do not have Hex deps

### DIFF
--- a/lib/mix/tasks/hex/outdated.ex
+++ b/lib/mix/tasks/hex/outdated.ex
@@ -118,12 +118,16 @@ defmodule Mix.Tasks.Hex.Outdated do
       |> get_versions(lock, opts[:pre])
       |> Enum.map(&format_all_row/1)
 
-    Utils.table(header, values)
+    if Enum.empty?(values) do
+      Hex.Shell.info "No hex dependencies"
+    else
+      Utils.table(header, values)
 
-    Hex.Shell.info ""
-    Hex.Shell.info "A green version in latest means you have the latest " <>
-                   "version of a given package. A green requirement means " <>
-                   "your current requirement matches the latest version."
+      Hex.Shell.info ""
+      Hex.Shell.info "A green version in latest means you have the latest " <>
+                     "version of a given package. A green requirement means " <>
+                     "your current requirement matches the latest version."
+    end
   end
 
   defp sort(deps) do

--- a/test/mix/tasks/hex/outdated_test.exs
+++ b/test/mix/tasks/hex/outdated_test.exs
@@ -37,6 +37,14 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     end
   end
 
+  defmodule WithoutHexDeps.Mixfile do
+    def project do
+      [app: :outdated_app,
+       version: "0.0.1",
+       deps: [{:beta, github: "owner/repo"}]]
+    end
+  end
+
   test "outdated" do
     Mix.Project.push OutdatedDeps.Mixfile
 
@@ -164,5 +172,18 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
             |> List.to_string
       assert_received {:mix_shell, :info, [^msg]}
     end
+  end
+
+  test "without hex deps" do
+    Mix.Project.push WithoutHexDeps.Mixfile
+
+    in_tmp fn ->
+      Hex.State.put(:home, tmp_path())
+      Mix.Dep.Lock.write %{beta: {:git, "https://github.com/owner/repo.git", ""}}
+
+      Mix.Task.run "hex.outdated"
+      msg = "No hex dependencies"
+      assert_received {:mix_shell, :info, [^msg]}
+   end
   end
 end


### PR DESCRIPTION
If someone runs the `hex.outdated` task and the application do not depend on any Hex package, show a proper message.

## Old message

```
==> app_one
Dependency  Current  Latest  Requirement

A green version in latest means you have the latest version of a given package. A green requirement means your current requirement matches the latest version.
```

## New message

```
==> app_one
Hex Dependencies: None
```