### PR TITLE
Restore including latest version with hex.search

### DIFF
--- a/lib/mix/tasks/hex/search.ex
+++ b/lib/mix/tasks/hex/search.ex
@@ -32,10 +32,14 @@ defmodule Mix.Tasks.Hex.Search do
   defp lookup_packages({200, packages, _headers}) do
     values =
       Enum.map(packages, fn package ->
-        [package["name"], url(package["name"])]
+        [package["name"], latest(package["releases"]), url(package["name"])]
       end)
 
-    Utils.print_table(["Package", "URL"], values)
+    Utils.print_table(["Package", "Version", "URL"], values)
+  end
+
+  defp latest([%{"version" => version} | _]) do
+    version
   end
 
   defp url(name) do

--- a/test/mix/tasks/hex/search_test.exs
+++ b/test/mix/tasks/hex/search_test.exs
@@ -4,8 +4,8 @@ defmodule Mix.Tasks.Hex.SearchTest do
 
   test "search" do
     Mix.Tasks.Hex.Search.run(["doc"])
-    assert_received {:mix_shell, :info, ["ex_doc\e[0m    https://hex.pm/packages/ex_doc" <> _]}
-    assert_received {:mix_shell, :info, ["only_doc\e[0m  https://hex.pm/packages/only_doc" <> _]}
+    assert_received {:mix_shell, :info, ["ex_doc\e[0m    0.1.0\e[0m    https://hex.pm/packages/ex_doc" <> _]}
+    assert_received {:mix_shell, :info, ["only_doc\e[0m  0.1.0\e[0m    https://hex.pm/packages/only_doc" <> _]}
   end
 
   test "empty search" do


### PR DESCRIPTION
This restores the behavior of printing out the latest version of each matching package. This used to be implemented, but was removed during some v2 refactoring.