### PR TITLE
Normalize usage of one pipe per line

### DIFF
--- a/lib/hex/api.ex
+++ b/lib/hex/api.ex
@@ -115,7 +115,10 @@ defmodule Hex.API do
     headers = Enum.into(headers, %{})
     Utils.handle_hex_message(headers['x-hex-message'])
 
-    body = body |> unzip(headers) |> decode(headers)
+    body =
+      body
+      |> unzip(headers)
+      |> decode(headers)
 
     {code, body, headers}
   end

--- a/lib/hex/api/verify_hostname.ex
+++ b/lib/hex/api/verify_hostname.ex
@@ -52,7 +52,7 @@ defmodule Hex.API.VerifyHostname do
     valid? =
       wildcard_pos != 0 and
         length(hostname) >= length(identifier) and
-        check_wildcard_in_leftmost_label(identifier, wildcard_pos) 
+        check_wildcard_in_leftmost_label(identifier, wildcard_pos)
 
     if valid? do
       before_w = :string.substr(identifier, 1, wildcard_pos - 1)
@@ -177,6 +177,10 @@ defmodule Hex.API.VerifyHostname do
   defp maybe_check_subject_cn([_|_], false, _tbs_cert, _hostname),
     do: false
 
-  defp maybe_check_subject_cn(_dns_names, false, tbs_cert, hostname),
-    do: otp_tbs_certificate(tbs_cert, :subject) |> extract_cn |> try_match_hostname(hostname)
+  defp maybe_check_subject_cn(_dns_names, false, tbs_cert, hostname) do
+    tbs_cert
+    |> otp_tbs_certificate(:subject)
+    |> extract_cn
+    |> try_match_hostname(hostname)
+  end
 end

--- a/lib/hex/mix.ex
+++ b/lib/hex/mix.ex
@@ -178,8 +178,16 @@ defmodule Hex.Mix do
     Enum.into(result, %{}, fn {name, app, version} ->
       app = String.to_atom(app)
       checksum = Hex.Registry.checksum(name, version) |> Base.encode16(case: :lower)
-      deps = Hex.Registry.deps(name, version) |> Enum.map(&registry_dep_to_def/1) |> Enum.sort
-      managers = managers(app) |> Enum.sort |> Enum.uniq
+      deps =
+        name
+        |> Hex.Registry.deps(version)
+        |> Enum.map(&registry_dep_to_def/1)
+        |> Enum.sort
+      managers =
+        app
+        |> managers()
+        |> Enum.sort
+        |> Enum.uniq
       {app, {:hex, String.to_atom(name), version, checksum, managers, deps}}
     end)
   end

--- a/lib/hex/resolver/backtracks.ex
+++ b/lib/hex/resolver/backtracks.ex
@@ -261,8 +261,14 @@ defmodule Hex.Resolver.Backtracks do
       {[x, y], _} ->
         [" (versions ", to_string(x), " and ", to_string(y), ")"]
       {_, true} when length(versions) > 2 ->
-        first = versions |> List.first |> to_string
-        last = versions |> List.last |> to_string
+        first =
+          versions
+          |> List.first
+          |> to_string
+        last =
+          versions
+          |> List.last
+          |> to_string
         [" (versions ", first, " to ", last, ")"]
       _ ->
         versions = Enum.map(versions, &to_string/1)

--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -109,7 +109,10 @@ defmodule Hex.SCM do
 
     meta = Hex.Tar.unpack(path, dest, {name, version})
     build_tools = guess_build_tools(meta)
-    managers = build_tools |> Enum.map(&String.to_atom/1) |> Enum.sort
+    managers =
+      build_tools
+      |> Enum.map(&String.to_atom/1)
+      |> Enum.sort
 
     manifest = encode_manifest(name, version, checksum, managers)
     File.write!(Path.join(dest, ".hex"), manifest)
@@ -170,7 +173,10 @@ defmodule Hex.SCM do
         (String.split(first, ",") ++ [[]])
         |> List.to_tuple
       [first, managers] ->
-        managers = managers |> String.split(",") |> Enum.map(&String.to_atom/1)
+        managers =
+          managers
+          |> String.split(",")
+          |> Enum.map(&String.to_atom/1)
         (String.split(first, ",") ++ [managers])
         |> List.to_tuple
     end

--- a/lib/hex/utils.ex
+++ b/lib/hex/utils.ex
@@ -171,5 +171,9 @@ defmodule Hex.Utils do
 
   def lock(nil), do: nil
   def lock({:hex, name, version}), do: [:hex, name, version, nil, nil, nil]
-  def lock(tuple), do: tuple |> Tuple.to_list |> Enum.take(6)
+  def lock(tuple) do
+    tuple
+    |> Tuple.to_list
+    |> Enum.take(6)
+  end
 end

--- a/lib/mix/hex/build.ex
+++ b/lib/mix/hex/build.ex
@@ -156,7 +156,11 @@ defmodule Mix.Hex.Build do
 
   defp print_metadata(metadata, key) do
     if value = metadata[key] do
-      key = key |> Atom.to_string |> String.replace("_", " ") |> String.capitalize
+      key =
+        key
+        |> Atom.to_string
+        |> String.replace("_", " ")
+        |> String.capitalize
       value = format_metadata_value(value)
       Hex.Shell.info("  #{key}: #{value}")
     end

--- a/test/mix/tasks/hex/docs_test.exs
+++ b/test/mix/tasks/hex/docs_test.exs
@@ -41,7 +41,10 @@ defmodule Mix.Tasks.Hex.DocsTest do
     bypass_mirror()
     Hex.State.put(:home, tmp_path())
 
-    docs_home = :home |> Hex.State.fetch!() |> Path.join("docs")
+    docs_home =
+      :home
+      |> Hex.State.fetch!()
+      |> Path.join("docs")
 
     in_tmp "docs", fn ->
       Mix.Tasks.Hex.Docs.run(["fetch", package, version])

--- a/test/support/hex_web.ex
+++ b/test/support/hex_web.ex
@@ -123,13 +123,17 @@ defmodule HexTest.HexWeb do
 
   defp hexweb_elixir do
     if path = System.get_env("HEXWEB_ELIXIR_PATH") do
-      path |> Path.expand |> Path.join("bin")
+      path
+      |> Path.expand
+      |> Path.join("bin")
     end
   end
 
   defp hexweb_otp do
     if path = System.get_env("HEXWEB_OTP_PATH") do
-      path |> Path.expand |> Path.join("bin")
+      path
+      |> Path.expand
+      |> Path.join("bin")
     end
   end
 


### PR DESCRIPTION
As @ericmj's [suggested](https://github.com/hexpm/hex/pull/336#pullrequestreview-14419850), we should use one pipe operator per line.

I excluded the file `lib/hex/state.ex` because I think the code is clear the way it is, wdyt?