### PR TITLE
Escape owner email address when adding or deleting an owner.

### DIFF
--- a/lib/hex/api/package.ex
+++ b/lib/hex/api/package.ex
@@ -12,12 +12,12 @@ defmodule Hex.API.Package do
   defmodule Owner do
     def add(repo, package, owner, auth) do
       owner = URI.encode_www_form(owner)
-      API.erlang_put_request(repo, "packages/#{package}/owners/#{owner}", %{}, auth)
+      API.erlang_put_request(repo, "packages/#{package}/owners/#{URI.encode(owner)}", %{}, auth)
     end
 
     def delete(repo, package, owner, auth) do
       owner = URI.encode_www_form(owner)
-      API.request(:delete, repo, "packages/#{package}/owners/#{owner}", auth)
+      API.request(:delete, repo, "packages/#{package}/owners/#{URI.encode(owner)}", auth)
     end
 
     def get(repo, package, auth) do


### PR DESCRIPTION
An email address can contain invalid path uri components such as "+". If you
try to add or remove an email address with a "+" in it, you will get
back a 404.