### PR TITLE
Redesign Hex.Tar

### DIFF
--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -109,4 +109,18 @@ defmodule Hex do
   else
     defp dev_setup, do: :ok
   end
+
+  def create_tar!(metadata, files, output) do
+    case Hex.Tar.create(metadata, files, output) do
+      {:ok, result} -> result
+      {:error, reason} -> Mix.raise Hex.Tar.format_error(reason)
+    end
+  end
+
+  def unpack_tar!(path, dest) do
+    case Hex.Tar.unpack(path, dest) do
+      {:ok, result} -> result
+      {:error, reason} -> Mix.raise Hex.Tar.format_error(reason)
+    end
+  end
 end

--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -126,11 +126,9 @@ defmodule Hex.SCM do
 
     File.rm_rf!(dest)
     registry_checksum = Hex.Registry.Server.checksum(repo, to_string(name), lock.version)
-    {meta, checksum} = Hex.Tar.unpack(path, dest)
+    {meta, tar_checksum} = Hex.unpack_tar!(path, dest)
 
-    if checksum != registry_checksum do
-      Mix.raise "Checksum mismatch against registry"
-    end
+    if Base.decode16!(tar_checksum) != registry_checksum, do: raise "Checksum mismatch against registry"
 
     build_tools = guess_build_tools(meta)
     managers =

--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -128,7 +128,7 @@ defmodule Hex.SCM do
     registry_checksum = Hex.Registry.Server.checksum(repo, to_string(name), lock.version)
     {meta, tar_checksum} = Hex.unpack_tar!(path, dest)
 
-    if Base.decode16!(tar_checksum) != registry_checksum, do: raise "Checksum mismatch against registry"
+    if tar_checksum != registry_checksum, do: raise "Checksum mismatch against registry"
 
     build_tools = guess_build_tools(meta)
     managers =

--- a/lib/hex/tar.ex
+++ b/lib/hex/tar.ex
@@ -1,16 +1,60 @@
 defmodule Hex.Tar do
+  @moduledoc false
+
+  # TODO: convert strings to atoms when unpacking
+  #
+  # @type metadata() :: %{
+  #         app: String.t(),
+  #         version: String.t(),
+  #         app: String.t(),
+  #         description: String.t(),
+  #         files: String.t(),
+  #         licenses: String.t(),
+  #         requirements: [requirement()],
+  #         build_tools: list(String.t()),
+  #         elixir: version_requirement(),
+  #         maintainers: list(String.t()),
+  #         links: map()
+  #       }
+  #
+  # @type requirement() :: %{
+  #         app: String.t(),
+  #         optional: boolean(),
+  #         requirement: version_requirement(),
+  #         repository: String.t()
+  #       }
+
+  @type metadata() :: map()
+
+  @type file() :: Path.t() | {Path.t(), binary()}
+
+  @type checksum :: binary()
+
+  @type tar :: binary()
+
   @supported ["3"]
   @version "3"
   @required_files ~w(VERSION CHECKSUM metadata.config contents.tar.gz)c
 
-  def create(meta, files, opts \\ []) do
-    output = Keyword.get(opts, :output, "#{meta[:name]}-#{meta[:version]}.tar")
-    cleanup_tarball? = Keyword.get(opts, :cleanup_tarball?, true)
+  @doc """
+  Creates a package tarball.
 
-    contents_path = "#{meta[:name]}-#{meta[:version]}-contents.tar.gz"
+  ## Examples
 
-    :ok = create_tar(contents_path, files, [:compressed])
-    contents = File.read!(contents_path)
+      iex> {:ok, {tar, checksum}} = Hex.Tar.create(%{app: :ecto, version: "2.0.0"}, ["lib/ecto.ex"], "deps/")
+      # creates deps/ecto-2.0.0.tar
+
+      iex> {:ok, {tar, checksum}} = Hex.Tar.create(%{app: :ecto, version: "2.0.0"}, [{"lib/ecto.ex", "defmodule Ecto"}], ".")
+      # creates ./ecto-2.0.0.tar
+
+      iex> {:ok, {tar, checksum}} = Hex.Tar.create(%{app: :ecto, version: "2.0.0"}, [{"ecto.ex", "defmodule Ecto"}], :memory)
+      # nothing is saved to disk
+
+  """
+  @spec create(metadata(), [file()], output :: Path.t() | :memory) ::
+          {:ok, {tar(), checksum()}} | {:error, term()}
+  def create(meta, files, output) do
+    contents = create_tar(:memory, files, [:compressed])
 
     meta_string = encode_term(meta)
     blob = @version <> meta_string <> contents
