### PR TITLE
Add function so connection error does not result in FunctionClauseError

### DIFF
--- a/lib/hex/registry/server.ex
+++ b/lib/hex/registry/server.ex
@@ -363,6 +363,7 @@ defmodule Hex.Registry.Server do
   end
 
   defp missing_status?({:ok, {status, _, _}}), do: status in [403, 404]
+  defp missing_status?(_), do: false
 
   defp maybe_wait(package, from, state, fun) do
     cond do


### PR DESCRIPTION
I noticed today that when I run `mix deps.get` when my wifi is down I get all of this:

```
± > mix deps.get                                                                                                                -I-
Failed to fetch record for 'hexpm/connection' from registry (using cache)
** (exit) exited in: GenServer.call(Hex.Registry.Server, {:versions, "hexpm", "connection"}, 60000)
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in Hex.Registry.Server.missing_status?/1
            (hex) lib/hex/registry/server.ex:365: Hex.Registry.Server.missing_status?({:error, {:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}})
            (hex) lib/hex/registry/server.ex:355: Hex.Registry.Server.print_error/4
            (hex) lib/hex/registry/server.ex:343: Hex.Registry.Server.write_result/4
            (hex) lib/hex/registry/server.ex:196: Hex.Registry.Server.handle_info/2
            (stdlib) gen_server.erl:616: :gen_server.try_dispatch/4
            (stdlib) gen_server.erl:686: :gen_server.handle_msg/6
            (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
    (elixir) lib/gen_server.ex:774: GenServer.call/3
    (hex) lib/hex/remote_converger.ex:261: Hex.RemoteConverger.check_dep/3
    (elixir) lib/enum.ex:681: anonymous fn/3 in Enum.each/2
    (stdlib) lists.erl:1263: :lists.foldl/3
    (elixir) lib/enum.ex:1843: Enum.each/2
    (hex) lib/hex/remote_converger.ex:39: Hex.RemoteConverger.converge/2
    (mix) lib/mix/dep/converger.ex:94: Mix.Dep.Converger.all/4
    (mix) lib/mix/dep/converger.ex:50: Mix.Dep.Converger.converge/4

18:26:41.129 [error] GenServer Hex.Registry.Server terminating
** (FunctionClauseError) no function clause matching in Hex.Registry.Server.missing_status?/1
    (hex) lib/hex/registry/server.ex:365: Hex.Registry.Server.missing_status?({:error, {:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}})
    (hex) lib/hex/registry/server.ex:355: Hex.Registry.Server.print_error/4
    (hex) lib/hex/registry/server.ex:343: Hex.Registry.Server.write_result/4
    (hex) lib/hex/registry/server.ex:196: Hex.Registry.Server.handle_info/2
    (stdlib) gen_server.erl:616: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:686: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:247: :proc_lib.init_p_do_apply/3
Last message: {:get_package, "hexpm", "connection", {:error, {:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}}}
State: %{closing_fun: nil, ets: #Reference<0.1097890196.3071934467.253465>, fetched: #MapSet<[]>, offline?: false, path: "/Users/parker/.hex/cache.ets", pending: #MapSet<[{"hexpm", "connection"}, {"hexpm", "db_connection"}, {"hexpm", "decimal"}, {"hexpm", "earmark"}, {"hexpm", "ecto"}, {"hexpm", "ex_doc"}, {"hexpm", "poolboy"}, {"hexpm", "postgrex"}]>, waiting: %{{"hexpm", "connection"} => [{{#PID<0.73.0>, #Reference<0.1097890196.3071803393.253493>}, #Function<3.75490635/0 in Hex.Registry.Server.handle_call/3>}]}}
```
The `FunctionClauseError` seems a bit misleading. Adding the missing function head gives a bit better set of messages:

```
± > mix deps.get                                                                                                                -N-
Failed to fetch record for 'hexpm/decimal' from registry (using cache)
{:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
Failed to fetch record for 'hexpm/ex_doc' from registry (using cache)
{:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
Failed to fetch record for 'hexpm/connection' from registry (using cache)
{:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
Failed to fetch record for 'hexpm/db_connection' from registry (using cache)
{:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
Failed to fetch record for 'hexpm/poolboy' from registry (using cache)
{:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
Failed to fetch record for 'hexpm/postgrex' from registry (using cache)
{:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
Failed to fetch record for 'hexpm/earmark' from registry (using cache)
{:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
Failed to fetch record for 'hexpm/ecto' from registry (using cache)
{:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
Resolving Hex dependencies...
Failed to fetch record for 'hexpm/sbroker' from registry (using cache)
{:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
Failed to fetch record for 'hexpm/mariaex' from registry (using cache)
{:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
Failed to fetch record for 'hexpm/poison' from registry (using cache)
{:failed_connect, [{:to_address, {'repo.hex.pm', 443}}, {:inet, [:inet], :nxdomain}]}
Dependency resolution completed:
  connection 1.0.4
  db_connection 1.1.2
  decimal 1.4.0
  earmark 1.2.3
  ecto 2.2.2
  ex_doc 0.16.4
  poolboy 1.5.1
  postgrex 0.13.3
```

However, it seems that perhaps this could be made even more clear as the last part of that looks like success. I'd be happy to work on another PR for that.

Thanks! Hex Rox!