### PR TITLE
hex.docs now opens with xdg-open for non OSX unix systems

### DIFF
--- a/lib/mix/tasks/hex/docs.ex
+++ b/lib/mix/tasks/hex/docs.ex
@@ -150,8 +150,10 @@ defmodule Mix.Tasks.Hex.Docs do
       case :os.type do
         {:win32, _} ->
           "start"
-        {:unix, _} ->
+        {:unix, :darwin} ->
           "open"
+        {:unix, _} ->
+          "xdg-open"
       end
 
     if System.find_executable(start_browser_command) do


### PR DESCRIPTION
Fix for #310 