### PR TITLE
List root dependencies in umbrella projects

### DIFF
--- a/lib/mix/tasks/hex/outdated.ex
+++ b/lib/mix/tasks/hex/outdated.ex
@@ -23,7 +23,6 @@ defmodule Mix.Tasks.Hex.Outdated do
     * `--pre` - include pre-releases when checking for newer versions
   """
 
-  @recursive true
   @switches [all: :boolean, pre: :boolean]
 
   def run(args) do


### PR DESCRIPTION
## Scenario

* umbrella project depends on: `{:ex_doc, "~> 0.13"}`
* sub-project `apps/app_one` depends on: `{:bupe, github: "owner/repo"}`
* sub-project `apps/app_two` depends on: `{:plug, "~> 1.0"}`

## Results

```bash
$ cd ~/umbrella
$ mix hex.outdated
Dependency  Current  Latest  Requirement
ex_doc      0.13.0   0.13.0  ~> 0.13

A green version in latest means you have the latest version of a given package. A green requirement means your current requirement matches the latest version.
$ mix hex.outdated --all
Dependency  Current  Latest  Requirement
earmark     1.0.1    1.0.1   ~> 1.0
ex_doc      0.13.0   0.13.0  ~> 0.13
plug        1.1.6    1.1.6   ~> 1.0

A green version in latest means you have the latest version of a given package. A green requirement means your current requirement matches the latest version.
```

Fixes: #263 
