### PR TITLE
More granular lock files updates

### DIFF
--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -81,7 +81,7 @@ defmodule Hex.SCM do
     end
   end
 
-  def checkout(opts) do
+  def update(opts) do
     Registry.open
 
     lock     = Hex.Utils.lock(opts[:lock]) |> ensure_lock(opts)
@@ -132,8 +132,9 @@ defmodule Hex.SCM do
     {:hex, String.to_atom(lock.name), lock.version, lock.checksum, managers, deps, lock.repo}
   end
 
-  def update(opts) do
-    checkout(opts)
+  def checkout(opts) do
+    update(opts)
+    opts[:lock]
   end
 
   @build_tools [


### PR DESCRIPTION
The goal of this PR is to avoid complete rewrites of the lock file when the lock tuples format changes.

This first commit achieves this for `mix deps.get` when the dependencies are already pulled (nothing changes in the lock file), and for `mix deps.update` (only the updated dependencies change in the lock file).

It doesn't work when doing `mix deps.get` when the `deps` folder is not present (the lock file is rewritten), a little guidance on where to look to fix this would be appreciated :)