@@ -22,157 +66,326 @@ defmodule Hex.Tar do
       {"metadata.config", meta_string},
       {"contents.tar.gz", contents}
     ]
-    :ok = create_tar(output, files, [])
 
-    tar = File.read!(output)
-    File.rm!(contents_path)
-    if cleanup_tarball?, do: File.rm!(output)
-    {tar, checksum}
+    tar = create_tar(output, files, [])
+    {:ok, {tar, checksum}}
   end
 
-  defp create_tar(path, files, opts) do
-    {:ok, tar} = :hex_erl_tar.open(Hex.string_to_charlist(path), opts ++ [:write])
+  def create_tar(path, files, opts) when is_binary(path) do
+    File.mkdir_p!(Path.dirname(path))
+    {:ok, tar} = :hex_erl_tar.open(string_to_charlist(path), opts ++ [:write])
 
     try do
-      Enum.each(files, fn
-        {name, contents, mode} ->
-          :ok = :hex_erl_tar.add(tar, contents, Hex.string_to_charlist(name), mode, [])
-        {name, contents} ->
-          :ok = :hex_erl_tar.add(tar, contents, Hex.string_to_charlist(name), [])
-        name ->
-          case Hex.file_lstat(name) do
-            {:ok, %File.Stat{type: type}} when type in [:directory, :symlink] ->
-              :ok = :hex_erl_tar.add(tar, Hex.string_to_charlist(name), [])
-            _stat ->
-              contents = File.read!(name)
-              mode = File.stat!(name).mode
-              :ok = :hex_erl_tar.add(tar, contents, Hex.string_to_charlist(name), mode, [])
-          end
-      end)
+      add_files(tar, files)
     after
       :hex_erl_tar.close(tar)
     end
+
+    File.read!(path)
   end
 
-  @spec unpack(Path.t() | {:binary, binary}, Path.t()) :: {map(), String.t()}
+  def create_tar(:memory, files, opts) do
+    compressed? = :compressed in opts
+    {:ok, fd} = :file.open([], [:ram, :read, :write, :binary])
+    {:ok, tar} = :hex_erl_tar.init(fd, :write, &file_op/2)
+
+    binary =
+      try do
+        try do
+          add_files(tar, files)
+        after
+          :ok = :hex_erl_tar.close(tar)
+        end
+
+        {:ok, size} = :file.position(fd, :cur)
+        {:ok, binary} = :file.pread(fd, 0, size)
+        binary
+      after
+        :ok = :file.close(fd)
+      end
+
+    if compressed? do
+      :zlib.gzip(binary)
+    else
+      binary
+    end
+  end
+
+  defp file_op(:write, {fd, data}), do: :file.write(fd, data)
+  defp file_op(:position, {fd, pos}), do: :file.position(fd, pos)
+  defp file_op(:read2, {fd, size}), do: :file.read(fd, size)
+  defp file_op(:close, _fd), do: :ok
+
+  defp add_files(tar, files) do
+    Enum.each(files, fn
+      {name, contents, mode} ->
+        :ok = :hex_erl_tar.add(tar, contents, string_to_charlist(name), mode, [])
+
+      {name, contents} ->
+        :ok = :hex_erl_tar.add(tar, contents, string_to_charlist(name), [])
+
+      name ->
+        case file_lstat(name) do
+          {:ok, %File.Stat{type: type}} when type in [:directory, :symlink] ->
+            :ok = :hex_erl_tar.add(tar, string_to_charlist(name), [])
+
+          _stat ->
+            contents = File.read!(name)
+            mode = File.stat!(name).mode
+            :ok = :hex_erl_tar.add(tar, contents, string_to_charlist(name), mode, [])
+        end
+    end)
+  end
+
+  @doc """
+  Unpacks a package tarball.
+
+  ## Examples
+
+      iex> {:ok, {metadata, checksum}} = Hex.Tar.unpack("ecto-2.0.0.tar", "deps/")
+      # unpacks to deps/ecto-2.0.0/
+
+      iex> {:ok, {metadata, checksum, files}} = Hex.Tar.unpack({:binary, tar}, :memory)
+      iex> files
+      [{"lib/ecto.ex", "defmodule Ecto ..."}, ...]
+
+  """
+  @spec unpack(file :: Path.t() | {:binary, binary()}, output :: Path.t()) ::
+          {:ok, {metadata(), checksum()}} | {:error, term()}
+  @spec unpack(file :: Path.t() | {:binary, binary()}, output :: :memory) ::
+          {:ok, {metadata(), checksum(), files :: [{Path.t(), binary()}]}} | {:error, term()}
   def unpack(tar, dest) do
     case :hex_erl_tar.extract(tar, [:memory]) do
