### PR TITLE
Add Hex.Shell.debug/1 used with MIX_DEBUG=1

### DIFF
--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -104,17 +104,17 @@ defmodule Hex.SCM do
 
     case Hex.Parallel.await(:hex_fetcher, {:tarball, repo, name, lock.version}, @fetch_timeout) do
       {:ok, :cached} ->
-        Hex.Shell.info "  Using locally cached package (#{path})"
+        Hex.Shell.debug "  Using locally cached package (#{path})"
 
       {:ok, :offline} ->
-        Hex.Shell.info "  [OFFLINE] Using locally cached package (#{path})"
+        Hex.Shell.debug "  [OFFLINE] Using locally cached package (#{path})"
 
       {:ok, :new, etag} ->
         Registry.tarball_etag(repo, name, lock.version, etag)
         if Version.compare(System.version, "1.4.0") == :lt do
           Registry.persist()
         end
-        Hex.Shell.info "  Fetched package (#{safe_url})"
+        Hex.Shell.debug "  Fetched package (#{safe_url})"
 
       {:error, reason} ->
         Hex.Shell.error(reason)

--- a/lib/hex/shell.ex
+++ b/lib/hex/shell.ex
@@ -11,6 +11,12 @@ defmodule Hex.Shell do
     Mix.shell.error(output)
   end
 
+  def debug(output) do
+    if function_exported?(Mix, :debug?, 0) and Mix.debug?() do
+      info(output)
+    end
+  end
+
   def yes?(output) do
     Mix.shell.yes?(output)
   end

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -111,10 +111,8 @@ defmodule Hex.State do
   end
 
   defp log_value(key, value) do
-    if function_exported?(Mix, :debug?, 0) and Mix.debug? do
-      if key in @logged_keys do
-        Hex.Shell.info "Using #{key} = #{value}"
-      end
+    if key in @logged_keys do
+      Hex.Shell.debug "Using #{key} = #{value}"
     end
   end
 


### PR DESCRIPTION
Ref https://github.com/hexpm/hex/issues/358#issuecomment-284712035
Ref https://github.com/hexpm/hex/issues/454

without MIX_DEBUG=1:

```
Resolving Hex dependencies...
Dependency resolution completed:
  certifi 1.0.0
  cowboy 1.1.2
  cowlib 1.0.2
  hackney 1.6.6 RETIRED!
    (invalid)
  idna 4.0.0
  metrics 1.0.1
  mime 1.1.0
  mimerl 1.0.2
  ranch 1.3.2
  ssl_verify_fun 1.1.1
* Getting mime (Hex package)
* Getting cowboy (Hex package)
* Getting hackney (Hex package)
* Getting certifi (Hex package)
* Getting idna (Hex package)
* Getting metrics (Hex package)
* Getting mimerl (Hex package)
* Getting ssl_verify_fun (Hex package)
* Getting cowlib (Hex package)
* Getting ranch (Hex package)
```

with MIX_DEBUG=1:

```
** Running mix loadconfig (inside Foo.MixProject)
** Running mix deps.get (inside Foo.MixProject)
** Running mix archive.check (inside Foo.MixProject)
Resolving Hex dependencies...
Dependency resolution completed:
  certifi 1.0.0
  cowboy 1.1.2
  cowlib 1.0.2
  hackney 1.6.6 RETIRED!
    (invalid)
  idna 4.0.0
  metrics 1.0.1
  mime 1.1.0
  mimerl 1.0.2
  ranch 1.3.2
  ssl_verify_fun 1.1.1
* Getting mime (Hex package)
  Using locally cached package (/Users/wojtek/.hex/packages/hexpm/mime-1.1.0.tar)
* Getting cowboy (Hex package)
  Using locally cached package (/Users/wojtek/.hex/packages/hexpm/cowboy-1.1.2.tar)
* Getting hackney (Hex package)
  Using locally cached package (/Users/wojtek/.hex/packages/hexpm/hackney-1.6.6.tar)
* Getting certifi (Hex package)
  Using locally cached package (/Users/wojtek/.hex/packages/hexpm/certifi-1.0.0.tar)
* Getting idna (Hex package)
  Using locally cached package (/Users/wojtek/.hex/packages/hexpm/idna-4.0.0.tar)
* Getting metrics (Hex package)
  Using locally cached package (/Users/wojtek/.hex/packages/hexpm/metrics-1.0.1.tar)
* Getting mimerl (Hex package)
  Using locally cached package (/Users/wojtek/.hex/packages/hexpm/mimerl-1.0.2.tar)
* Getting ssl_verify_fun (Hex package)
  Using locally cached package (/Users/wojtek/.hex/packages/hexpm/ssl_verify_fun-1.1.1.tar)
* Getting cowlib (Hex package)
  Using locally cached package (/Users/wojtek/.hex/packages/hexpm/cowlib-1.0.2.tar)
* Getting ranch (Hex package)
  Using locally cached package (/Users/wojtek/.hex/packages/hexpm/ranch-1.3.2.tar)
```