### PR TITLE
Handle package documentation mirror response

### DIFF
--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -182,16 +182,19 @@ defmodule Mix.Tasks.Hex.Docs do
   end
 
   defp retrieve_compressed_docs(organization, package, version, target) do
-    File.mkdir_p!(Path.dirname(target))
-
     unless File.exists?(target) do
       request_docs_from_mirror(organization, package, version, target)
     end
   end
 
   defp request_docs_from_mirror(organization, package, version, target) do
-    {:ok, {200, body, _}} = Hex.Repo.get_docs(organization, package, version)
-    File.write!(target, body)
+    case Hex.Repo.get_docs(organization, package, version) do
+      {:ok, {200, body, _}} ->
+        File.mkdir_p!(Path.dirname(target))
+        File.write!(target, body)
+      _ ->
+        Mix.raise "No package with name #{package} or version #{version}"
+    end
   end
 
   defp extract_doc_contents(target) do


### PR DESCRIPTION
When executes `hex.docs fetch` Mix task with a package version that does not exist, raises a `MatchError` exception.

Example:

```zsh
% mix hex.docs fetch elixir 1.3.5
** (MatchError) no match of right hand side value: {:ok, {403, "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>B94CAE1A61603FE2</RequestId><HostId>80EI0mEDxzmDBdL3eRU5wbVenHgXsiJ0/KWO7kpk45Eeeg7dCa2sB/5T4XEyrq1pF4977wciXGY=</HostId></Error>", %{'accept-ranges' => 'bytes', 'connection' => 'keep-alive', 'content-length' => '243', 'content-type' => 'application/xml', 'date' => 'Sat, 26 Aug 2017 06:29:29 GMT', 'server' => 'AmazonS3', 'via' => '1.1 varnish', 'x-amz-id-2' => '80EI0mEDxzmDBdL3eRU5wbVenHgXsiJ0/KWO7kpk45Eeeg7dCa2sB/5T4XEyrq1pF4977wciXGY=', 'x-amz-request-id' => 'B94CAE1A61603FE2', 'x-cache' => 'MISS', 'x-cache-hits' => '0', 'x-served-by' => 'cache-gig17027-GIG', 'x-timer' => 'S1503728969.714953,VS0,VE535'}}}
    (hex) lib/mix/tasks/hex.docs.ex:193: Mix.Tasks.Hex.Docs.request_docs_from_mirror/4
    (hex) lib/mix/tasks/hex.docs.ex:65: Mix.Tasks.Hex.Docs.fetch_docs/2
    (mix) lib/mix/task.ex:301: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:75: Mix.CLI.run_task/2
    (elixir) lib/code.ex:376: Code.require_file/2
```

This pull request fix this issue and handle mirror response.