### PR TITLE
Use MixProject instead of Mixfile in mix.exs files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,4 +1,4 @@
-defmodule Hex.Mixfile do
+defmodule Hex.MixProject do
   use Mix.Project
 
   @version "0.16.2-dev"

--- a/test/fixtures/ecto/mix.exs
+++ b/test/fixtures/ecto/mix.exs
@@ -1,4 +1,4 @@
-defmodule Ecto.Fixture.Mixfile do
+defmodule Ecto.Fixture.MixProject do
   use Mix.Project
 
   def project do

--- a/test/fixtures/ex_doc/mix.exs
+++ b/test/fixtures/ex_doc/mix.exs
@@ -1,4 +1,4 @@
-defmodule ExDoc.Fixture.Mixfile do
+defmodule ExDoc.Fixture.MixProject do
   use Mix.Project
 
   def project do

--- a/test/fixtures/has_hex_dep/mix.exs
+++ b/test/fixtures/has_hex_dep/mix.exs
@@ -1,4 +1,4 @@
-defmodule HasHexDep.Fixture.Mixfile do
+defmodule HasHexDep.Fixture.MixProject do
   use Mix.Project
 
   def project do

--- a/test/fixtures/override_with_path/mix.exs
+++ b/test/fixtures/override_with_path/mix.exs
@@ -1,4 +1,4 @@
-defmodule OverrideWithPath.Fixture.Mixfile do
+defmodule OverrideWithPath.Fixture.MixProject do
   use Mix.Project
 
   def project do

--- a/test/fixtures/sample/mix.exs
+++ b/test/fixtures/sample/mix.exs
@@ -1,4 +1,4 @@
-defmodule Sample.Fixture.Mixfile do
+defmodule Sample.Fixture.MixProject do
   use Mix.Project
 
   def project do

--- a/test/hex/mix_task_test.exs
+++ b/test/hex/mix_task_test.exs
@@ -162,8 +162,8 @@ defmodule Hex.MixTaskTest do
       assert_received {:mix_shell, :info, ["  ok"]}
     end
   after
-    purge [Ecto.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-           Ex_doc.NoConflict.Mixfile]
+    purge [Ecto.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+           Ex_doc.NoConflict.MixProject]
   end
 
   test "deps.get with lock" do
@@ -183,8 +183,8 @@ defmodule Hex.MixTaskTest do
       assert_received {:mix_shell, :info, ["* ex_doc 0.0.1 (Hex package)" <> _]}
     end
   after
-    purge [Ecto.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-           Ex_doc.NoConflict.Mixfile]
+    purge [Ecto.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+           Ex_doc.NoConflict.MixProject]
   end
 
   test "deps.update" do
@@ -196,8 +196,8 @@ defmodule Hex.MixTaskTest do
       # `deps.get` to set up lock
       Mix.Task.run "deps.get"
 
-      purge [Ecto.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-             Ex_doc.NoConflict.Mixfile]
+      purge [Ecto.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+             Ex_doc.NoConflict.MixProject]
 
       Mix.ProjectStack.clear_cache
       Mix.Project.pop
@@ -225,8 +225,8 @@ defmodule Hex.MixTaskTest do
       assert_received {:mix_shell, :info, ["  ok"]}
     end
   after
-    purge [Ecto.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-           Ex_doc.NoConflict.Mixfile, Sample.Fixture.Mixfile]
+    purge [Ecto.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+           Ex_doc.NoConflict.MixProject, Sample.Fixture.MixProject]
   end
 
   test "deps.update locked dependency" do
@@ -241,8 +241,8 @@ defmodule Hex.MixTaskTest do
       assert_received {:mix_shell, :info, ["\e[32m  ecto 0.2.1\e[0m"]}
     end
   after
-    purge [Ecto.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-           Ex_doc.NoConflict.Mixfile, Sample.Fixture.Mixfile]
+    purge [Ecto.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+           Ex_doc.NoConflict.MixProject, Sample.Fixture.MixProject]
   end
 
   test "deps.get with override" do
