### PR TITLE
Add mix hex.build --smoke

### DIFF
--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -140,11 +140,11 @@ defmodule Mix.Tasks.Hex.Build do
 
       File.cd!(content_dir, fn ->
         opts = [env: [{"MIX_ENV", "prod"}]]
-        Mix.Shell.cmd("mix do deps.get, compile", opts, &IO.write/1)
+        Mix.shell().cmd("mix do deps.get, compile", opts)
 
         # Running custom commands
         Enum.each(args, fn cmd ->
-          Mix.Shell.cmd(cmd, opts, &IO.write/1)
+          Mix.shell().cmd(cmd, opts)
         end)
       end)
       {:error, reason} ->

--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -122,14 +122,12 @@ defmodule Mix.Tasks.Hex.Build do
 
   defp build_smoke_package(meta, cmd \\ nil) do
     {tar, _checksum} = Hex.Tar.create(meta, meta.files)
-    pkg_dir = "#{meta.name}-#{meta.version}-smoke"
+    pkg_dir = "#{meta.name}-smoke"
     content_dir = Path.join(pkg_dir, "contents")
 
-    if File.exists?(pkg_dir) do
-      Mix.raise("Please delete '#{pkg_dir}' if you want to continue. Exiting...")
-    else
-      File.mkdir_p!(content_dir)
-    end
+    if File.exists?(pkg_dir), do: File.rm_rf!(pkg_dir)
+ 
+    File.mkdir_p!(content_dir)
 
     case :hex_erl_tar.extract({:binary, tar}, [:compressed, cwd: pkg_dir]) do
       :ok ->

--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -126,7 +126,7 @@ defmodule Mix.Tasks.Hex.Build do
     content_dir = Path.join(pkg_dir, "contents")
 
     if File.exists?(pkg_dir), do: File.rm_rf!(pkg_dir)
- 
+
     File.mkdir_p!(content_dir)
 
     case :hex_erl_tar.extract({:binary, tar}, [:compressed, cwd: pkg_dir]) do

--- a/test/mix/tasks/hex.build_test.exs
+++ b/test/mix/tasks/hex.build_test.exs
@@ -252,7 +252,7 @@ defmodule Mix.Tasks.Hex.BuildTest do
       fun = fn ->
         File.write!("myfile.txt", "hello")
         File.write!("executable.sh", "world")
-        assert Mix.Tasks.Hex.Build.run(["--smoke"]) == :ok
+        Mix.Tasks.Hex.Build.run(["--smoke"])
       end
 
       assert capture_io(fun) =~ "Building release_h 0.0.1"
@@ -272,7 +272,7 @@ defmodule Mix.Tasks.Hex.BuildTest do
       fun = fn ->
         File.write!("myfile.txt", "hello")
         File.write!("executable.sh", "world")
-        assert Mix.Tasks.Hex.Build.run(["--smoke", "touch end.txt"]) == :ok
+        Mix.Tasks.Hex.Build.run(["--smoke", "touch end.txt"])
       end
 
       assert capture_io(fun) =~ "Building release_h 0.0.1"

--- a/test/mix/tasks/hex.build_test.exs
+++ b/test/mix/tasks/hex.build_test.exs
@@ -242,38 +242,6 @@ defmodule Mix.Tasks.Hex.BuildTest do
     purge([ReleaseIncludeRepoDeps.MixProject])
   end
 
-  test "error if invalid option is given" do
-    Mix.Project.push(ReleaseIncludeRepoDeps.MixProject)
-
-    in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
-
-      error_msg = "1 error found!\n--invalid : Unknown option"
-
-      assert_raise(OptionParser.ParseError, error_msg, fn ->
-        Mix.Tasks.Hex.Build.run(["--invalid"])
-      end)
-    end)
-  after
-    purge([ReleaseIncludeRepoDeps.MixProject])
-  end
-
-  test "error if invalid argument is given" do
-    Mix.Project.push(ReleaseIncludeRepoDeps.MixProject)
-
-    in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
-
-      error_msg = "Invalid arguments, expected:\n\nmix hex.build [--smoke [command]...]\n"
-
-      assert_raise(Mix.Error, error_msg, fn ->
-        Mix.Tasks.Hex.Build.run(["echo hello"])
-      end)
-    end)
-  after
-    purge([ReleaseIncludeRepoDeps.MixProject])
-  end
-
   test "create smoke package" do
     Mix.Project.push(ReleaseFiles.MixProject)
 

--- a/test/mix/tasks/hex.build_test.exs
+++ b/test/mix/tasks/hex.build_test.exs
@@ -223,25 +223,6 @@ defmodule Mix.Tasks.Hex.BuildTest do
     purge [ReleaseIncludeReservedFile.MixProject]
   end
 
-  test "error if smoke directory already exists" do
-    Mix.Project.push(ReleaseIncludeRepoDeps.MixProject)
-
-    in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
-
-      pkg_dir = "release_a-0.0.1-smoke"
-
-      error_msg = "Please delete '#{pkg_dir}' if you want to continue. Exiting..."
-
-      assert_raise(Mix.Error, error_msg, fn ->
-        File.mkdir!(pkg_dir)
-        Mix.Tasks.Hex.Build.run(["--smoke"])
-      end)
-    end)
-  after
-    purge([ReleaseIncludeRepoDeps.MixProject])
-  end
-
   test "create smoke package" do
     Mix.Project.push(ReleaseFiles.MixProject)
 
@@ -276,7 +257,7 @@ defmodule Mix.Tasks.Hex.BuildTest do
       end
 
       assert capture_io(fun) =~ "Building release_h 0.0.1"
-      assert File.exists?("release_h-0.0.1-smoke/contents/end.txt")
+      assert File.exists?("release_h-smoke/contents/end.txt")
     end)
   after
     Mix.shell(Mix.Shell.Process)


### PR DESCRIPTION
The current behavior allows to build the package, extracts its content in the `#{meta.name}-#{meta.version)-smoke` directory, retrieve the package dependencies, and then compiles the app. But, there are some things still missing, such as:

* [x] Add unit tests!
* [x] Add docs about the new feature
* [x] Run custom commands after compilation, e.g. `mix docs`

Any feedback is more than welcome.

Closes #436 