### PR TITLE
Update docs to match tests code

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Hex bundles a list of root CA certificates used for certificate validation in HT
 
 Integration tests run against the API server [hexpm](https://github.com/hexpm/hexpm). It needs to be cloned into `../hexpm` or `HEXWEB_PATH` needs to be set and point its location. hexpm also requires postgresql with username `postgres` and password `postgres`.
 
-Run integration tests with `mix test --include integration`.
+Exclude integration tests with `mix test --exclude integration`.
 
 ## License
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@ This document simply outlines the release process:
 
 1. Ensure you are running on the oldest supported Erlang version
 
-2. Run `mix do clean --deps, clean && mix test --include integration` to ensure all tests pass from scratch and the CI is green
+2. Run `mix do clean --deps, clean && mix test` to ensure all tests pass from scratch and the CI is green
 
 3. Remove all `-dev` extension from versions (see below for all files)
 


### PR DESCRIPTION
Docs mention including integration tests but they are already included by default.

Discussion here: https://github.com/hexpm/hex/issues/379