### PR TITLE
Fix persisting registry on Elixir < 1.4.0

### DIFF
--- a/lib/hex/registry/server.ex
+++ b/lib/hex/registry/server.ex
@@ -111,14 +111,9 @@ defmodule Hex.Registry.Server do
     {:noreply, state}
   end
 
-  def handle_call(:persist, from, state) do
-    state = wait_closing(state, fn ->
-      persist(state.ets, state.path)
-      GenServer.reply(from, :ok)
-      state
-    end)
-
-    {:noreply, state}
+  def handle_call(:persist, _from, state) do
+    persist(state.ets, state.path)
+    {:reply, :ok, state}
   end
 
   def handle_call({:prefetch, packages}, _from, state) do

--- a/lib/hex/registry/server.ex
+++ b/lib/hex/registry/server.ex
@@ -113,7 +113,7 @@ defmodule Hex.Registry.Server do
 
   def handle_call(:persist, from, state) do
     state = wait_closing(state, fn ->
-      persist(state.tid, state.path)
+      persist(state.ets, state.path)
       GenServer.reply(from, :ok)
       state
     end)


### PR DESCRIPTION
Without this, there's a deadlock on Elixir 1.3 where both `Hex.SCM` and `Hex.RemoteConverger` are trying to persist.