### PR TITLE
Make gzip reproducible

### DIFF
--- a/mix-new.lock
+++ b/mix-new.lock
@@ -1,6 +1,9 @@
-%{"bypass": {:git, "https://github.com/PSPDFKit-labs/bypass.git", "87721c7ff56e6b307cb0e04d8a44666ce502b28b", []},
+%{
+  "bypass": {:git, "https://github.com/PSPDFKit-labs/bypass.git", "87721c7ff56e6b307cb0e04d8a44666ce502b28b", []},
   "cowboy": {:git, "https://github.com/ninenines/cowboy.git", "d08c2ab39d38c181abda279d5c2cadfac33a50c1", [tag: "1.0.4"]},
   "cowlib": {:git, "https://github.com/ninenines/cowlib.git", "45f750db410a4b08c68d142ad0af839f544c5d3d", [tag: "1.0.2"]},
   "mime": {:git, "https://github.com/elixir-lang/mime.git", "5ab714e38b25a59b68bda1df7b58da499b2c3aa7", [tag: "v1.0.1"]},
   "plug": {:git, "https://github.com/elixir-lang/plug.git", "1b161d55dc383df6f9e44e08f8359a862ad70b6c", [tag: "v1.2.0"]},
-  "ranch": {:git, "https://github.com/ninenines/ranch.git", "a5d2efcde9a34ad38ab89a26d98ea5335e88625a", [tag: "1.2.1"]}}
+  "ranch": {:git, "https://github.com/ninenines/ranch.git", "a5d2efcde9a34ad38ab89a26d98ea5335e88625a", [tag: "1.2.1"]},
+  "stream_data": {:git, "https://github.com/whatyouhide/stream_data.git", "36d0d1a4787b62661c1d803a39934ffc8eea43e5", [tag: "v0.4.0"]},
+}

--- a/mix.exs
+++ b/mix.exs
@@ -38,6 +38,12 @@ defmodule Hex.MixProject do
   # Can't use hex dependencies because the elixir compiler loads dependencies
   # and calls the dependency SCM. This would cause us to crash if the SCM was
   # Hex because we have to unload Hex before compiling it.
+  defp deps(elixir_version) when elixir_version >= {1, 5, 0} do
+    [
+      {:stream_data, github: "whatyouhide/stream_data", tag: "v0.4.0", only: :test},
+      {:plug, github: "elixir-lang/plug", tag: "v1.2.0", only: :test, override: true}
+    ] ++ deps()
+  end
   defp deps(elixir_version) when elixir_version >= {1, 2, 3} do
     [{:plug, github: "elixir-lang/plug", tag: "v1.2.0", only: :test, override: true}] ++
       deps()

--- a/test/hex/tar_properties_test.exs
+++ b/test/hex/tar_properties_test.exs
@@ -1,0 +1,25 @@
+{:ok, system_version} = Version.parse(System.version)
+elixir_version = {system_version.major, system_version.minor, system_version.patch}
+
+if elixir_version >= {1, 5, 0} do
+  {:ok, _} = Application.ensure_all_started(:stream_data)
+
+  defmodule Hex.TarPropertiesTest do
+    use HexTest.Case, async: true
+    use ExUnitProperties
+
+    property "gzip is circular" do
+      check all binary <- binary() do
+        assert :zlib.gunzip(Hex.Tar.gzip(binary)) == binary
+      end
+    end
+
+    property "Hex.Tar is equivalent to zlib" do
+      check all binary <- binary() do
+        assert <<31, 139, 8, 0, 0, 0, 0, 0, 0, _os, zlib_rest::binary>> = :zlib.gzip(binary)
+        assert <<31, 139, 8, 0, 0, 0, 0, 0, 0, 0, hex_rest::binary>> = Hex.Tar.gzip(binary)
+        assert zlib_rest == hex_rest
+      end
+    end
+  end
+end

--- a/test/hex/tar_test.exs
+++ b/test/hex/tar_test.exs
@@ -1,6 +1,5 @@
 defmodule Hex.TarTest do
   use HexTest.Case
-  @moduletag :integration
 
   @mix_exs """
   defmodule Foo.MixProject do
@@ -78,7 +77,7 @@ defmodule Hex.TarTest do
 
       files =
         files
-        |> replace_file('CHECKSUM', "22D7C2C004D6096D8B4BB40D984782D4D9D97E059F38632A947B4550C28A2B4A")
+        |> replace_file('CHECKSUM', "B3B3F6EF099FF41CB8323A57121BF445D62919A2F8F6FE3C86AF3AB47B627FB0")
         |> replace_file('metadata.config', """
                         {<<\"app\">>,<<\"foo\">>}.
                         {<<\"name\">>,<<\"foo\">>}.
@@ -149,7 +148,7 @@ defmodule Hex.TarTest do
       files =
         valid_files
         |> replace_file('metadata.config', "ok $")
-        |> replace_file('CHECKSUM', "7CC4126B1B4DA063841229BA8952AA4BAA4F21615F8CBD69DA8B36C0733F7151")
+        |> replace_file('CHECKSUM', "F518E93D179E7E08204BA23F7C798115B549573837ECD3DEB60BCB3767C60A01")
 
       :ok = :hex_erl_tar.create('badmetadata.tar', files, [:write])
       assert {:error, {:metadata, {:illegal, '$'}}} = Hex.Tar.unpack("badmetadata.tar", :memory)
@@ -157,7 +156,7 @@ defmodule Hex.TarTest do
       files =
         valid_files
         |> replace_file('metadata.config', "ok[")
-        |> replace_file('CHECKSUM', "7E65497E24EB8D39D7A2882928DF254D2CF6C8950998C651B88D3F12EB3D2152")
+        |> replace_file('CHECKSUM', "129352225A4A168A0109D0BF7866B8FAB00B09D12525562D578FAA6374F1AA0F")
 
       :ok = :hex_erl_tar.create('badmetadata.tar', files, [:write])
       assert {:error, {:metadata, :invalid_terms}} = Hex.Tar.unpack("badmetadata.tar", :memory)
@@ -165,7 +164,7 @@ defmodule Hex.TarTest do
       files =
         valid_files
         |> replace_file('metadata.config', "asdfasdfasdfasdf.")
-        |> replace_file('CHECKSUM', "72749F733A9825E0DEAD3378AD7FB9AC97559A4E9D6BD1F73E8A6C349A662203")
+        |> replace_file('CHECKSUM', "145ACF0F595484B179041F58706E8C5EAB05E4A714BAA756507CF889AB92E80B")
 
       :ok = :hex_erl_tar.create('badmetadata.tar', files, [:write])
       assert {:error, {:metadata, {:user, 'illegal atom asdfasdfasdfasdf'}}} = Hex.Tar.unpack("badmetadata.tar", :memory)
@@ -173,7 +172,7 @@ defmodule Hex.TarTest do
       files =
         valid_files
         |> replace_file('metadata.config', "ok.")
-        |> replace_file('CHECKSUM', "B4BF57D33731B5C4D64055BEF7BB0D4A80DB5ACD8A2117A6657A14DC5C207E2E")
+        |> replace_file('CHECKSUM', "4477712AF5857ACCA5B09E8B37C7D775513AB33D76589590BF23ABF2FBB29C47")
 
       :ok = :hex_erl_tar.create('badmetadata.tar', files, [:write])
       assert {:error, {:metadata, :not_key_value}} = Hex.Tar.unpack("badmetadata.tar", :memory)


### PR DESCRIPTION
zlib can change the OS value in the gzip header. Instead build the header manually with 0 as OS value.