### PR TITLE
Fix elixir 1.0.x compatibility

### DIFF
--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -131,11 +131,11 @@ defmodule Hex.SCM do
     {"Makefile.win", "make"}
   ]
 
-  defp guess_build_tools(%{"build_tools" => tools}) do
+  def guess_build_tools(%{"build_tools" => tools}) do
     tools
   end
 
-  defp guess_build_tools(meta) do
+  def guess_build_tools(meta) do
     base_files =
       (meta["files"] || [])
       |> Enum.filter(&(Path.dirname(&1) == "."))

--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -139,7 +139,7 @@ defmodule Hex.SCM do
     base_files =
       (meta["files"] || [])
       |> Enum.filter(&(Path.dirname(&1) == "."))
-      |> MapSet.new
+      |> Enum.into(Hex.Set.new)
 
     Enum.flat_map(@build_tools, fn {file, tool} ->
       if file in base_files,

--- a/test/hex/scm_test.exs
+++ b/test/hex/scm_test.exs
@@ -1,0 +1,15 @@
+defmodule Hex.SCMTest do
+  use ExUnit.Case, async: true
+
+  test "guess build_tools" do
+    empty_meta    = %{}
+    guessed_meta  = %{"build_tools" => ["mix"]}
+    no_tools_meta = %{"files" => ["README.md"]}
+    tools_meta    = %{"files" => ["README.md", "mix.exs", "lib"]}
+
+    assert [] = Hex.SCM.guess_build_tools(empty_meta)
+    assert ["mix"] = Hex.SCM.guess_build_tools(guessed_meta)
+    assert [] = Hex.SCM.guess_build_tools(no_tools_meta)
+    assert ["mix"] = Hex.SCM.guess_build_tools(tools_meta)
+  end
+end


### PR DESCRIPTION
After the last changes the backwards compatibility with Elixir 1.0.x versions has been accidentally broken.

Changing `MapSet.new` to the already existing `Hex.Set.new` wrapper should fix that.

This was the actual error message I encountered:

```
** (UndefinedFunctionError) undefined function: MapSet.new/1 (module MapSet is not available)
    MapSet.new(["CHANGES.md", "LICENSE", "mix.exs", "rebar.config", "README.md"])
    (hex) lib/hex/scm.ex:142: Hex.SCM.guess_build_tools/1
    (hex) lib/hex/scm.ex:111: Hex.SCM.checkout/1
    (mix) lib/mix/dep/fetcher.ex:64: Mix.Dep.Fetcher.do_fetch/3
    (mix) lib/mix/dep/converger.ex:154: Mix.Dep.Converger.all/8
    (mix) lib/mix/dep/converger.ex:163: Mix.Dep.Converger.all/8
    (mix) lib/mix/dep/converger.ex:47: Mix.Dep.Converger.converge/4
    (mix) lib/mix/dep/fetcher.ex:16: Mix.Dep.Fetcher.all/3
```
