### PR TITLE
Add hex.repo subtask to show repo config

### DIFF
--- a/lib/mix/tasks/hex.repo.ex
+++ b/lib/mix/tasks/hex.repo.ex
@@ -190,7 +190,6 @@ defmodule Mix.Tasks.Hex.Repo do
           ["URL", "Public key", "Auth key"],
           [[repo.url, show_public_key(repo.public_key), repo.auth_key]]
         )
-        repo
     end
   end
 end

--- a/lib/mix/tasks/hex.repo.ex
+++ b/lib/mix/tasks/hex.repo.ex
@@ -38,6 +38,10 @@ defmodule Mix.Tasks.Hex.Repo do
 
       mix hex.repo remove NAME
 
+  ### Show repo config
+
+      mix hex.repo show NAME
+
   ### List all repos
 
       mix hex.repo list
@@ -58,6 +62,8 @@ defmodule Mix.Tasks.Hex.Repo do
         set_auth_key(name, auth_key)
       ["remove", name] ->
         remove(name)
+      ["show", name] ->
+        show(name)
       ["list"] ->
         list()
       _ ->
@@ -169,5 +175,22 @@ defmodule Mix.Tasks.Hex.Repo do
   defp sshfp_string(key) do
     :crypto.hash(:sha256, :public_key.ssh_encode(key, :ssh2_pubkey))
     |> Base.encode64(padding: false)
+  end
+
+  defp show(name) do
+    repo =
+      read_config()
+      |> Map.get(name)
+
+    case repo do
+      nil ->
+        Mix.raise "Config does not contain repo #{name}"
+      _ ->
+        Mix.Tasks.Hex.print_table(
+          ["URL", "Public key", "Auth key"],
+          [[repo.url, show_public_key(repo.public_key), repo.auth_key]]
+        )
+        repo
+    end
   end
 end

--- a/test/mix/tasks/hex.repo_test.exs
+++ b/test/mix/tasks/hex.repo_test.exs
@@ -1,8 +1,6 @@
 defmodule Mix.Tasks.Hex.RepoTest do
   use HexTest.Case
 
-  import ExUnit.CaptureIO
-
   @public_key """
   -----BEGIN PUBLIC KEY-----
   MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApqREcFDt5vV21JVe2QNB
@@ -56,7 +54,11 @@ defmodule Mix.Tasks.Hex.RepoTest do
       Hex.State.put(:home, System.cwd!)
 
       Mix.Tasks.Hex.Repo.run(["add", "reponame", "url"])
-      capture_io(fn -> Mix.Tasks.Hex.Repo.run(["show", "reponame"]) end) =~ "https://repo.hex.pm"
+      Mix.Tasks.Hex.Repo.run(["show", "reponame"])
+      assert_received {:mix_shell, :info, [headers]}
+      assert_received {:mix_shell, :info, [config]}
+      assert headers =~ ~r{URL.*Public key.*Auth key}
+      assert config =~ "url"
     end
   end
 

--- a/test/mix/tasks/hex.repo_test.exs
+++ b/test/mix/tasks/hex.repo_test.exs
@@ -48,4 +48,23 @@ defmodule Mix.Tasks.Hex.RepoTest do
       assert ["$repos": %{"reponame" => %{url: "other_url"}}] = Hex.Config.read
     end
   end
+
+  test "show returns repo config" do
+    in_tmp fn ->
+      Hex.State.put(:home, System.cwd!)
+
+      Mix.Tasks.Hex.Repo.run(["add", "reponame", "url"])
+      assert %{url: "url"} = Mix.Tasks.Hex.Repo.run(["show", "reponame"])
+    end
+  end
+
+  test "show raises an error when called with non-existant repo name" do
+    in_tmp fn ->
+      Hex.State.put(:home, System.cwd!)
+
+      assert_raise Mix.Error, "Config does not contain repo reponame", fn ->
+        Mix.Tasks.Hex.Repo.run(["show", "reponame"])
+      end
+    end
+  end
 end

--- a/test/mix/tasks/hex.repo_test.exs
+++ b/test/mix/tasks/hex.repo_test.exs
@@ -1,6 +1,8 @@
 defmodule Mix.Tasks.Hex.RepoTest do
   use HexTest.Case
 
+  import ExUnit.CaptureIO
+
   @public_key """
   -----BEGIN PUBLIC KEY-----
   MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApqREcFDt5vV21JVe2QNB
@@ -49,12 +51,12 @@ defmodule Mix.Tasks.Hex.RepoTest do
     end
   end
 
-  test "show returns repo config" do
+  test "show prints repo config" do
     in_tmp fn ->
       Hex.State.put(:home, System.cwd!)
 
       Mix.Tasks.Hex.Repo.run(["add", "reponame", "url"])
-      assert %{url: "url"} = Mix.Tasks.Hex.Repo.run(["show", "reponame"])
+      capture_io(fn -> Mix.Tasks.Hex.Repo.run(["show", "reponame"]) end) =~ "https://repo.hex.pm"
     end
   end
 


### PR DESCRIPTION
Fixes https://github.com/hexpm/hex/issues/363.

When repo is found:
```sh
$ mix hex.repo show hexpm
URL                  Public key                                          Auth key
https://repo.hex.pm  SHA256:O1LOYhHFW4kcrblKAxROaDEzLD8bn1seWbe5tq8TRsk
```

When repo is not found:
```sh
$ mix hex.repo show somerepo
** (Mix) Config does not contain repo somerepo
```