### PR TITLE
Hide basic authentication password from the message.

### DIFF
--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -91,8 +91,9 @@ defmodule Hex.SCM do
     filename = "#{name}-#{lock.version}.tar"
     path     = cache_path(repo, filename)
     url      = Hex.Repo.get_repo(repo).url <> "/tarballs/#{filename}"
+    safe_url = Regex.replace(~r/\/\/([^:]*):[^@]+@/, url, "//\\1:******@")
 
-    Hex.Shell.info "  Checking package (#{url})"
+    Hex.Shell.info "  Checking package (#{safe_url})"
 
     case Hex.Parallel.await(:hex_fetcher, {:tarball, repo, name, lock.version}, @fetch_timeout) do
       {:ok, :cached} ->


### PR DESCRIPTION
When you use a private repo with the basic authentication, `mix deps.get` reveals the password.

```
* Updating some_thing (Hex package)
  Checking package (https://username:password@private.repo.example.com/path/some_thing-0.1.2.tar)
```

This PR replaces the password part with `******`.

```
* Updating some_thing (Hex package)
  Checking package (https://username:******@private.repo.example.com/path/some_thing-0.1.2.tar)
```