@@ -268,8 +268,8 @@ defmodule Hex.MixTaskTest do
       assert_received {:mix_shell, :info, ["  ok"]}
     end
   after
-    purge [Ecto.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-           Ex_doc.NoConflict.Mixfile]
+    purge [Ecto.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+           Ex_doc.NoConflict.MixProject]
   end
 
   test "deps.get with non hex dependency that has hex dependency" do
@@ -284,8 +284,8 @@ defmodule Hex.MixTaskTest do
       assert_received {:mix_shell, :info, ["* Getting ex_doc (Hex package)"]}
     end
   after
-    purge [Ecto.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-           Ex_doc.NoConflict.Mixfile, HasHexDep.Fixture.Mixfile]
+    purge [Ecto.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+           Ex_doc.NoConflict.MixProject, HasHexDep.Fixture.MixProject]
   end
 
   test "converged hex dependency considers all requirements" do
@@ -300,7 +300,7 @@ defmodule Hex.MixTaskTest do
       assert %{postgrex: {:hex, :postgrex, "0.2.0", _, _, _, "hexpm"}} = Mix.Dep.Lock.read
     end
   after
-    purge [Ecto.Fixture.Mixfile, Postgrex.NoConflict.Mixfile, Ex_doc.NoConflict.Mixfile]
+    purge [Ecto.Fixture.MixProject, Postgrex.NoConflict.MixProject, Ex_doc.NoConflict.MixProject]
   end
 
   test "do not fetch git children of hex dependencies" do
@@ -318,8 +318,8 @@ defmodule Hex.MixTaskTest do
       refute_received {:mix_shell, :info, ["* sample" <> _]}
     end
   after
-    purge [Ecto.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-           Ex_doc.NoConflict.Mixfile]
+    purge [Ecto.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+           Ex_doc.NoConflict.MixProject]
   end
 
   test "override hex dependency with path dependency" do
@@ -338,7 +338,7 @@ defmodule Hex.MixTaskTest do
       assert %{postgrex: {:hex, :postgrex, "0.2.1", _, _, _, "hexpm"}} = Mix.Dep.Lock.read
     end
   after
-    purge [Postgrex.NoConflict.Mixfile, ExDoc.Fixture.Mixfile]
+    purge [Postgrex.NoConflict.MixProject, ExDoc.Fixture.MixProject]
   end
 
   test "override hex dependency two levels down with path dependency" do
@@ -359,8 +359,8 @@ defmodule Hex.MixTaskTest do
                postgrex: {:hex, :postgrex, "0.2.1", _, _, _, "hexpm"}} = Mix.Dep.Lock.read
     end
   after
-    purge [Phoenix.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-           ExDoc.Fixture.Mixfile]
+    purge [Phoenix.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+           ExDoc.Fixture.MixProject]
   end
 
   test "override hex dependency with path dependency from dependency" do
@@ -381,8 +381,8 @@ defmodule Hex.MixTaskTest do
       assert %{postgrex: {:hex, :postgrex, "0.2.1", _, _, _, "hexpm"}} = Mix.Dep.Lock.read
     end
   after
-    purge [OverrideWithPath.Fixture.Mixfile, ExDoc.Fixture.Mixfile,
-           Postgrex.NoConflict.Mixfile]
+    purge [OverrideWithPath.Fixture.MixProject, ExDoc.Fixture.MixProject,
+           Postgrex.NoConflict.MixProject]
   end
 
   test "optional dependency" do
@@ -402,7 +402,7 @@ defmodule Hex.MixTaskTest do
       refute_received {:mix_shell, :info, ["* ex_doc (Hex package)" <> _]}
     end
   after
-    purge [Only_doc.NoConflict.Mixfile, Ex_doc.NoConflict.Mixfile]
+    purge [Only_doc.NoConflict.MixProject, Ex_doc.NoConflict.MixProject]
   end
 
   test "with optional dependency" do
