### PR TITLE
Remove docs for old task: mix hex.user test

### DIFF
--- a/lib/mix/tasks/hex.user.ex
+++ b/lib/mix/tasks/hex.user.ex
@@ -54,12 +54,6 @@ defmodule Mix.Tasks.Hex.User do
 
       mix hex.user key --list
 
-  ### Test authentication
-
-  Tests if authentication works with the stored API key.
-
-      mix hex.user test
-
   ### Reset user password
 
       mix hex.user reset password


### PR DESCRIPTION
The Mix task `mix hex.user test` is documented but it does not exist anymore.