### PR TITLE
colors retired package yellow in mix hex.info PACKAGE

### DIFF
--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -87,19 +87,19 @@ defmodule Mix.Tasks.Hex.Info do
     releases = package["releases"] || []
     print_config(package["name"], List.first(releases))
     retirements = package["retirements"] || %{}
-    Hex.Shell.info ["Releases: "] ++ format_releases(releases, retirements) ++ ["\n"]
+    Hex.Shell.info ["Releases: "] ++ format_releases(releases, Map.keys(retirements)) ++ ["\n"]
     print_meta(meta)
   end
 
   defp format_releases(releases, retirements) do
     {releases, rest} = Enum.split(releases, 8)
-    Enum.map(releases, fn(r) -> color_retired_version(r["version"], Map.keys(retirements)) end)
+    Enum.map(releases, &format_version(&1, retirements))
     |> join_formatted_releases([])
     |> Kernel.++(if(rest != [], do: [:reset, ", ..."] , else: [""]))
   end
 
-  defp color_retired_version(version, retired_versions) do
-    if Enum.member?(retired_versions, version) do
+  defp format_version(%{"version" => version}, retirements) do
+    if version in retirements do
       [:yellow, version, " (retired)", :reset]
     else
       [version]

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -86,7 +86,7 @@ defmodule Mix.Tasks.Hex.Info do
     Hex.Shell.info desc <> "\n"
     releases = package["releases"] || []
     print_config(package["name"], List.first(releases))
-    retirements = package["retirement"] || %{}
+    retirements = package["retirements"] || %{}
     Hex.Shell.info ["Releases: "] ++ format_releases(releases, retirements) ++ ["\n"]
     print_meta(meta)
   end
@@ -100,7 +100,7 @@ defmodule Mix.Tasks.Hex.Info do
 
   defp color_retired_version(version, retired_versions) do
     if Enum.member?(retired_versions, version) do
-      [:yellow, version]
+      [:yellow, version, " (retired)", :reset]
     else
       [:reset, version]
     end
@@ -108,7 +108,7 @@ defmodule Mix.Tasks.Hex.Info do
 
   defp join_formatted_releases([h | []], collection), do: collection ++ h
   defp join_formatted_releases([h | t], collection) do
-    join_formatted_releases(t, collection ++ [h, [:reset, ", "]])
+    join_formatted_releases(t, collection ++ [h, ", "])
   end
   defp join_formatted_releases([], collection), do: collection
 

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -94,8 +94,8 @@ defmodule Mix.Tasks.Hex.Info do
   defp format_releases(releases, retirements) do
     {releases, rest} = Enum.split(releases, 8)
     Enum.map(releases, &format_version(&1, retirements))
-    |> join_formatted_releases([])
-    |> Kernel.++(if(rest != [], do: [:reset, ", ..."] , else: [""]))
+    |> Enum.intersperse([", "])
+    |> add_ellipsis(rest)
   end
 
   defp format_version(%{"version" => version}, retirements) do
@@ -106,11 +106,8 @@ defmodule Mix.Tasks.Hex.Info do
     end
   end
 
-  defp join_formatted_releases([h | []], collection), do: collection ++ h
-  defp join_formatted_releases([h | t], collection) do
-    join_formatted_releases(t, collection ++ [h, ", "])
-  end
-  defp join_formatted_releases([], collection), do: collection
+  defp add_ellipsis(output, []), do: output
+  defp add_ellipsis(output, _rest), do: output ++ [", ..."]
 
   defp print_meta(meta) do
     print_list(meta, "contributors")

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -102,7 +102,7 @@ defmodule Mix.Tasks.Hex.Info do
     if Enum.member?(retired_versions, version) do
       [:yellow, version, " (retired)", :reset]
     else
-      [:reset, version]
+      [version]
     end
   end
 

--- a/test/mix/tasks/hex.info_test.exs
+++ b/test/mix/tasks/hex.info_test.exs
@@ -13,6 +13,11 @@ defmodule Mix.Tasks.Hex.InfoTest do
     assert_received {:mix_shell, :error, ["No package with name no_package"]}
   end
 
+  test "package with retired release" do
+    Mix.Tasks.Hex.Info.run(["tired"])
+    assert_received {:mix_shell, :info, ["Releases: 0.2.0, 0.1.0 (retired)\n"]}
+  end
+
   test "package with custom repo" do
     bypass_repo("myorg")
     Mix.Tasks.Hex.Info.run(["ecto", "--organization", "myorg"])

--- a/test/mix/tasks/hex.info_test.exs
+++ b/test/mix/tasks/hex.info_test.exs
@@ -7,6 +7,7 @@ defmodule Mix.Tasks.Hex.InfoTest do
     assert_received {:mix_shell, :info, ["Some description\n"]}
     assert_received {:mix_shell, :info, ["Config: {:ex_doc, \"~> 0.1.0\"}"]}
     assert_received {:mix_shell, :info, ["Maintainers: John Doe, Jane Doe"]}
+    assert_received {:mix_shell, :info, ["Releases: 0.1.0, 0.1.0-rc1, 0.0.1\n"]}
 
     Mix.Tasks.Hex.Info.run(["no_package"])
     assert_received {:mix_shell, :error, ["No package with name no_package"]}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -43,4 +43,7 @@ unless :integration in ExUnit.configuration[:exclude] do
   Hexpm.new_package("baz", "0.1.0", [foo: "0.1.0"], pkg_meta, auth)
   Hexpm.new_package("beta", "1.0.0", [], pkg_meta, auth)
   Hexpm.new_package("beta", "1.1.0-beta", [], pkg_meta, auth)
+  Hexpm.new_package("tired", "0.1.0", [], pkg_meta, auth)
+  Hexpm.new_package("tired", "0.2.0", [], pkg_meta, auth)
+  {:ok, _} = Hex.API.Release.retire("hexpm", "tired", "0.1.0", %{reason: "invalid"}, auth)
 end


### PR DESCRIPTION
<img width="524" alt="screen shot 2018-01-13 at 12 26 18 am" src="https://user-images.githubusercontent.com/773380/34903942-ffee46aa-f7f8-11e7-93ad-b7729c5f6e7b.png">
<img width="592" alt="screen shot 2018-01-13 at 12 26 03 am" src="https://user-images.githubusercontent.com/773380/34903943-0000c0aa-f7f9-11e7-85b8-ce02f5a34503.png">

This depends on https://github.com/hexpm/hexpm/pull/616 to work, but will not break in the meantime.
If retirement data is returned with the API call, the versions that have been retired will be printed in yellow (see screenshots)