### PR TITLE
Make html_url optional

### DIFF
--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -292,7 +292,7 @@ defmodule Mix.Tasks.Hex.Publish do
 
     case Hex.API.Release.new(meta.name, tarball, auth, progress) do
       {:ok, {code, body, _}} when code in 200..299 ->
-        location = body["html_url"]
+        location = body["html_url"] || body["url"]
         Hex.Shell.info ""
         Hex.Shell.info("Package published to #{location} (#{String.downcase(checksum)})")
         :ok


### PR DESCRIPTION
In the spec [1] we've made `html_url` required, however I can see it being optional too. I imagine someone could build a hex custom repo with just APIs and no HTML stuff. If we make it optional, we still need to display some URL when package is published, so I think falling back to API url is reasonable.

This really is only an issue when we allow publishing packages to non-hexpm repos, however leaving it here as a mental note :)

[1] https://github.com/hexpm/specifications/pull/21/files#diff-2625016b50d68d922257f74801cac29cR313

cc @asgoel