### PR TITLE
Fixes issue in hex.publish where it ignored the organization flag

### DIFF
--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -118,7 +118,7 @@ defmodule Mix.Tasks.Hex.Publish do
         revert(build, organization, revert_version)
 
       ["package"] ->
-        if proceed?(build, opts) do
+        if proceed?(build, organization, opts) do
           auth = Mix.Tasks.Hex.auth_info()
           create_release(build, organization, auth, opts)
         end
@@ -143,7 +143,7 @@ defmodule Mix.Tasks.Hex.Publish do
   end
 
   defp create(build, organization, opts) do
-    if proceed?(build, opts) do
+    if proceed?(build, organization, opts) do
       Hex.Shell.info("Building docs...")
       docs_task(build, opts)
       auth = Mix.Tasks.Hex.auth_info()
@@ -189,10 +189,9 @@ defmodule Mix.Tasks.Hex.Publish do
     end
   end
 
-  defp proceed?(build, opts) do
+  defp proceed?(build, organization, opts) do
     confirm? = Keyword.get(opts, :confirm, true)
     meta = build.meta
-    organization = build.organization
     exclude_deps = build.exclude_deps
     package = build.package
 
@@ -204,11 +203,11 @@ defmodule Mix.Tasks.Hex.Publish do
     cond do
       not confirm? ->
         true
-      build.organization in [nil, "hexpm"] ->
+      organization in [nil, "hexpm"] ->
         Hex.Shell.info(["Publishing package to ", emphasis("public"), " repository hexpm."])
         Hex.Shell.yes?("Proceed?")
       true ->
-        Hex.Shell.info(["Publishing package to ", emphasis("private"), " repository #{build.organization}."])
+        Hex.Shell.info(["Publishing package to ", emphasis("private"), " repository #{organization}."])
         Hex.Shell.yes?("Proceed?")
     end
   end

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -245,6 +245,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert_received {:mix_shell, :info, ["  Files:"]}
       assert_received {:mix_shell, :info, ["    myfile.txt"]}
       assert_received {:mix_shell, :info, ["  Extra: \n    c: d"]}
+      assert_received {:mix_shell, :info, ["Publishing package to \e[1mpublic\e[0m repository hexpm."]}
       refute_received {:mix_shell, :error, ["Missing metadata fields" <> _]}
     end
   after
@@ -262,6 +263,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       send self(), {:mix_shell_input, :yes?, true}
       send self(), {:mix_shell_input, :prompt, "hunter42"}
       Mix.Tasks.Hex.Publish.run(["package", "--no-progress"])
+      assert_received {:mix_shell, :info, ["Publishing package to \e[1mprivate\e[0m repository myorg."]}
       assert_received {:mix_shell, :info, ["Package published to myrepo html_url" <> _]}
     end
   after
@@ -294,6 +296,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       send self(), {:mix_shell_input, :yes?, true}
       send self(), {:mix_shell_input, :prompt, "hunter42"}
       Mix.Tasks.Hex.Publish.run(["package", "--no-progress", "--organization", "myorg2"])
+      assert_received {:mix_shell, :info, ["Publishing package to \e[1mprivate\e[0m repository myorg2."]}
       assert_received {:mix_shell, :info, ["Package published to myrepo html_url" <> _]}
     end
   after


### PR DESCRIPTION
When publishing using the --organization flag, but not including organization in the mix.exs metadata, the output asks the user to confirm they are publishign to *public* repo hexpm.
Since that module is already setting the organization var using the flag first, then the metadata second, this PR uses that var instead of only looking at the metadata.