### PR TITLE
Add "integration" tag to hex.organization_test.exs

### DIFF
--- a/test/mix/tasks/hex.organization_test.exs
+++ b/test/mix/tasks/hex.organization_test.exs
@@ -1,5 +1,6 @@
 defmodule Mix.Tasks.Hex.OrganizationTest do
   use HexTest.Case
+  @moduletag :integration
 
   test "auth" do
     in_tmp fn ->


### PR DESCRIPTION
It appears this test file may be missing the "integration" tag. It fails when run without the local server up.