-      {:ok, files} ->
+      {:ok, files} when files != [] ->
         files = Enum.into(files, %{})
-        check_version(files['VERSION'])
-        check_files(files)
-        checksum = checksum(files)
-        extract_contents(files['contents.tar.gz'], dest)
-        copy_metadata(files['metadata.config'], dest)
-        {decode_metadata(files['metadata.config']), checksum}
 
-      :ok ->
-        Mix.raise "Unpacking tarball failed: tarball empty"
+        %{checksum: nil, files: files, metadata: nil, contents: nil}
+        |> check_files()
+        |> check_version()
+        |> check_checksum()
+        |> copy_metadata(dest)
+        |> decode_metadata()
+        |> extract_contents(dest)
+
+      {:ok, []} ->
+        {:error, {:tarball, :empty}}
 
       {:error, reason} ->
-        Mix.raise "Unpacking tarball failed: " <> format_error(reason)
+        {:error, {:tarball, reason}}
     end
   end
 
-  defp check_files(files) do
-    files = Map.keys(files)
-    diff_files(@required_files, files)
-  end
+  defp check_version({:error, _} = error), do: error
 
-  defp diff_files(required, given) do
-    diff = required -- given
-    if diff != [] do
-      diff = Enum.join(diff, ", ")
-      Mix.raise "Missing files in tarball #{diff}"
+  defp check_version(state) do
+    version = state.files['VERSION']
+
+    if version in @supported do
+      state
+    else
+      {:error, {:unsupported_version, version}}
     end
   end
 
-  defp check_version(version) do
-    unless version in @supported do
-      Mix.raise "Unsupported tarball version #{version}. " <>
-                 "Try updating Hex with `mix local.hex`."
+  defp check_files({:error, _} = error), do: error
+
+  defp check_files(state) do
+    case @required_files -- Map.keys(state.files) do
+      [] -> state
+      diff -> {:error, {:missing_files, diff}}
     end
   end
 
-  defp checksum(files) do
-    case Base.decode16(files['CHECKSUM'], case: :mixed) do
-      {:ok, tar_checksum} ->
-        meta = files['metadata.config']
-        blob = files['VERSION'] <> meta <> files['contents.tar.gz']
-        checksum = :crypto.hash(:sha256, blob)
+  defp check_checksum({:error, _} = error), do: error
 
-        if checksum == tar_checksum do
-          checksum
+  defp check_checksum(state) do
+    checksum_base16 = state.files['CHECKSUM']
+
+    case Base.decode16(checksum_base16, case: :mixed) do
+      {:ok, expected_checksum} ->
+        meta = state.files['metadata.config']
+        blob = state.files['VERSION'] <> meta <> state.files['contents.tar.gz']
+        actual_checksum = :crypto.hash(:sha256, blob)
+
+        if expected_checksum == actual_checksum do
+          %{state | checksum: checksum_base16}
         else
-          Mix.raise "Checksum mismatch in tarball"
+          {:error, {:checksum_mismatch, expected_checksum, actual_checksum}}
         end
 
       :error ->
-        Mix.raise "Checksum invalid"
+        {:error, :invalid_checksum}
     end
   end
 
