### PR TITLE
Add a column to hex.search output showing stable version

### DIFF
--- a/lib/mix/tasks/hex.search.ex
+++ b/lib/mix/tasks/hex.search.ex
@@ -54,8 +54,11 @@ defmodule Mix.Tasks.Hex.Search do
   end
 
   defp latest_stable(releases) do
-    %{"version" => version} = releases
-    |> Enum.find(%{"version" => nil}, &is_stable/1)
+    %{"version" => version} = Enum.find(
+      releases,
+      %{"version" => nil},
+      &is_stable/1
+    )
 
     version
   end

--- a/lib/mix/tasks/hex.search.ex
+++ b/lib/mix/tasks/hex.search.ex
@@ -64,10 +64,8 @@ defmodule Mix.Tasks.Hex.Search do
   end
 
   defp is_stable(%{"version" => version}) do
-    case Version.parse(version) do
-      {:ok, parsed_version} -> parsed_version.pre == []
-      _ -> false
-    end
+    parsed_version = Hex.Version.parse!(version)
+    parsed_version.pre == []
   end
 
   defp trim_heredoc(string) do

--- a/lib/mix/tasks/hex.search.ex
+++ b/lib/mix/tasks/hex.search.ex
@@ -60,14 +60,16 @@ defmodule Mix.Tasks.Hex.Search do
 
   defp latest_stable(releases) do
     %{"version" => version} = releases
-    |> Enum.find(fn %{"version" => version} ->
-      case Version.parse(version) do
-        {:ok, parsed_version} -> parsed_version.pre == []
-        _ -> false
-      end
-    end)
+    |> Enum.find(%{"version" => nil}, &is_stable/1)
 
     version
+  end
+
+  defp is_stable(%{"version" => version}) do
+    case Version.parse(version) do
+      {:ok, parsed_version} -> parsed_version.pre == []
+      _ -> false
+    end
   end
 
   defp trim_heredoc(string) do

--- a/lib/mix/tasks/hex.search.ex
+++ b/lib/mix/tasks/hex.search.ex
@@ -42,20 +42,15 @@ defmodule Mix.Tasks.Hex.Search do
         [
           package["name"],
           Hex.Utils.truncate(package["meta"]["description"] |> trim_heredoc),
-          latest(package["releases"]),
           latest_stable(package["releases"]),
           package["html_url"] || package["url"]
         ]
       end)
 
     Mix.Tasks.Hex.print_table(
-      ["Package", "Description", "Latest", "Stable", "URL"],
+      ["Package", "Description", "Version", "URL"],
       values
     )
-  end
-
-  defp latest([%{"version" => version} | _]) do
-    version
   end
 
   defp latest_stable(releases) do


### PR DESCRIPTION
Fixes https://github.com/hexpm/hexpm/issues/571

New output (notice that I changed the `Version` column to `Latest` to avoid confusion

```
$ mix run -e 'Mix.Tasks.Hex.Search.run(["postgrex"])'
Package       Description                                            Latest      Stable  URL
postgrex      description                                            1.0.0-rc.1  0.13.3  https://hex.pm/packages/postgrex
ecto_network  Ecto types to support MACADDR and Network extensio...  0.6.0       0.6.0   https://hex.pm/packages/ecto_network
geo_postgis   PostGIS extension for Postgrex.                        1.0.0       1.0.0   https://hex.pm/packages/geo_postgis
posterize     erlang wrapper for the postgrex postgres client        0.13.3      0.13.3  https://hex.pm/packages/posterize
hstore        A collection of encoders and decoders for hstore d...  0.0.2       0.0.2   https://hex.pm/packages/hstore
postgrex_cdb  PostgreSQL driver for Elixir compatible with Cockr...  0.13.3      0.13.3  https://hex.pm/packages/postgrex_cdb
seek          A simple wrapper around Postgrex to simplify writi...  0.0.1       0.0.1   https://hex.pm/packages/seek
```