### PR TITLE
Preserve symlinks and empty directories in tar

### DIFF
--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -55,6 +55,25 @@ defmodule Hex do
     def enum_split_with(enum, fun), do: Enum.split_with(enum, fun)
   end
 
+  def file_lstat(path, opts \\ []) do
+    opts = Keyword.put_new(opts, :time, :universal)
+    case :file.read_link_info(IO.chardata_to_string(path), opts) do
+      {:ok, fileinfo} ->
+        {:ok, File.Stat.from_record(fileinfo)}
+      error ->
+        error
+    end
+  end
+
+  def file_lstat!(path, opts \\ []) do
+    case file_lstat(path, opts) do
+      {:ok, info}      -> info
+      {:error, reason} ->
+        raise File.Error, reason: reason, action: "read file stats",
+          path: IO.chardata_to_string(path)
+    end
+  end
+
   if Mix.env == :test do
     defp children do
       import Supervisor.Spec

--- a/lib/hex/tar.ex
+++ b/lib/hex/tar.ex
@@ -38,7 +38,7 @@ defmodule Hex.Tar do
         {name, contents} ->
           :ok = :hex_erl_tar.add(tar, contents, Hex.string_to_charlist(name), [])
         name ->
-          case File.lstat(name) do
+          case Hex.file_lstat(name) do
             {:ok, %File.Stat{type: type}} when type in [:directory, :symlink] ->
               :ok = :hex_erl_tar.add(tar, Hex.string_to_charlist(name), [])
             _stat ->

--- a/lib/hex/tar.ex
+++ b/lib/hex/tar.ex
@@ -40,7 +40,7 @@ defmodule Hex.Tar do
         name ->
           case File.lstat(name) do
             {:ok, %File.Stat{type: type}} when type in [:directory, :symlink] ->
-              :ok == :hex_erl_tar.add(tar, Hex.string_to_charlist(name), [])
+              :ok = :hex_erl_tar.add(tar, Hex.string_to_charlist(name), [])
             _stat ->
               contents = File.read!(name)
               mode = File.stat!(name).mode

--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -367,7 +367,7 @@ defmodule Mix.Tasks.Hex.Build do
   end
 
   defp dir_files(path) do
-    case File.lstat(path) do
+    case Hex.file_lstat(path) do
       {:ok, %File.Stat{type: :directory}} ->
         [path | Path.wildcard(Path.join(path, "**"), match_dot: true)]
       _ ->

--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -362,16 +362,16 @@ defmodule Mix.Tasks.Hex.Build do
     |> Enum.flat_map(&Path.wildcard/1)
     |> Enum.flat_map(&dir_files/1)
     |> Enum.map(&Path.expand/1)
-    |> Enum.filter(&File.regular?/1)
     |> Enum.uniq()
     |> Enum.map(&Path.relative_to(&1, expand_dir))
   end
 
   defp dir_files(path) do
-    if File.dir?(path) do
-      Path.wildcard(Path.join(path, "**"), match_dot: true)
-    else
-      [path]
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :directory}} ->
+        [path | Path.wildcard(Path.join(path, "**"), match_dot: true)]
+      _ ->
+        [path]
     end
   end
 

--- a/src/hex_erl_tar.erl
+++ b/src/hex_erl_tar.erl
@@ -1261,12 +1261,10 @@ convert_header(_Bin, _Reader) ->
 %% If the file is a directory, a slash is appended to the name.
 fileinfo_to_header(Name, #file_info{}=Fi, Link) when is_list(Name) ->
     BaseHeader = #tar_header{name=Name,
-                             mtime=Fi#file_info.mtime,
-                             atime=Fi#file_info.atime,
-                             ctime=Fi#file_info.ctime,
+                             mtime=0,
+                             atime=0,
+                             ctime=0,
                              mode=Fi#file_info.mode,
-                             uid=Fi#file_info.uid,
-                             gid=Fi#file_info.gid,
                              typeflag=?TYPE_REGULAR},
     do_fileinfo_to_header(BaseHeader, Fi, Link).
 

--- a/test/mix/tasks/hex.build_test.exs
+++ b/test/mix/tasks/hex.build_test.exs
@@ -44,12 +44,14 @@ defmodule Mix.Tasks.Hex.BuildTest do
     in_tmp fn ->
       Hex.State.put(:home, tmp_path())
 
