### PR TITLE
Fix handle_redirect to match calling arguments

### DIFF
--- a/lib/hex/http.ex
+++ b/lib/hex/http.ex
@@ -89,7 +89,7 @@ defmodule Hex.HTTP do
     end
   end
 
-  defp handle_redirect({{_version, code, _reason}, headers, _body})
+  defp handle_redirect({code, _body, headers})
        when code in [301, 302, 303, 307, 308] do
     headers = Enum.into(headers, %{})
 


### PR DESCRIPTION
The arguments on handle_redirect will never match (handle_response transforms the three item tuple into a different three item tuple), so the redirect logic will never be called.

I'd love to add a test for this, but the timeout, retry, and redirect methods are all private, and request directly calls httpc. I thought about adding an adapter, but wasn't sure if that'd add too much indirection.