-  def extract_contents(file, dest, opts \\ []) do
-    mode = opts[:mode] || :binary
-    case :hex_erl_tar.extract({mode, file}, [:compressed, cwd: dest]) do
+  defp decode_metadata({:error, _} = error), do: error
+
+  defp decode_metadata(state) do
+    string = safe_to_charlist(state.files['metadata.config'])
+
+    case :safe_erl_term.string(string) do
+      {:ok, tokens, _line} ->
+        try do
+          terms = :safe_erl_term.terms(tokens)
+          %{state | metadata: Enum.into(terms, %{})}
+        rescue
+          FunctionClauseError ->
+            {:error, {:metadata, :invalid_terms}}
+
+          ArgumentError ->
+            {:error, {:metadata, :not_key_value}}
+        end
+
+      {:error, {_line, :safe_erl_term, reason}, _line2} ->
+        {:error, {:metadata, reason}}
+    end
+  end
+
+  defp copy_metadata({:error, _} = error, _dest), do: error
+
+  defp copy_metadata(state, :memory) do
+    state
+  end
+
+  defp copy_metadata(state, dest) do
+    File.mkdir_p!(dest)
+    file_name = "hex_metadata.config"
+    path = Path.join(dest, file_name)
+    File.write!(path, state.files['metadata.config'])
+    state
+  end
+
+  defp extract_contents({:error, _} = error, _dest), do: error
+
+  defp extract_contents(state, dest) do
+    case do_extract_contents(state.files['contents.tar.gz'], dest) do
+      :ok ->
+        {:ok, {state.metadata, state.checksum}}
+
+      {:ok, files} ->
+        files = for {path, contents} <- files, do: {List.to_string(path), contents}
+        {:ok, {state.metadata, state.checksum, files}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp do_extract_contents(binary, :memory) do
+    case :hex_erl_tar.extract({:binary, binary}, [:compressed, :memory]) do
+      {:ok, files} ->
+        {:ok, files}
+
+      {:error, reason} ->
+        {:error, {:inner_tarball, reason}}
+    end
+  end
+
+  defp do_extract_contents(binary, dest) do
+    case :hex_erl_tar.extract({:binary, binary}, [:compressed, cwd: dest]) do
       :ok ->
         Path.join(dest, "**")
         |> Path.wildcard()
         |> Enum.each(&File.touch!/1)
+
         :ok
+
       {:error, reason} ->
-        Mix.raise "Unpacking inner tarball failed: " <> format_error(reason)
+        {:error, {:inner_tarball, reason}}
     end
   end
 
   defp encode_term(list) do
     list
-    |> Hex.Utils.binarify(maps: false)
+    |> binarify(maps: false)
     |> Enum.map(&[:io_lib_pretty.print(&1, encoding: :utf8) | ".\n"])
     |> IO.chardata_to_string()
   end
 
-  defp format_error({_path, reason}) do
-    format_error(reason)
+  @tarball_error "Unpacking tarball failed: "
+  @inner_error "Unpacking inner tarball failed: "
+  @metadata_error "Error reading package metadata: "
+
+  def format_error({:tarball, :empty}), do: @tarball_error <> "Empty tarball"
+  def format_error({:tarball, reason}), do: @tarball_error <> format_tarball_error(reason)
+  def format_error({:inner_tarball, reason}), do: @inner_error <> format_tarball_error(reason)
+  def format_error({:metadata, :invalid_terms}), do: @metadata_error <> "Invalid terms"
+  def format_error({:metadata, :not_key_value}), do: @metadata_error <> "Not in key-value format"
+  def format_error({:metadata, reason}), do: @metadata_error <> format_metadata_error(reason)
+  def format_error(:invalid_checksum), do: "Invalid tarball checksum"
+
+  def format_error({:checksum_mismatch, expected, actual}) do
+    "Tarball checksum mismatch\n\nExpected: #{inspect(expected)}\nActual:  #{inspect(actual)}\n"
   end
 
-  defp format_error(reason) do
-    :hex_erl_tar.format_error(reason)
-    |> List.to_string()
+  defp format_tarball_error(reason) do
+    reason |> :hex_erl_tar.format_error() |> List.to_string()
   end
 
-  defp decode_metadata(contents) do
-    string = safe_to_charlist(contents)
-    case :safe_erl_term.string(string) do
-      {:ok, tokens, _line} ->
-        try do
-          terms = :safe_erl_term.terms(tokens)
-          Enum.into(terms, %{})
-        rescue
-          FunctionClauseError ->
-            Mix.raise "Error reading package metadata: invalid terms"
-          ArgumentError ->
-            Mix.raise "Error reading package metadata: not in key-value format"
-        end
-
-      {:error, reason} ->
-        Mix.raise "Error reading package metadata: #{inspect reason}"
-    end
+  defp format_metadata_error(reason) do
+    reason |> :safe_erl_term.format_error() |> List.to_string()
   end
 
-  defp copy_metadata(content, dest) do
-    file_name = "hex_metadata.config"
-    path = Path.join(dest, file_name)
-    File.write!(path, content)
-  end
+  # Utils
 
   # Some older packages have invalid unicode
   defp safe_to_charlist(string) do
     try do
-      Hex.string_to_charlist(string)
+      string_to_charlist(string)
     rescue
       UnicodeConversionError ->
         :erlang.binary_to_list(string)
+    end
+  end
+
+  if Version.compare(System.version(), "1.3.0") == :lt do
+    defp string_to_charlist(string), do: String.to_char_list(string)
+  else
+    defp string_to_charlist(string), do: String.to_charlist(string)
+  end
+
+  defp binarify(binary, _opts) when is_binary(binary) do
+    binary
+  end
+
+  defp binarify(number, _opts) when is_number(number) do
+    number
+  end
+
+  defp binarify(atom, _opts) when is_nil(atom) or is_boolean(atom) do
+    atom
+  end
+
+  defp binarify(atom, _opts) when is_atom(atom) do
+    Atom.to_string(atom)
+  end
+
+  defp binarify(list, opts) when is_list(list) do
+    for(elem <- list, do: binarify(elem, opts))
+  end
+
+  defp binarify(tuple, opts) when is_tuple(tuple) do
+    for(elem <- Tuple.to_list(tuple), do: binarify(elem, opts))
+    |> List.to_tuple()
+  end
+
+  defp binarify(map, opts) when is_map(map) do
+    if Keyword.get(opts, :maps, true) do
+      for(elem <- map, into: %{}, do: binarify(elem, opts))
+    else
+      for(elem <- map, do: binarify(elem, opts))
+    end
+  end
+
+  defp file_lstat(path, opts \\ []) do
+    opts = Keyword.put_new(opts, :time, :universal)
+
+    case :file.read_link_info(IO.chardata_to_string(path), opts) do
+      {:ok, fileinfo} ->
+        {:ok, File.Stat.from_record(fileinfo)}
+
+      error ->
+        error
     end
   end
 end

--- a/lib/hex/tar.ex
+++ b/lib/hex/tar.ex
@@ -163,12 +163,7 @@ defmodule Hex.Tar do
   defp copy_metadata(content, dest) do
     file_name = "hex_metadata.config"
     path = Path.join(dest, file_name)
-
-    if File.exists?(path) do
-      Hex.Shell.warn("Skipping #{file_name} because it already exists in destination directory")
-    else
-      File.write!(path, content)
-    end
+    File.write!(path, content)
   end
 
   # Some older packages have invalid unicode

--- a/lib/hex/tar.ex
+++ b/lib/hex/tar.ex
@@ -280,7 +280,7 @@ defmodule Hex.Tar do
     base_files =
       (meta["files"] || [])
       |> Enum.filter(&(Path.dirname(&1) == "."))
-      |> MapSet.new()
+      |> Hex.Set.new()
 
     build_tools =
       Enum.flat_map(@build_tools, fn {file, tool} ->

--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -96,24 +96,22 @@ defmodule Mix.Tasks.Hex.Build do
     print_info(meta, organization, exclude_deps, package[:files])
 
     if opts[:unpack] do
-      dest = Keyword.get(opts, :output, "#{meta.name}-#{meta.version}")
-      build_and_unpack_package(meta, dest)
+      output = Keyword.get(opts, :output, "#{meta.name}-#{meta.version}")
+      build_and_unpack_package(meta, output)
     else
-      opts = Keyword.merge(opts, [cleanup_tarball?: false])
-      build_package(meta, opts)
+      output = Keyword.get(opts, :output, "#{meta.name}-#{meta.version}.tar")
+      build_package(meta, output)
     end
   end
 
-  defp build_package(meta, opts) do
-    {_tar, checksum} = Hex.Tar.create(meta, meta.files, opts)
+  defp build_package(meta, output) do
+    {_tar, checksum} = Hex.create_tar!(meta, meta.files, output)
     Hex.Shell.info("Package checksum: #{checksum}")
   end
 
-  defp build_and_unpack_package(meta, dest) do
-    {tar, checksum} = Hex.Tar.create(meta, meta.files)
-
-    {_meta, unpack_checksum} = Hex.Tar.unpack({:binary, tar}, dest)
-    ^checksum = Base.encode16(unpack_checksum)
+  defp build_and_unpack_package(meta, output) do
+    {tar, checksum} = Hex.create_tar!(meta, meta.files, :memory)
+    {_meta, ^checksum} = Hex.unpack_tar!({:binary, tar}, output)
   end
 
   def prepare_package() do

--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -203,7 +203,7 @@ defmodule Mix.Tasks.Hex.Docs do
 
   defp extract_doc_contents(target) do
     fd = File.open!(target, [:read, :compressed])
-    Hex.Tar.extract_contents(fd, Path.dirname(target), mode: :file)
+    :ok = :hex_erl_tar.extract({:file, fd}, [:compressed, cwd: Path.dirname(target)])
   end
 
   defp docs_dir() do

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -316,7 +316,7 @@ defmodule Mix.Tasks.Hex.Publish do
 
   defp create_release(build, organization, auth, opts) do
     meta = build.meta
-    {tarball, checksum} = Hex.Tar.create(meta, meta.files)
+    {tarball, checksum} = Hex.create_tar!(meta, meta.files, :memory)
     progress? = Keyword.get(opts, :progress, true)
     progress = progress_fun(progress?, byte_size(tarball))
 

--- a/test/hex/api_test.exs
+++ b/test/hex/api_test.exs
@@ -12,7 +12,7 @@ defmodule Hex.APITest do
     auth = Hexpm.new_key([user: "user", pass: "hunter42"])
 
     meta = %{name: :pear, app: :pear, version: "0.0.1", build_tools: ["mix"], requirements: [], licenses: ["MIT"], description: "pear"}
-    {tar, _checksum} = Hex.Tar.create(meta, [])
+    {tar, _checksum} = Hex.create_tar!(meta, [], :memory)
     assert {:ok, {404, _, _}} = Hex.API.Release.get("hexpm", "pear", "0.0.1")
     assert {:ok, {201, _, _}} = Hex.API.Release.new("hexpm", "pear", tar, auth)
     assert {:ok, {200, body, _}} = Hex.API.Release.get("hexpm", "pear", "0.0.1")
@@ -20,7 +20,7 @@ defmodule Hex.APITest do
 
     reqs = [%{name: :pear, app: :pear, requirement: "~> 0.0.1", optional: false}]
     meta = %{name: :grape, app: :grape, version: "0.0.2", build_tools: ["mix"], requirements: reqs, licenses: ["MIT"], description: "grape"}
-    {tar, _checksum} = Hex.Tar.create(meta, [])
+    {tar, _checksum} = Hex.create_tar!(meta, [], :memory)
     assert {:ok, {201, _, _}} = Hex.API.Release.new("hexpm", "grape", tar, auth)
     assert {:ok, {200, body, _}} = Hex.API.Release.get("hexpm", "grape", "0.0.2")
     assert body["requirements"] == %{"pear" => %{"app" => "pear", "requirement" => "~> 0.0.1", "optional" => false}}
@@ -33,7 +33,7 @@ defmodule Hex.APITest do
     auth = Hexpm.new_key([user: "user", pass: "hunter42"])
 
     meta = %{name: :tangerine, app: :tangerine, version: "0.0.1", build_tools: ["mix"], requirements: [], licenses: ["MIT"], description: "tangerine"}
-    {tar, _checksum} = Hex.Tar.create(meta, [])
+    {tar, _checksum} = Hex.create_tar!(meta, [], :memory)
     assert {:ok, {201, _, _}} = Hex.API.Release.new("hexpm", "tangerine", tar, auth)
 
     tarball = Path.join(tmp_path(), "docs.tar.gz")

--- a/test/hex/tar_test.exs
+++ b/test/hex/tar_test.exs
@@ -28,15 +28,15 @@ defmodule Hex.TarTest do
       File.write!("mix.exs", @mix_exs)
 
       assert {:ok, {tar, checksum}} = Hex.Tar.create(@metadata, @files, "a/b.tar")
-      assert {:ok, {metadata2, ^checksum}} = Hex.Tar.unpack("a/b.tar", "unpack/")
+      assert {:ok, {metadata, ^checksum}} = Hex.Tar.unpack("a/b.tar", "unpack/")
 
       assert byte_size(checksum) == 32
       assert File.read!("a/b.tar") == tar
       assert File.ls!("unpack") == ["hex_metadata.config", "mix.exs"]
       assert {:ok, metadata_kw} = :file.consult("unpack/hex_metadata.config")
       assert File.read!("unpack/mix.exs") == File.read!("mix.exs")
-      assert Map.new(metadata_kw) == metadata2
-      assert Map.new(metadata2) == stringify(@metadata)
+      assert Enum.into(metadata_kw, %{}) == metadata
+      assert metadata == stringify(@metadata)
     end)
   end
 
@@ -46,7 +46,7 @@ defmodule Hex.TarTest do
 
       assert {:ok, {tar, checksum}} = Hex.Tar.create(@metadata, files, :memory)
       assert {:ok, {metadata2, ^checksum, ^files}} = Hex.Tar.unpack({:binary, tar}, :memory)
-      assert Map.new(metadata2) == stringify(@metadata)
+      assert metadata2 == stringify(@metadata)
     end)
   end
 
