### PR TITLE
Make mix hex.docs consider current project's version

### DIFF
--- a/lib/hex/utils.ex
+++ b/lib/hex/utils.ex
@@ -94,12 +94,12 @@ defmodule Hex.Utils do
   def hex_package_url(package, version),
     do: "https://hex.pm/packages/#{package}/#{version}"
 
-  def hexdocs_url(package),
+  def hexdocs_url(package, :latest),
     do: "https://hexdocs.pm/#{package}"
   def hexdocs_url(package, version),
     do: "https://hexdocs.pm/#{package}/#{version}"
 
-  def hexdocs_module_url(package, module),
+  def hexdocs_module_url(package, :latest, module),
     do: "https://hexdocs.pm/#{package}/#{module}.html"
   def hexdocs_module_url(package, version, module),
     do: "https://hexdocs.pm/#{package}/#{version}/#{module}.html"
@@ -175,5 +175,16 @@ defmodule Hex.Utils do
     tuple
     |> Tuple.to_list
     |> Enum.take(6)
+  end
+
+  def current_lock_and_deps() do
+    lock = Mix.Dep.Lock.read
+    deps = Mix.Dep.loaded([]) |> Enum.filter(& &1.scm == Hex.SCM)
+
+    Hex.Registry.open!(Hex.Registry.Server)
+    Hex.Mix.packages_from_lock(lock)
+    |> Hex.Registry.prefetch
+
+    {lock, deps}
   end
 end

--- a/lib/mix/tasks/hex/outdated.ex
+++ b/lib/mix/tasks/hex/outdated.ex
@@ -29,12 +29,8 @@ defmodule Mix.Tasks.Hex.Outdated do
     Hex.start
     {opts, args, _} = OptionParser.parse(args, switches: @switches)
 
-    lock = Mix.Dep.Lock.read
-    deps = Mix.Dep.loaded([]) |> Enum.filter(& &1.scm == Hex.SCM)
-
-    Hex.Registry.open!(Hex.Registry.Server)
-    Hex.Mix.packages_from_lock(lock)
-    |> Hex.Registry.prefetch
+    Mix.Project.get!
+    {lock, deps} = Hex.Utils.current_lock_and_deps()
 
     case args do
       [app] ->

--- a/lib/mix/tasks/hex/publish.ex
+++ b/lib/mix/tasks/hex/publish.ex
@@ -164,7 +164,7 @@ defmodule Mix.Tasks.Hex.Publish do
   defp docs_task(build, opts) do
     name = build.meta.name
 
-    canonical = opts[:canonical] || Hex.Utils.hexdocs_url(name)
+    canonical = opts[:canonical] || Hex.Utils.hexdocs_url(name, :latest)
     args = ["--canonical", canonical]
     try do
       Mix.Task.run("docs", args)

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -210,10 +210,10 @@ defmodule HexTest.Case do
     Bypass.expect bypass, fn conn ->
       case conn do
         %Plug.Conn{request_path: "/docs/package-1.1.2.tar.gz"} ->
-          tar_file = tmp_path("package-1.1.2.tar.gz")
-          index_file = Hex.string_to_charlist("index.html")
-          :erl_tar.create(tar_file, [{index_file, ""}], [:compressed])
-          package = File.read!(tar_file)
+          package = build_docs_package("package-1.1.2.tar.gz")
+          Plug.Conn.resp(conn, 200, package)
+        %Plug.Conn{request_path: "/docs/bar-0.1.0.tar.gz"} ->
+          package = build_docs_package("bar-1.1.2.tar.gz")
           Plug.Conn.resp(conn, 200, package)
         %Plug.Conn{request_path: "/docs/package"} ->
           Plug.Conn.resp(conn, 404, "")
@@ -221,5 +221,12 @@ defmodule HexTest.Case do
     end
 
     bypass
+  end
+
+  defp build_docs_package(file) do
+    tar_file = tmp_path(file)
+    index_file = Hex.string_to_charlist("index.html")
+    :erl_tar.create(tar_file, [{index_file, ""}], [:compressed])
+    File.read!(tar_file)
   end
 end


### PR DESCRIPTION
Instead of always going for the latest, if inside a mix project, it will first consider the version that is used by the project. For use outside of mix projects or if the package is not used by the project, it falls back to latest.