+      File.mkdir!("dir")
       File.mkdir!("empty_dir")
-      File.write!("empty_dir/.dotfile", "")
+      File.write!("dir/.dotfile", "")
       File.ln_s("empty_dir", "link_dir")
 
-      mtime_dir = File.stat!("empty_dir").mtime
-      mtime_file = File.stat!("empty_dir/.dotfile").mtime
+      # mtime_dir = File.stat!("dir").mtime
+      mtime_empty_dir = File.stat!("empty_dir").mtime
+      mtime_file = File.stat!("dir/.dotfile").mtime
       mtime_link = File.stat!("link_dir").mtime
 
       File.write!("myfile.txt", "hello")
@@ -61,18 +63,19 @@ defmodule Mix.Tasks.Hex.BuildTest do
 
       extract("release_h-0.0.1.tar", "unzip")
 
-      #Check that mtimes are not retained for files and directories and symlinks
-      assert File.stat!("unzip/empty_dir").mtime != mtime_dir
-      assert File.stat!("unzip/empty_dir/.dotfile").mtime != mtime_file
-      assert File.stat!("unzip/linkdir").mtime != mtime_link
+      # Check that mtimes are not retained for files and directories and symlinks
+      # erl_tar does not set mtime from tar if a directory contain files
+      # assert File.stat!("unzip/dir").mtime != mtime_dir
+      assert File.stat!("unzip/empty_dir").mtime != mtime_empty_dir
+      assert File.stat!("unzip/dir/.dotfile").mtime != mtime_file
+      assert File.stat!("unzip/link_dir").mtime != mtime_link
 
       assert File.lstat!("unzip/link_dir").type == :symlink
       assert File.lstat!("unzip/empty_dir").type == :directory
       assert File.read!("unzip/myfile.txt") == "hello"
-      assert File.read!("unzip/empty_dir/.dotfile") == ""
+      assert File.read!("unzip/dir/.dotfile") == ""
       assert File.stat!("unzip/myfile.txt").mode == 0o100644
       assert File.stat!("unzip/executable.sh").mode == 0o100755
-      IO.inspect File.stat!("unzip/link_dir")
     end
   after
     purge [ReleaseFiles.MixProject]

--- a/test/mix/tasks/hex.build_test.exs
+++ b/test/mix/tasks/hex.build_test.exs
@@ -70,8 +70,8 @@ defmodule Mix.Tasks.Hex.BuildTest do
       assert File.stat!("unzip/dir/.dotfile").mtime != mtime_file
       assert File.stat!("unzip/link_dir").mtime != mtime_link
 
-      assert File.lstat!("unzip/link_dir").type == :symlink
-      assert File.lstat!("unzip/empty_dir").type == :directory
+      assert Hex.file_lstat!("unzip/link_dir").type == :symlink
+      assert Hex.file_lstat!("unzip/empty_dir").type == :directory
       assert File.read!("unzip/myfile.txt") == "hello"
       assert File.read!("unzip/dir/.dotfile") == ""
       assert File.stat!("unzip/myfile.txt").mode == 0o100644

--- a/test/support/release_samples.ex
+++ b/test/support/release_samples.ex
@@ -94,7 +94,7 @@ defmodule ReleaseFiles.MixProject do
      version: "0.0.1",
      description: "foo",
      package: [
-       files: ["myfile.txt", "executable.sh", "empty_dir", "link_dir"],
+       files: ["myfile.txt", "executable.sh", "dir", "empty_dir", "link_dir"],
        licenses: ["MIT"],
        links: %{"a" => "http://a"},
        maintainers: ["maintainers"]]]

--- a/test/support/release_samples.ex
+++ b/test/support/release_samples.ex
@@ -94,7 +94,7 @@ defmodule ReleaseFiles.MixProject do
      version: "0.0.1",
      description: "foo",
      package: [
-       files: ["myfile.txt", "executable.sh", "empty_dir"],
+       files: ["myfile.txt", "executable.sh", "empty_dir", "link_dir"],
        licenses: ["MIT"],
        links: %{"a" => "http://a"},
        maintainers: ["maintainers"]]]


### PR DESCRIPTION
Empty directories and symlinks are currently omitted when packaging the tar file. This PR allows empty directories and symlinks to be retained. 

This should be rebased once https://github.com/hexpm/hex/pull/440 lands