### PR TITLE
Use present continuous in @moduledoc summaries and @shortdocs

### DIFF
--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Hex.Docs do
   use Mix.Task
 
-  @shortdoc "Fetch or open documentation of a package"
+  @shortdoc "Fetches or opens documentation of a package"
 
   @moduledoc """
-  Fetch or open documentation of a package.
+  Fetches or opens documentation of a package.
 
       mix hex.docs fetch PACKAGE [VERSION]
 

--- a/lib/mix/tasks/hex.install.ex
+++ b/lib/mix/tasks/hex.install.ex
@@ -8,7 +8,7 @@ defmodule Mix.Tasks.Hex.Install do
   @shortdoc false
 
   @moduledoc """
-  Manually install specific Hex version.
+  Manually installs specific Hex version.
 
       mix hex.install VERSION
   """


### PR DESCRIPTION
To be in accordance with the format used in Elixir