### PR TITLE
Add --module flag to hex.docs task

### DIFF
--- a/lib/hex/utils.ex
+++ b/lib/hex/utils.ex
@@ -99,6 +99,11 @@ defmodule Hex.Utils do
   def hexdocs_url(package, version),
     do: "https://hexdocs.pm/#{package}/#{version}"
 
+  def hexdocs_module_url(package, module),
+    do: "https://hexdocs.pm/#{package}/#{module}.html"
+  def hexdocs_module_url(package, version, module),
+    do: "https://hexdocs.pm/#{package}/#{version}/#{module}.html"
+
   def proxy_config(url) do
     {http_proxy, https_proxy} = proxy_setup()
     proxy_auth(URI.parse(url), http_proxy, https_proxy)

--- a/lib/mix/tasks/hex/docs.ex
+++ b/lib/mix/tasks/hex/docs.ex
@@ -17,13 +17,14 @@ defmodule Mix.Tasks.Hex.Docs do
   ## Command line options
 
     * `--offline` - Open a local version available in your filesystem
+    * `--module Some.Module` - Open a specified module documentation page inside desired package
 
   It will open the specified version of the documentation for a package in a
   Web browser. If you do not specify the `version` argument, this task will
   open the latest documentation.
   """
 
-  @switches [offline: :boolean]
+  @switches [offline: :boolean, module: :string]
 
   def run(args) do
     Hex.start
@@ -110,7 +111,7 @@ defmodule Mix.Tasks.Hex.Docs do
       open_docs_offline(package, opts)
     else
       package
-      |> get_docs_url
+      |> get_docs_url(opts)
       |> browser_open
     end
   end
@@ -137,12 +138,20 @@ defmodule Mix.Tasks.Hex.Docs do
     end
   end
 
-  defp get_docs_url([name]) do
-    Hex.Utils.hexdocs_url(name)
+  defp get_docs_url([name], opts) do
+    if module = opts[:module] do
+      Hex.Utils.hexdocs_module_url(name, module)
+    else
+      Hex.Utils.hexdocs_url(name)
+    end
   end
 
-  defp get_docs_url([name, version]) do
-    Hex.Utils.hexdocs_url(name, version)
+  defp get_docs_url([name, version], opts) do
+    if module = opts[:module] do
+      Hex.Utils.hexdocs_module_url(name, version, module)
+    else
+      Hex.Utils.hexdocs_url(name, version)
+    end
   end
 
   defp browser_open(path) do


### PR DESCRIPTION
As discussed at #315 adding `--module` flag for opening specified module documentation