@@ -140,6 +140,6 @@ defmodule Hex.TarTest do
   end
 
   defp stringify(%{} = map) do
-    Map.new(map, fn {k, v} -> {Atom.to_string(k), v} end)
+    Enum.into(map, %{}, fn {k, v} -> {Atom.to_string(k), v} end)
   end
 end

--- a/test/hex/tar_test.exs
+++ b/test/hex/tar_test.exs
@@ -30,7 +30,7 @@ defmodule Hex.TarTest do
       assert {:ok, {tar, checksum}} = Hex.Tar.create(@metadata, @files, "a/b.tar")
       assert {:ok, {metadata2, ^checksum}} = Hex.Tar.unpack("a/b.tar", "unpack/")
 
-      assert checksum == "523518DD40CB7250140639AA3025E8E09A8F370A4E9F6D6BEF4D81132467ACA8"
+      assert byte_size(checksum) == 32
       assert File.read!("a/b.tar") == tar
       assert File.ls!("unpack") == ["hex_metadata.config", "mix.exs"]
       assert {:ok, metadata_kw} = :file.consult("unpack/hex_metadata.config")
@@ -87,7 +87,7 @@ defmodule Hex.TarTest do
       :ok = :hex_erl_tar.create('badchecksum.tar', files, [:write])
       assert {:error, :invalid_checksum} = Hex.Tar.unpack("badchecksum.tar", :memory)
 
