### PR TITLE
Fix crash on managers check

### DIFF
--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -147,12 +147,16 @@ defmodule Hex.SCM do
   end
 
   def checkout(opts) do
-    updated_lock = update(opts)
-    maybe_use_updated_lock(opts[:lock], updated_lock)
+    fetched_lock = update(opts)
+    maybe_use_fetched_lock(opts[:lock], fetched_lock)
   end
 
-  defp maybe_use_updated_lock({:hex, _, _, _, [], _, _}, updated_lock), do: updated_lock
-  defp maybe_use_updated_lock({:hex, _, _, _, _managers, _, _} = old_lock, _updated_lock), do: old_lock
+  defp maybe_use_fetched_lock(current_lock, fetched_lock) do
+    case Hex.Utils.lock(current_lock) do
+      %{managers: []} -> fetched_lock
+      _ -> current_lock
+    end
+  end
 
   @build_tools [
     {"mix.exs"     , "mix"},

--- a/test/hex/mix_task_test.exs
+++ b/test/hex/mix_task_test.exs
@@ -526,7 +526,7 @@ defmodule Hex.MixTaskTest do
   end
 
   defp old_lock_tuple(lock_tuple) do
-    {elem(lock_tuple, 0), elem(lock_tuple, 1), elem(lock_tuple, 2), elem(lock_tuple, 3)}
+    lock_tuple |> Tuple.to_list() |> Enum.take(6) |> List.to_tuple()
   end
 
   defp rewrite_lock_in_old_format() do
@@ -595,9 +595,9 @@ defmodule Hex.MixTaskTest do
       Mix.Task.run "deps.update", ["ex_doc"]
 
       assert %{
-               ecto: {:hex, :ecto, "0.2.0", _},
+               ecto: {:hex, :ecto, "0.2.0", _, _, _},
                ex_doc: {:hex, :ex_doc, "0.0.1", _, [:mix], _, _},
-               postgrex: {:hex, :postgrex, "0.2.0", _}
+               postgrex: {:hex, :postgrex, "0.2.0", _, _, _}
              } = Mix.Dep.Lock.read()
     end
   after

--- a/test/hex/mix_task_test.exs
+++ b/test/hex/mix_task_test.exs
@@ -526,7 +526,7 @@ defmodule Hex.MixTaskTest do
   end
 
   defp old_lock_tuple(lock_tuple) do
-    lock_tuple |> Tuple.to_list() |> Enum.take(6) |> List.to_tuple()
+    {elem(lock_tuple, 0), elem(lock_tuple, 1), elem(lock_tuple, 2), elem(lock_tuple, 3)}
   end
 
   defp rewrite_lock_in_old_format() do
@@ -595,9 +595,9 @@ defmodule Hex.MixTaskTest do
       Mix.Task.run "deps.update", ["ex_doc"]
 
       assert %{
-               ecto: {:hex, :ecto, "0.2.0", _, _, _},
+               ecto: {:hex, :ecto, "0.2.0", _},
                ex_doc: {:hex, :ex_doc, "0.0.1", _, [:mix], _, _},
-               postgrex: {:hex, :postgrex, "0.2.0", _, _, _}
+               postgrex: {:hex, :postgrex, "0.2.0", _}
              } = Mix.Dep.Lock.read()
     end
   after


### PR DESCRIPTION
Ref https://github.com/hexpm/hex/pull/426#issuecomment-340291244

Couldn't easily reproduce in the test suite. Manual repro is to:

1. resolve deps e.g. on Hex v0.15
2. update Hex to `master`
3. `rm -rf deps`
4. `mix deps.get`.

Note, on `master`, `rm -rf ~/.hex/cache.ets` fixes the problem.