### PR TITLE
Changed hex.outdated to show if a dependency can be updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## v0.14.2-dev
 
+### Bug fixes
+  * mix hex.outdated correctly tests if a package can be updated
+
 ## v0.14.1 (2016-11-24)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,5 @@
 ## v0.14.2-dev
 
-### Bug fixes
-  * mix hex.outdated correctly tests if a package can be updated
-
 ## v0.14.1 (2016-11-24)
 
 ### Enhancements

--- a/lib/mix/tasks/hex/outdated.ex
+++ b/lib/mix/tasks/hex/outdated.ex
@@ -117,13 +117,14 @@ defmodule Mix.Tasks.Hex.Outdated do
     if Enum.empty?(values) do
       Hex.Shell.info "No hex dependencies"
     else
-      header = ["Dependency", "Current", "Latest", "Requirement"]
+      header = ["Dependency", "Current", "Latest", "Update possible"]
       Utils.print_table(header, values)
 
       message =
         "A green version in latest means you have the latest " <>
-        "version of a given package. A green requirement means " <>
-        "your current requirement matches the latest version."
+        "version of a given package. Update possible indicates " <>
+        "if your current requirement matches the latest version.\n" <>
+        "Run `mix hex.outdated APP` to see requirements for a specific dependency."
       Hex.Shell.info ["\n" | message]
     end
   end
@@ -137,8 +138,14 @@ defmodule Mix.Tasks.Hex.Outdated do
       case Hex.Utils.lock(lock[dep.app]) do
         [:hex, package, lock_version, _checksum, _managers, _deps] ->
           latest_version = latest_version(package, lock_version, pre?)
-          req = dep.requirement
-          [[Atom.to_string(dep.app), lock_version, latest_version, req]]
+
+          requirements =
+            deps
+            |> get_requirements(dep.app)
+            |> Enum.map(fn [_, req_version] -> req_version end)
+            |> List.insert_at(0, dep.requirement)
+
+          [[Atom.to_string(dep.app), lock_version, latest_version, requirements]]
         _ ->
           []
       end
@@ -171,18 +178,23 @@ defmodule Mix.Tasks.Hex.Outdated do
     List.last(versions)
   end
 
-  defp format_all_row([package, lock, latest, req]) do
+  defp format_all_row([package, lock, latest, requirements]) do
     outdated? = Hex.Version.compare(lock, latest) == :lt
     latest_color = if outdated?, do: :red, else: :green
 
-    req_matches? = version_match?(latest, req)
-    req = req || ""
-    req_color = if req_matches?, do: :green, else: :red
+    req_matches? = Enum.all?(requirements, &(version_match?(latest, &1)))
+
+    {update_possible_color, update_possible} =
+      case {outdated?, req_matches?} do
+        {true, true} -> {:green, "Yes"}
+        {true, false} -> {:red, "No"}
+        {false, _} -> {:green, ""}
+      end
 
     [[:bright, package],
      lock,
      [latest_color, latest],
-     [req_color, req]]
+     [update_possible_color, update_possible]]
   end
 
   defp version_match?(_version, nil), do: true

--- a/lib/mix/tasks/hex/outdated.ex
+++ b/lib/mix/tasks/hex/outdated.ex
@@ -143,7 +143,7 @@ defmodule Mix.Tasks.Hex.Outdated do
             deps
             |> get_requirements(dep.app)
             |> Enum.map(fn [_, req_version] -> req_version end)
-            |> List.insert_at(0, dep.requirement)
+          requirements = [dep.requirement | requirements]
 
           [[Atom.to_string(dep.app), lock_version, latest_version, requirements]]
         _ ->

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -39,6 +39,7 @@ unless :integration in ExUnit.configuration[:exclude] do
   HexWeb.new_package("foo", "0.1.0", [], pkg_meta, auth)
   HexWeb.new_package("foo", "0.1.1", [], pkg_meta, auth)
   HexWeb.new_package("bar", "0.1.0", [foo: "~> 0.1.0"], pkg_meta, auth)
+  HexWeb.new_package("baz", "0.1.0", [foo: "0.1.0"], pkg_meta, auth)
   HexWeb.new_package("beta", "1.0.0", [], pkg_meta, auth)
   HexWeb.new_package("beta", "1.1.0-beta", [], pkg_meta, auth)
 end


### PR DESCRIPTION
It now takes all dependent packages into account and simply prints a `Yes` or a `No` for outdated packages.

Fixes #322

The added test would show with a green "Requirement" before this update, even though it can't be updated.