### PR TITLE
[WIP] Include package versions in deps.get

### DIFF
--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -11,8 +11,13 @@ defmodule Hex.SCM do
     true
   end
 
-  def format(_opts) do
-    "Hex package"
+  def format(opts) do
+    case Hex.Utils.lock(opts[:lock]) do
+      %{version: version} ->
+        "Hex package v#{version}"
+      nil ->
+        "Hex package"
+    end
   end
 
   def format_lock(opts) do


### PR DESCRIPTION
This allows us to include version in the output (see https://github.com/hexpm/hex/pull/461 for output without it):

```
Resolving Hex dependencies...
Dependency resolution completed:
  certifi 1.0.0
  cowboy 1.1.2
  cowlib 1.0.2
  hackney 1.6.6 RETIRED!
    (invalid)
  idna 4.0.0
  metrics 1.0.1
  mime 1.1.0
  mimerl 1.0.2
  ranch 1.3.2
  ssl_verify_fun 1.1.1
* Getting mime (Hex package v1.1.0)
* Getting cowboy (Hex package v1.1.2)
* Getting hackney (Hex package v1.6.6)
```

This is the exact output we wanted to have in https://github.com/hexpm/hex/issues/454 (+/- hiding some output when not in debug mode)

However, including the version here makes it a bit redundant in other places:

```
$ mix deps
* idna (Hex package v4.0.0) (rebar3)
  locked at 4.0.0 (idna) 10aaa9f7
  the dependency build is outdated, please run "mix deps.compile"
* mimerl (Hex package v1.0.2) (rebar3)
  locked at 1.0.2 (mimerl) 993f9b0e
  the dependency build is outdated, please run "mix deps.compile"
```

```
$ mix deps.compile && mix deps
* idna 4.0.0 (Hex package v4.0.0) (rebar3)
  locked at 4.0.0 (idna) 10aaa9f7
  ok
* mimerl 1.0.2 (Hex package v1.0.2) (rebar3)
  locked at 1.0.2 (mimerl) 993f9b0e
  ok
```

WDYT?