### PR TITLE
Alerts if a package has been retired in hex.info

### DIFF
--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -159,17 +159,9 @@ defmodule Mix.Tasks.Hex.Info do
   defp print_retirement(nil), do: ""
   defp print_retirement(%{"retirement" => nil}), do: ""
   defp print_retirement(release) do
-    reason = release["retirement"]["reason"]
-    message = release["retirement"]["message"]
-    Hex.Shell.info [[:bright, "This version has been retired "], [:reset, format_retirement_info(reason, message)]]
+    retirement = %{reason: release["retirement"]["reason"], message: release["retirement"]["message"]}
+    Hex.Shell.warn [[:bright, "This version has been retired"], [:normal, ": "], [:normal, Hex.Utils.package_retirement_message(retirement)]]
   end
-  defp format_retirement_info(reason, nil) do
-    "(#{reason})"
-  end
-  defp format_retirement_info(reason, message) do
-    "(#{reason} - #{message})"
-  end
-
   defp format_pre([]) do
     ""
   end

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -156,7 +156,6 @@ defmodule Mix.Tasks.Hex.Info do
     "~> #{major}.#{minor}.#{patch}#{format_pre(pre)}"
   end
 
-  defp print_retirement(nil), do: ""
   defp print_retirement(%{"retirement" => nil}), do: ""
   defp print_retirement(release) do
     retirement = %{reason: release["retirement"]["reason"], message: release["retirement"]["message"]}

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -104,6 +104,9 @@ defmodule Mix.Tasks.Hex.Info do
 
   defp print_release(package, release) do
     version = release["version"]
+
+    print_retirement(release)
+
     print_config(package, release)
 
     if release["has_docs"] do
@@ -151,6 +154,20 @@ defmodule Mix.Tasks.Hex.Info do
   end
   defp format_version(%Version{major: major, minor: minor, patch: patch, pre: pre}) do
     "~> #{major}.#{minor}.#{patch}#{format_pre(pre)}"
+  end
+
+  defp print_retirement(nil), do: ""
+  defp print_retirement(%{"retirement" => nil}), do: ""
+  defp print_retirement(release) do
+    reason = release["retirement"]["reason"]
+    message = release["retirement"]["message"]
+    Hex.Shell.info [[:bright, "This version has been retired "], [:reset, format_retirement_info(reason, message)]]
+  end
+  defp format_retirement_info(reason, nil) do
+    "(#{reason})"
+  end
+  defp format_retirement_info(reason, message) do
+    "(#{reason} - #{message})"
   end
 
   defp format_pre([]) do


### PR DESCRIPTION
prints an alert when info is searched on a package version.
![screen shot 2018-01-07 at 11 07 46 am](https://user-images.githubusercontent.com/773380/34652440-14463f16-f39b-11e7-8599-32b3fc5c5501.png)
