### PR TITLE
Prevent empty package["meta"]["description"] to crash search

### DIFF
--- a/lib/mix/tasks/hex.search.ex
+++ b/lib/mix/tasks/hex.search.ex
@@ -79,6 +79,7 @@ defmodule Mix.Tasks.Hex.Search do
     parsed_version.pre == []
   end
 
+  defp trim_heredoc(nil), do: ""
   defp trim_heredoc(string) do
     string |> String.split("\n", trim: true) |> Enum.map_join(" ", &(&1 |> Hex.string_trim()))
   end


### PR DESCRIPTION
When searching for `mox` or `mock`, the cli returns an error:

```
❯ mix hex.search mock
** (FunctionClauseError) no function clause matching in String.split/3

    The following arguments were given to String.split/3:

        # 1
        nil

        # 2
        "\n"

        # 3
        [trim: true]

    (elixir) lib/string.ex:366: String.split/3
    (hex) lib/mix/tasks/hex.search.ex:83: Mix.Tasks.Hex.Search.trim_heredoc/1
    (hex) lib/mix/tasks/hex.search.ex:55: anonymous fn/1 in Mix.Tasks.Hex.Search.lookup_packages/1
    (elixir) lib/enum.ex:1270: Enum."-map/2-lists^map/1-0-"/2
    (elixir) lib/enum.ex:1270: Enum."-map/2-lists^map/1-0-"/2
    (hex) lib/mix/tasks/hex.search.ex:52: Mix.Tasks.Hex.Search.lookup_packages/1
    (mix) lib/mix/task.ex:301: Mix.Task.run_task/3
    (mix) lib/mix/cli.ex:75: Mix.CLI.run_task/2
```

Other packages search works as expected:

```
❯ mix hex.search remote
Package                        Description
remote_ip                      A plug to overwrite the Co
plug_cloudflare                Convert CloudFlare's CF-Co
honeydew                       Pluggable local/remote job
```

## Version
```
❯ mix hex.info
Hex:    0.17.3-dev
Elixir: 1.5.2
OTP:    20.1
```

This is because the packages don’t include a meta description field. The fix is pretty easy but I could not test it. The search tests on the repository seems to only contains integration tests. 