### PR TITLE
Clarify repository key read-only access

### DIFF
--- a/lib/mix/tasks/hex.organization.ex
+++ b/lib/mix/tasks/hex.organization.ex
@@ -37,7 +37,7 @@ defmodule Mix.Tasks.Hex.Organization do
 
   This command is useful to pre-generate keys for use with `mix hex.organization auth NAME --key KEY`
   on CI servers or similar systems. It returns the hash of the generated key that you can pass to
-  `auth NAME --key KEY`
+  `auth NAME --key KEY`. This key allows read-only access to the repository
 
       mix hex.organization key NAME
 


### PR DESCRIPTION
I didn't see anywhere that mentioned that this key allows read-only access, and prevents any write access. @ericmj confirmed in the #hex Slack channel that this is the case. This is an important security feature, and I think it would be helpful if it was documented.

Happy to alter the wording or format, just LMK.