-      files = replace_file(valid_files, 'CHECKSUM', Base.encode16("bad"))
+      files = replace_file(valid_files, 'metadata.config', "{<<\"name\">>,<<\"foo\">>}")
       :ok = :hex_erl_tar.create('checksummismatch.tar', files, [:write])
       assert {:error, {:checksum_mismatch, _, _}} = Hex.Tar.unpack("checksummismatch.tar", :memory)
 

--- a/test/hex/tar_test.exs
+++ b/test/hex/tar_test.exs
@@ -119,8 +119,18 @@ defmodule Hex.TarTest do
       :ok = :hex_erl_tar.create('empty.tar', [], [:write])
       assert {:error, {:tarball, :empty}} = Hex.Tar.unpack("empty.tar", :memory)
 
-      :ok = :hex_erl_tar.create('missing.tar', [{'VERSION', "3"}, {'ignored', "IGNORED"}], [:write])
-      assert {:error, {:missing_files, ['CHECKSUM' | _]}} = Hex.Tar.unpack("missing.tar", :memory)
+      :ok = :hex_erl_tar.create('missing.tar', [{'VERSION', "3"}], [:write])
+      assert {:error, {:tarball, {:missing_files, ['CHECKSUM' | _]}}} = Hex.Tar.unpack("missing.tar", :memory)
+
+      files = [
+        {'VERSION', ""},
+        {'CHECKSUM', ""},
+        {'metadata.config', ""},
+        {'contents.tar.gz', ""},
+        {'invalid.txt', ""},
+      ]
+      :ok = :hex_erl_tar.create('missing.tar', files, [:write])
+      assert {:error, {:tarball, {:invalid_files, ['invalid.txt']}}} = Hex.Tar.unpack("missing.tar", :memory)
 
       files = replace_file(valid_files, 'VERSION', "0")
       :ok = :hex_erl_tar.create('badversion.tar', files, [:write])