@@ -423,7 +423,7 @@ defmodule Hex.MixTaskTest do
       assert_received {:mix_shell, :info, ["  locked at 0.0.1 (ex_doc)" <> _]}
     end
   after
-    purge [Only_doc.NoConflict.Mixfile, Ex_doc.NoConflict.Mixfile]
+    purge [Only_doc.NoConflict.MixProject, Ex_doc.NoConflict.MixProject]
   end
 
   test "with package name" do
@@ -442,7 +442,7 @@ defmodule Hex.MixTaskTest do
       assert_received {:mix_shell, :info, ["  locked at 0.1.0 (package_name)" <> _]}
     end
   after
-    purge [Package_name.NoConflict.Mixfile]
+    purge [Package_name.NoConflict.MixProject]
   end
 
   test "with depend name" do
@@ -464,7 +464,7 @@ defmodule Hex.MixTaskTest do
       assert_received {:mix_shell, :info, ["  locked at 0.1.0 (package_name)" <> _]}
     end
   after
-    purge [Depend_name.NoConflict.Mixfile, Package_name.NoConflict.Mixfile]
+    purge [Depend_name.NoConflict.MixProject, Package_name.NoConflict.MixProject]
   end
 
   test "deps.get with incorrect version" do
@@ -530,8 +530,8 @@ defmodule Hex.MixTaskTest do
       assert old_lock == Mix.Dep.Lock.read()
     end
   after
-    purge [Ecto.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-           Ex_doc.NoConflict.Mixfile]
+    purge [Ecto.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+           Ex_doc.NoConflict.MixProject]
   end
 
   test "deps.get does not rewrite the lock file when deps are not present" do
@@ -548,8 +548,8 @@ defmodule Hex.MixTaskTest do
       assert old_lock == Mix.Dep.Lock.read()
     end
   after
-    purge [Ecto.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-           Ex_doc.NoConflict.Mixfile]
+    purge [Ecto.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+           Ex_doc.NoConflict.MixProject]
   end
 
   test "deps.update only rewrites given dependencies" do
@@ -569,7 +569,7 @@ defmodule Hex.MixTaskTest do
       assert tuple_size(new_lock.ex_doc) > 4
     end
   after
-    purge [Ecto.NoConflict.Mixfile, Postgrex.NoConflict.Mixfile,
-           Ex_doc.NoConflict.Mixfile]
+    purge [Ecto.NoConflict.MixProject, Postgrex.NoConflict.MixProject,
+           Ex_doc.NoConflict.MixProject]
   end
 end

--- a/test/mix/tasks/hex.audit_test.exs
+++ b/test/mix/tasks/hex.audit_test.exs
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Hex.AuditTest do
   @package :test_package
   @package_name Atom.to_string(@package)
 
