### PR TITLE
Add hex.audit

### DIFF
--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -181,15 +181,8 @@ defmodule Hex.RemoteConverger do
 
   defp print_status(retired, name, version) do
     Hex.Shell.warn "  #{name} #{version} RETIRED!"
-    Hex.Shell.warn "    (#{retirement_reason(retired[:reason])}) #{retired[:message]}"
+    Hex.Shell.warn "    #{Hex.Utils.package_retirement_message(retired)}"
   end
-
-  defp retirement_reason(:RETIRED_OTHER), do: "other"
-  defp retirement_reason(:RETIRED_INVALID), do: "invalid"
-  defp retirement_reason(:RETIRED_SECURITY), do: "security"
-  defp retirement_reason(:RETIRED_DEPRECATED), do: "deprecated"
-  defp retirement_reason(:RETIRED_RENAMED), do: "renamed"
-  defp retirement_reason(other), do: other
 
   defp verify_resolved(resolved, lock) do
     Enum.each(resolved, fn {repo, name, app, version} ->

--- a/lib/hex/utils.ex
+++ b/lib/hex/utils.ex
@@ -164,6 +164,20 @@ defmodule Hex.Utils do
   def hexdocs_module_url(package, version, module),
     do: "https://hexdocs.pm/#{package}/#{version}/#{module}.html"
 
+  def package_retirement_reason(:RETIRED_OTHER),      do: "other"
+  def package_retirement_reason(:RETIRED_INVALID),    do: "invalid"
+  def package_retirement_reason(:RETIRED_SECURITY),   do: "security"
+  def package_retirement_reason(:RETIRED_DEPRECATED), do: "deprecated"
+  def package_retirement_reason(:RETIRED_RENAMED),    do: "renamed"
+  def package_retirement_reason(other), do: other
+
+  def package_retirement_message(%{reason: reason_code, message: message}) do
+    "(#{package_retirement_reason(reason_code)}) #{message}"
+  end
+  def package_retirement_message(%{reason: reason_code}) do
+    "(#{package_retirement_reason(reason_code)})"
+  end
+
   # From https://github.com/fishcakez/dialyze/blob/6698ae582c77940ee10b4babe4adeff22f1b7779/lib/mix/tasks/dialyze.ex#L168
   def otp_version do
     major = :erlang.system_info(:otp_release) |> List.to_string

--- a/lib/mix/tasks/hex.audit.ex
+++ b/lib/mix/tasks/hex.audit.ex
@@ -47,5 +47,4 @@ defmodule Mix.Tasks.Hex.Audit do
       nil -> []
     end
   end
-  defp retirement_status(_), do: []
 end

--- a/lib/mix/tasks/hex.audit.ex
+++ b/lib/mix/tasks/hex.audit.ex
@@ -1,0 +1,41 @@
+defmodule Mix.Tasks.Hex.Audit do
+  use Mix.Task
+  alias Hex.Registry.Server, as: Registry
+
+  def run(_) do
+    Hex.start
+
+    lock = Mix.Dep.Lock.read
+    deps = Mix.Dep.loaded([]) |> Enum.filter(& &1.scm == Hex.SCM)
+
+    Registry.open
+
+    Hex.Mix.packages_from_lock(lock)
+    |> Registry.prefetch
+
+    case retired_packages(deps, lock) do
+      [] ->
+        Hex.Shell.info "No retired packages found"
+      packages ->
+        header = ["Dependency", "Version", "Retirement reason"]
+        Mix.Tasks.Hex.print_table(header, packages)
+        Mix.raise "Found retired packages"
+    end
+  end
+
+  defp retired_packages(deps, lock) do
+    Enum.map(deps,
+      fn dep -> retirement_status(Hex.Utils.lock(lock[dep.app])) end)
+    |> Enum.reject(&Enum.empty?/1)
+  end
+
+  defp retirement_status(%{repo: repo, name: package, version: version}) do
+    retired = Registry.retired(repo, package, version)
+
+    case retired do
+      %{} -> [package, version, Hex.Utils.package_retirement_message(retired)]
+      nil -> []
+    end
+  end
+  defp retirement_status(_), do: []
+end

--- a/lib/mix/tasks/hex.audit.ex
+++ b/lib/mix/tasks/hex.audit.ex
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.Hex.Audit do
   def run(_) do
     Hex.start
 
-    lock = Mix.Dep.Lock.read
+    lock = Mix.Dep.Lock.read()
     deps = Mix.Dep.loaded([]) |> Enum.filter(& &1.scm == Hex.SCM)
 
     Registry.open
@@ -35,8 +35,7 @@ defmodule Mix.Tasks.Hex.Audit do
   end
 
   defp retired_packages(deps, lock) do
-    Enum.map(deps,
-      fn dep -> retirement_status(Hex.Utils.lock(lock[dep.app])) end)
+    Enum.map(deps, &retirement_status(Hex.Utils.lock(lock[&1.app])))
     |> Enum.reject(&Enum.empty?/1)
   end
 

--- a/lib/mix/tasks/hex.audit.ex
+++ b/lib/mix/tasks/hex.audit.ex
@@ -2,6 +2,17 @@ defmodule Mix.Tasks.Hex.Audit do
   use Mix.Task
   alias Hex.Registry.Server, as: Registry
 
+  @shortdoc "Shows retired Hex dependencies"
+
+  @moduledoc """
+  Shows all Hex dependencies that have been marked as retired.
+
+  Retired packages are no longer recommended to be used by their
+  maintainers. The task will display a message describing
+  the reason for retirement and exit with a non-zero code
+  if any retired dependencies are found.
+  """
+
   def run(_) do
     Hex.start
 

--- a/lib/mix/tasks/hex.audit.ex
+++ b/lib/mix/tasks/hex.audit.ex
@@ -30,7 +30,8 @@ defmodule Mix.Tasks.Hex.Audit do
       packages ->
         header = ["Dependency", "Version", "Retirement reason"]
         Mix.Tasks.Hex.print_table(header, packages)
-        Mix.raise "Found retired packages"
+        Hex.Shell.error "Found retired packages"
+        set_exit_code(1)
     end
   end
 
@@ -46,5 +47,11 @@ defmodule Mix.Tasks.Hex.Audit do
       %{} -> [package, version, Hex.Utils.package_retirement_message(retired)]
       nil -> []
     end
+  end
+
+  if Mix.env() == :test do
+    defp set_exit_code(_code), do: :ok
+  else
+    defp set_exit_code(code), do: System.at_exit(fn(_) -> System.halt(code) end)
   end
 end

--- a/test/mix/tasks/hex.audit_test.exs
+++ b/test/mix/tasks/hex.audit_test.exs
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Hex.AuditTest do
 
   setup_all do
     auth = Hexpm.new_user("audit_user", "audit@mail.com", "passpass", "key")
-    [auth: auth]
+    {:ok, [auth: auth]}
   end
 
   test "audit (retired package without a message)", context do

--- a/test/mix/tasks/hex.audit_test.exs
+++ b/test/mix/tasks/hex.audit_test.exs
@@ -70,6 +70,10 @@ defmodule Mix.Tasks.Hex.AuditTest do
   defp retire_test_package(version, reason, message \\ "") do
     send self(), {:mix_shell_input, :prompt, "passpass"}
     Mix.Tasks.Hex.Retire.run([@package_name, version, reason, "--message", message])
+
+    # Mix does not support the RemoteConverger.post_converge/0 callback on Elixir < 1.4,
+    # so we need to explicitly reset the registry.
+    Hex.Registry.Server.close()
   end
 
   defp assert_output_row(package, version, message) do

--- a/test/mix/tasks/hex.audit_test.exs
+++ b/test/mix/tasks/hex.audit_test.exs
@@ -22,11 +22,11 @@ defmodule Mix.Tasks.Hex.AuditTest do
     with_test_package "0.1.0", context, fn ->
       retire_test_package "0.1.0", "security"
 
-      assert_raise Mix.Error, "Found retired packages", fn ->
-        Mix.Task.run "hex.audit"
-      end
+      Mix.Task.run "hex.audit"
 
       assert_output_row @package_name, "0.1.0", "(security)"
+
+      assert_received {:mix_shell, :error, ["Found retired packages"]}
     end
   end
 
@@ -34,11 +34,11 @@ defmodule Mix.Tasks.Hex.AuditTest do
     with_test_package "0.2.0", context, fn ->
       retire_test_package "0.2.0", "invalid", "Superseded by v1.0.0"
 
-      assert_raise Mix.Error, "Found retired packages", fn ->
-        Mix.Task.run "hex.audit"
-      end
+      Mix.Task.run "hex.audit"
 
       assert_output_row @package_name, "0.2.0", "(invalid) Superseded by v1.0.0"
+
+      assert_received {:mix_shell, :error, ["Found retired packages"]}
     end
   end
 

--- a/test/mix/tasks/hex.audit_test.exs
+++ b/test/mix/tasks/hex.audit_test.exs
@@ -1,0 +1,87 @@
+defmodule Mix.Tasks.Hex.AuditTest do
+  use HexTest.Case
+  @moduletag :integration
+
+  @package :test_package
+  @package_name Atom.to_string(@package)
+
+  defmodule RetiredDeps.Mixfile do
+    def project do
+      [app: :test_app,
+       version: "0.0.1",
+       deps: [{:test_package, ">= 0.1.0"}]]
+    end
+  end
+
+  setup_all do
+    auth = Hexpm.new_user("audit_user", "audit@mail.com", "passpass", "key")
+    [auth: auth]
+  end
+
+  test "audit (retired package without a message)", context do
+    with_test_package "0.1.0", context, fn ->
+      retire_test_package "0.1.0", "security"
+
+      assert_raise Mix.Error, "Found retired packages", fn ->
+        Mix.Task.run "hex.audit"
+      end
+
+      assert_output_row @package_name, "0.1.0", "(security)"
+    end
+  end
+
+  test "audit (retired package with a custom message)", context do
+    with_test_package "0.2.0", context, fn ->
+      retire_test_package "0.2.0", "invalid", "Superseded by v1.0.0"
+
+      assert_raise Mix.Error, "Found retired packages", fn ->
+        Mix.Task.run "hex.audit"
+      end
+
+      assert_output_row @package_name, "0.2.0", "(invalid) Superseded by v1.0.0"
+    end
+  end
+
+  test "audit (no retired packages)", context do
+    with_test_package "1.0.0", context, fn ->
+      Mix.Task.run "hex.audit"
+
+      assert_received {:mix_shell, :info, ["No retired packages found"]}
+    end
+  end
+
+  def with_test_package(version, %{auth: auth}, fun) do
+    Mix.Project.push RetiredDeps.Mixfile
+
+    Hexpm.new_package(@package_name, version, [], %{}, auth)
+
+    in_tmp fn ->
+      Hex.State.put(:home, tmp_path())
+      Hex.Config.update(auth)
+      Mix.Dep.Lock.write %{@package => {:hex, @package, version}}
+
+      Mix.Task.run "deps.get"
+      flush()
+
+      fun.()
+    end
+  end
+
+  defp retire_test_package(version, reason, message \\ "") do
+    send self(), {:mix_shell_input, :prompt, "passpass"}
+    Mix.Tasks.Hex.Retire.run([@package_name, version, reason, "--message", message])
+  end
+
+  defp assert_output_row(package, version, message) do
+    whitespace_length = String.length("Retirement reason  ") - String.length(message)
+    whitespace_length = if whitespace_length < 2, do: 2, else: whitespace_length
+
+    output =
+      [package, :reset, "  ", version, :reset, "    ", message, :reset,
+        String.duplicate(" ", whitespace_length)]
+      |> IO.ANSI.format
+      |> List.to_string
+
+    assert_received {:mix_shell, :info, [^output]}
+  end
+end


### PR DESCRIPTION
This PR resolves #375.

As per the issue, the `hex.audit` task searches for packages that are locked to retired versions. If they're found, the task lists them and exits with an error code (1).

Here's sample output:
![Sample output of hex.audit](http://i.imgur.com/bB5SnLz.png)

Package retirement reasons (`RETIRED_INVALID`, `RETIRED_SECURITY`, etc.) were mapped to corresponding text messages inside a private function in Hex.RemoteConverger. I've moved it to Hex.Utils to be able to use it inside the task, but I'm not sure if that's the right place for it.

I may have missed some other important details, too, so any feedback is appreciated :smiley: 