--- a/test/hex/tar_test.exs
+++ b/test/hex/tar_test.exs
@@ -24,7 +24,9 @@ defmodule Hex.TarTest do
       bar: %{
         app: :bar, optional: "false", requirement: "0.1.0"
       }
-    }
+    },
+    files: ["mix.exs"],
+    build_tools: ["mix"]
   }
 
   @files ["mix.exs"]
@@ -40,9 +42,10 @@ defmodule Hex.TarTest do
       assert File.read!("a/b.tar") == tar
       assert File.ls!("unpack") == ["hex_metadata.config", "mix.exs"]
       assert {:ok, metadata_kw} = :file.consult("unpack/hex_metadata.config")
-      assert :proplists.get_keys(metadata_kw) == ~w(name app version requirements)
+      assert :proplists.get_keys(metadata_kw) == ~w(files name app build_tools version requirements)
       assert File.read!("unpack/mix.exs") == File.read!("mix.exs")
       assert metadata == stringify(@metadata)
+      assert metadata["build_tools"] == ["mix"]
     end)
   end
 
@@ -182,7 +185,7 @@ defmodule Hex.TarTest do
       files =
         valid_files
         |> replace_file('contents.tar.gz', "badtar")
-        |> replace_file('CHECKSUM', "4C68A4E04D1B7B29A7511B27EFCCB6117F8748A99C98E4397EEF0F076E1C19AB")
+        |> replace_file('CHECKSUM', "892343F3E69A7408B75BFF02F438716B890828E06715EFED75F6FCAD2FC9E44E")
 
       :ok = :hex_erl_tar.create('badcontents.tar', files, [:write])
       assert {:error, {:inner_tarball, :eof}} = Hex.Tar.unpack("badcontents.tar", :memory)

--- a/test/hex/tar_test.exs
+++ b/test/hex/tar_test.exs
@@ -70,9 +70,6 @@ defmodule Hex.TarTest do
     end)
   end
 
-  test "unpack optional fields" do
-  end
-
   test "unpack with legacy requirements format" do
     in_tmp(fn ->
       files = [{"mix.exs", @mix_exs}]

--- a/test/support/hexpm.ex
+++ b/test/support/hexpm.ex
@@ -234,7 +234,7 @@ defmodule HexTest.Hexpm do
     mix_exs = :io_lib.format(@mix_exs_template, [module, name, version, deps])
 
     files = [{"mix.exs", List.to_string(mix_exs)}]
-    {tar, _checksum} = Hex.Tar.create(meta, files)
+    {tar, _checksum} = Hex.create_tar!(meta, files, :memory)
 
     {:ok, {result, %{"version" => ^version}, _}} = Hex.API.Release.new("hexpm", name, tar, auth)
     assert result in [200, 201]


### PR DESCRIPTION
The goal is to define a public API that can be reused in other projects later on. A proper proposal to follow.

TODO:

- [x] investigate flaky build
- [x] replace `Mix.raise` with returning `{:error, ...}`
- [ ] return metadata keys as atoms when unpacking