-  defmodule RetiredDeps.Mixfile do
+  defmodule RetiredDeps.MixProject do
     def project do
       [app: :test_app,
        version: "0.0.1",
@@ -46,7 +46,7 @@ defmodule Mix.Tasks.Hex.AuditTest do
   end
 
   def with_test_package(version, %{auth: auth}, fun) do
-    Mix.Project.push RetiredDeps.Mixfile
+    Mix.Project.push RetiredDeps.MixProject
 
     Hexpm.new_package(@package_name, version, [], %{}, auth)
 

--- a/test/mix/tasks/hex.build_test.exs
+++ b/test/mix/tasks/hex.build_test.exs
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Hex.BuildTest do
   end
 
   test "create" do
-    Mix.Project.push ReleaseSimple.Mixfile
+    Mix.Project.push ReleaseSimple.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -22,11 +22,11 @@ defmodule Mix.Tasks.Hex.BuildTest do
       assert package_created?("release_a-0.0.1")
     end
   after
-    purge [ReleaseSimple.Mixfile]
+    purge [ReleaseSimple.MixProject]
   end
 
   test "create with package name" do
-    Mix.Project.push ReleaseName.Mixfile
+    Mix.Project.push ReleaseName.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -35,11 +35,11 @@ defmodule Mix.Tasks.Hex.BuildTest do
       assert package_created?("released_name-0.0.1")
     end
   after
-    purge [ReleaseName.Mixfile]
+    purge [ReleaseName.MixProject]
   end
 
   test "create with files" do
-    Mix.Project.push ReleaseFiles.Mixfile
+    Mix.Project.push ReleaseFiles.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -56,11 +56,11 @@ defmodule Mix.Tasks.Hex.BuildTest do
       assert File.stat!("unzip/executable.sh").mode == 0o100755
     end
   after
-    purge [ReleaseFiles.Mixfile]
+    purge [ReleaseFiles.MixProject]
   end
 
   test "create with deps" do
-    Mix.Project.push ReleaseDeps.Mixfile
+    Mix.Project.push ReleaseDeps.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -78,12 +78,12 @@ defmodule Mix.Tasks.Hex.BuildTest do
       end
     end
   after
-    purge [ReleaseDeps.Mixfile]
+    purge [ReleaseDeps.MixProject]
   end
 
   # TODO: convert to integration test
   test "create with custom repo deps" do
-    Mix.Project.push ReleaseCustomRepoDeps.Mixfile
+    Mix.Project.push ReleaseCustomRepoDeps.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -95,11 +95,11 @@ defmodule Mix.Tasks.Hex.BuildTest do
       ] = build.meta.requirements
     end
   after
-    purge [ReleaseCustomRepoDeps.Mixfile]
+    purge [ReleaseCustomRepoDeps.MixProject]
   end
 
   test "create with meta" do
-    Mix.Project.push ReleaseMeta.Mixfile
+    Mix.Project.push ReleaseMeta.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -117,11 +117,11 @@ defmodule Mix.Tasks.Hex.BuildTest do
       end
     end
   after
-    purge [ReleaseMeta.Mixfile]
+    purge [ReleaseMeta.MixProject]
   end
 
   test "reject package if description is missing" do
-    Mix.Project.push ReleaseNoDescription.Mixfile
+    Mix.Project.push ReleaseNoDescription.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -138,11 +138,11 @@ defmodule Mix.Tasks.Hex.BuildTest do
       end
     end
   after
-    purge [ReleaseNoDescription.Mixfile]
+    purge [ReleaseNoDescription.MixProject]
   end
 
   test "error if description is too long" do
-    Mix.Project.push ReleaseTooLongDescription.Mixfile
+    Mix.Project.push ReleaseTooLongDescription.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -156,11 +156,11 @@ defmodule Mix.Tasks.Hex.BuildTest do
       end
     end
   after
-    purge [ReleaseTooLongDescription.Mixfile]
+    purge [ReleaseTooLongDescription.MixProject]
   end
 
   test "error if package has unstable dependencies" do
-    Mix.Project.push ReleasePreDeps.Mixfile
+    Mix.Project.push ReleasePreDeps.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -172,6 +172,6 @@ defmodule Mix.Tasks.Hex.BuildTest do
       end
     end
   after
-    purge [ReleasePreDeps.Mixfile]
+    purge [ReleasePreDeps.MixProject]
   end
 end

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
   use HexTest.Case
   @moduletag :integration
 
