### PR TITLE
Make minor doc rewording to Mix.Tasks.Hex{Build,Publish}

### DIFF
--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -44,7 +44,7 @@ defmodule Mix.Tasks.Hex.Build do
 
   As can be seen Hex package dependencies works alongside git dependencies.
   Important to note is that non-Hex dependencies will not be used during
-  dependency resolution and neither will be they listed as dependencies of the
+  dependency resolution and neither will they be listed as dependencies of the
   package.
 
   ## Package configuration

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -61,7 +61,7 @@ defmodule Mix.Tasks.Hex.Publish do
 
   As can be seen Hex package dependencies works alongside git dependencies.
   Important to note is that non-Hex dependencies will not be used during
-  dependency resolution and neither will be they listed as dependencies of the
+  dependency resolution and neither will they be listed as dependencies of the
   package.
 
   ## Package configuration


### PR DESCRIPTION
This is just a tiny grammar change for the moduledocs of `hex.build.ex` and `hex.publish.ex`.