### PR TITLE
Adding --offline option to hex.docs open

### DIFF
--- a/lib/mix/tasks/hex/docs.ex
+++ b/lib/mix/tasks/hex/docs.ex
@@ -98,7 +98,7 @@ defmodule Mix.Tasks.Hex.Docs do
 
   defp open_docs(package, opts) do
     if opts[:offline] do
-      package |> open_docs_offline(opts)
+      open_docs_offline(package, opts)
     else
       package
       |> get_docs_url

--- a/lib/mix/tasks/hex/docs.ex
+++ b/lib/mix/tasks/hex/docs.ex
@@ -14,14 +14,20 @@ defmodule Mix.Tasks.Hex.Docs do
 
       mix hex.docs open package <version>
 
+  ## Command line options
+
+    * `--offline` - Open a local version available in your filesystem
+
   It will open the specified version of the documentation for a package in a
   Web browser. If you do not specify the `version` argument, this task will
-  open the latest documentation available in your filesystem.
+  open the latest documentation.
   """
+
+  @switches [offline: :boolean]
 
   def run(args) do
     Hex.start
-    {opts, args, _} = OptionParser.parse(args)
+    {opts, args, _} = OptionParser.parse(args, switches: @switches)
     opts = normalize_options(opts)
 
     case args do

--- a/lib/mix/tasks/hex/docs.ex
+++ b/lib/mix/tasks/hex/docs.ex
@@ -118,11 +118,11 @@ defmodule Mix.Tasks.Hex.Docs do
   end
 
   defp get_docs_url([name]) do
-    name |> Hex.Utils.hexdocs_url
+    Hex.Utils.hexdocs_url(name)
   end
 
   defp get_docs_url([name, version]) do
-    name |> Hex.Utils.hexdocs_url(version)
+    Hex.Utils.hexdocs_url(name, version)
   end
 
   defp browser_open(path) do
@@ -146,7 +146,7 @@ defmodule Mix.Tasks.Hex.Docs do
       Mix.raise "Documentation file not found: #{path}"
     end
 
-    path |> browser_open
+    browser_open(path)
   end
 
   defp find_latest_version(path) do

--- a/test/mix/tasks/hex/docs_test.exs
+++ b/test/mix/tasks/hex/docs_test.exs
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
     version = "1.1.2"
     message = "Documentation file not found: #{docs_home}/#{package}/#{version}/index.html"
     assert_raise Mix.Error, message, fn ->
-      Mix.Tasks.Hex.Docs.run(["open", package, version])
+      Mix.Tasks.Hex.Docs.run(["open", package, version, "--offline"])
     end
   end
 
@@ -91,7 +91,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
     end
 
     assert_raise Mix.Error, msg, fn ->
-      Mix.Tasks.Hex.Docs.run(["open"])
+      Mix.Tasks.Hex.Docs.run(["open", "--offline"])
     end
   end
 end


### PR DESCRIPTION
hex.docs open will go online to hexdocs.pm
unless --offline option is specified.

fix #291 