-  defmodule OutdatedDeps.Mixfile do
+  defmodule OutdatedDeps.MixProject do
     def project do
       [app: :outdated_app,
        version: "0.0.2",
@@ -11,7 +11,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     end
   end
 
-  defmodule OutdatedBetaDeps.Mixfile do
+  defmodule OutdatedBetaDeps.MixProject do
     def project do
       [app: :outdated_app,
        version: "0.0.1",
@@ -19,7 +19,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     end
   end
 
-  defmodule OutdatedApp.Mixfile do
+  defmodule OutdatedApp.MixProject do
     def project do
       [app: :outdated_app,
        version: "0.0.1",
@@ -29,7 +29,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     end
   end
 
-  defmodule NotOutdatedApp.Mixfile do
+  defmodule NotOutdatedApp.MixProject do
     def project do
       [app: :outdated_app,
        version: "0.0.1",
@@ -37,7 +37,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     end
   end
 
-  defmodule WithoutHexDeps.Mixfile do
+  defmodule WithoutHexDeps.MixProject do
     def project do
       [app: :outdated_app,
        version: "0.0.1",
@@ -45,7 +45,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     end
   end
 
-  defmodule OutdatedMultiDeps.Mixfile do
+  defmodule OutdatedMultiDeps.MixProject do
     def project do
       [app: :outdated_app,
        version: "0.0.2",
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
   end
 
   test "outdated" do
-    Mix.Project.push OutdatedDeps.Mixfile
+    Mix.Project.push OutdatedDeps.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -76,7 +76,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
   end
 
   test "outdated --all" do
-    Mix.Project.push OutdatedDeps.Mixfile
+    Mix.Project.push OutdatedDeps.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -106,7 +106,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
   end
 
   test "outdated --all with multiple dependent packages" do
-    Mix.Project.push OutdatedMultiDeps.Mixfile
+    Mix.Project.push OutdatedMultiDeps.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -130,7 +130,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
   end
 
   test "outdated --pre" do
-    Mix.Project.push OutdatedBetaDeps.Mixfile
+    Mix.Project.push OutdatedBetaDeps.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -157,7 +157,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
   end
 
   test "outdated app" do
-    Mix.Project.push OutdatedApp.Mixfile
+    Mix.Project.push OutdatedApp.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -190,7 +190,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
   end
 
   test "not outdated app" do
-    Mix.Project.push NotOutdatedApp.Mixfile
+    Mix.Project.push NotOutdatedApp.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -208,7 +208,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
   end
 
   test "without hex deps" do
-    Mix.Project.push WithoutHexDeps.Mixfile
+    Mix.Project.push WithoutHexDeps.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -223,7 +223,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
   test "umbrella projects" do
     in_tmp "umbrella", fn ->
       File.write! "mix.exs", """
-      defmodule Umbrella.Mixfile do
+      defmodule Umbrella.MixProject do
         use Mix.Project
 
         def project do
@@ -237,7 +237,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
       Mix.Project.in_project :umbrella, ".", fn _ ->
         File.mkdir_p!("apps/bacon")
         File.write! "apps/bacon/mix.exs", """
-        defmodule Bacon.Mixfile do
+        defmodule Bacon.MixProject do
           use Mix.Project
 
           def project do

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -9,31 +9,31 @@ defmodule Mix.Tasks.Hex.PublishTest do
   use HexTest.Case
   @moduletag :integration
 
-  defmodule DocsSimple.Mixfile do
+  defmodule DocsSimple.MixProject do
     def project do
       [app: :ex_doc, version: "0.1.0"]
     end
   end
 
-  defmodule DocsError.Mixfile do
+  defmodule DocsError.MixProject do
     def project do
       [app: :ex_doc, version: "0.1.1"]
     end
   end
 
   test "ensure user exists" do
-    Mix.Project.push ReleaseSimple.Mixfile
+    Mix.Project.push ReleaseSimple.MixProject
     Hex.State.put(:home, tmp_path("does_not_exist"))
 
     assert_raise Mix.Error, "No authorized user found. Run 'mix hex.user auth'", fn ->
       Mix.Tasks.Hex.Publish.run([])
     end
   after
-    purge [ReleaseSimple.Mixfile]
+    purge [ReleaseSimple.MixProject]
   end
 
   test "create and revert a package" do
-    Mix.Project.push ReleaseSimple.Mixfile
+    Mix.Project.push ReleaseSimple.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -54,11 +54,11 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert {:ok, {404, _, _}} = Hex.API.Release.get("hexpm", "release_a", "0.0.1")
     end
   after
-    purge [ReleaseSimple.Mixfile]
+    purge [ReleaseSimple.MixProject]
   end
 
   test "create and revert docs" do
-    Mix.Project.push DocsSimple.Mixfile
+    Mix.Project.push DocsSimple.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -75,7 +75,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
   end
 
   test "docs when package is not published yet" do
-    Mix.Project.push DocsError.Mixfile
+    Mix.Project.push DocsError.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -92,7 +92,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
   end
 
   test "package create with package name" do
-    Mix.Project.push ReleaseName.Mixfile
+    Mix.Project.push ReleaseName.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -116,11 +116,11 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert body["meta"]["app"] == "release_d"
     end
   after
-    purge [ReleaseName.Mixfile]
+    purge [ReleaseName.MixProject]
   end
 
   test "create with key" do
-    Mix.Project.push ReleaseSimple.Mixfile
+    Mix.Project.push ReleaseSimple.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -132,11 +132,11 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert {:ok, {200, _, _}} = Hex.API.Release.get("hexpm", "release_a", "0.0.1")
     end
   after
-    purge [ReleaseSimple.Mixfile]
+    purge [ReleaseSimple.MixProject]
   end
 
   test "create with deps" do
-    Mix.Project.push ReleaseDeps.Mixfile
+    Mix.Project.push ReleaseDeps.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -157,11 +157,11 @@ defmodule Mix.Tasks.Hex.PublishTest do
       end
     end
   after
-    purge [ReleaseDeps.Mixfile]
+    purge [ReleaseDeps.MixProject]
   end
 
   test "raise for missing metadata" do
-    Mix.Project.push ReleaseMeta.Mixfile
+    Mix.Project.push ReleaseMeta.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -184,11 +184,11 @@ defmodule Mix.Tasks.Hex.PublishTest do
       end
     end
   after
-    purge [ReleaseMeta.Mixfile]
+    purge [ReleaseMeta.MixProject]
   end
 
   test "create with metadata" do
-    Mix.Project.push ReleaseMeta.Mixfile
+    Mix.Project.push ReleaseMeta.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -210,11 +210,11 @@ defmodule Mix.Tasks.Hex.PublishTest do
       refute_received {:mix_shell, :error, ["Missing metadata fields" <> _]}
     end
   after
-    purge [ReleaseMeta.Mixfile]
+    purge [ReleaseMeta.MixProject]
   end
 
   test "create package with :organization config" do
-    Mix.Project.push ReleaseRepo.Mixfile
+    Mix.Project.push ReleaseRepo.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -227,11 +227,11 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert_received {:mix_shell, :info, ["Package published to myrepo html_url" <> _]}
     end
   after
-    purge [ReleaseRepo.Mixfile]
+    purge [ReleaseRepo.MixProject]
   end
 
   test "create package with :organization config with no organization in user config" do
-    Mix.Project.push ReleaseRepo.Mixfile
+    Mix.Project.push ReleaseRepo.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -242,11 +242,11 @@ defmodule Mix.Tasks.Hex.PublishTest do
       Mix.Tasks.Hex.Publish.run(["package", "--no-progress"])
     end
   after
-    purge [ReleaseRepo.Mixfile]
+    purge [ReleaseRepo.MixProject]
   end
 
   test "create package with --organization flag overrides :organization config" do
-    Mix.Project.push ReleaseRepo.Mixfile
+    Mix.Project.push ReleaseRepo.MixProject
 
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
@@ -259,6 +259,6 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert_received {:mix_shell, :info, ["Package published to myrepo html_url" <> _]}
     end
   after
-    purge [ReleaseRepo.Mixfile]
+    purge [ReleaseRepo.MixProject]
   end
 end

--- a/test/support/hexpm.ex
+++ b/test/support/hexpm.ex
@@ -28,8 +28,8 @@ defmodule HexTest.Hexpm do
     }
   end
 
-  @mixfile_template """
-  defmodule ~s.NoConflict.Mixfile do
+  @mix_exs_template """
+  defmodule ~s.NoConflict.MixProject do
     use Mix.Project
 
     def project do
@@ -227,9 +227,9 @@ defmodule HexTest.Hexpm do
 
     deps = inspect(deps, pretty: true)
     module = String.capitalize(name)
-    mixfile = :io_lib.format(@mixfile_template, [module, name, version, deps])
+    mix_exs = :io_lib.format(@mix_exs_template, [module, name, version, deps])
 
-    files = [{"mix.exs", List.to_string(mixfile)}]
+    files = [{"mix.exs", List.to_string(mix_exs)}]
     {tar, _checksum} = Hex.Tar.create(meta, files)
 
     {:ok, {result, %{"version" => ^version}, _}} = Hex.API.Release.new("hexpm", name, tar, auth)

--- a/test/support/release_samples.ex
+++ b/test/support/release_samples.ex
@@ -1,4 +1,4 @@
-defmodule ReleaseSimple.Mixfile do
+defmodule ReleaseSimple.MixProject do
   def project do
     [app: :release_a,
      description: "baz",
@@ -9,7 +9,7 @@ defmodule ReleaseSimple.Mixfile do
   end
 end
 
-defmodule ReleaseDeps.Mixfile do
+defmodule ReleaseDeps.MixProject do
   def project do
     [app: :release_b, description: "bar", version: "0.0.2",
      deps: [{:ex_doc, "0.0.1"}],
@@ -17,7 +17,7 @@ defmodule ReleaseDeps.Mixfile do
   end
 end
 
-defmodule ReleaseCustomRepoDeps.Mixfile do
+defmodule ReleaseCustomRepoDeps.MixProject do
   def project do
     [
       app: :release_b_custom, description: "bar", version: "0.0.2",
@@ -30,7 +30,7 @@ defmodule ReleaseCustomRepoDeps.Mixfile do
   end
 end
 
-defmodule ReleaseMeta.Mixfile do
+defmodule ReleaseMeta.MixProject do
   def project do
     [app: :release_c, version: "0.0.3",
      description: "foo",
@@ -42,7 +42,7 @@ defmodule ReleaseMeta.Mixfile do
   end
 end
 
-defmodule ReleaseName.Mixfile do
+defmodule ReleaseName.MixProject do
   def project do
     [app: :release_d, description: "Whatever", version: "0.0.1",
      package: [name: :released_name,
@@ -52,20 +52,20 @@ defmodule ReleaseName.Mixfile do
   end
 end
 
-defmodule ReleaseNoDescription.Mixfile do
+defmodule ReleaseNoDescription.MixProject do
   def project do
     [app: :release_e, version: "0.0.1"]
   end
 end
 
-defmodule ReleaseTooLongDescription.Mixfile do
+defmodule ReleaseTooLongDescription.MixProject do
   def project do
     [app: :release_f, description: String.duplicate("w", 301),
      version: "0.0.1"]
   end
 end
 
-defmodule ReleasePreDeps.Mixfile do
+defmodule ReleasePreDeps.MixProject do
   def project do
     [app: :release_g, description: "bar", version: "0.0.1",
      deps: [{:ex_doc, "~> 0.0.1-pre"}],
@@ -76,7 +76,7 @@ defmodule ReleasePreDeps.Mixfile do
   end
 end
 
-defmodule ReleaseFiles.Mixfile do
+defmodule ReleaseFiles.MixProject do
   def project do
     [app: :release_h,
      version: "0.0.1",
@@ -89,7 +89,7 @@ defmodule ReleaseFiles.Mixfile do
   end
 end
 
-defmodule ReleaseRepo.Mixfile do
+defmodule ReleaseRepo.MixProject do
   def project do
     [app: :ecto,
      description: "baz",


### PR DESCRIPTION
Mix renames the module in `mix.exs` file from `Mixfile` to `MixProject`.

This pull request updates the name.

Reference: https://github.com/elixir-lang/elixir/commit/c6a0edcd32359eca284ff0166d19a6dc979ee954