### PR TITLE
 Set atime/mtime/ctime to 2000-01-01 so that tar works on FAT

### DIFF
--- a/lib/hex/tar.ex
+++ b/lib/hex/tar.ex
@@ -154,23 +154,25 @@ defmodule Hex.Tar do
   defp file_op(:read2, {fd, size}), do: :file.read(fd, size)
   defp file_op(:close, _fd), do: :ok
 
+  @tar_opts [atime: 0, mtime: 0, ctime: 0, uid: 0, gid: 0]
+
   defp add_files(tar, files) do
     Enum.each(files, fn
       {name, contents, mode} ->
-        :ok = :hex_erl_tar.add(tar, contents, string_to_charlist(name), mode, [])
+        :ok = :hex_erl_tar.add(tar, contents, string_to_charlist(name), mode, @tar_opts)
 
       {name, contents} ->
-        :ok = :hex_erl_tar.add(tar, contents, string_to_charlist(name), [])
+        :ok = :hex_erl_tar.add(tar, contents, string_to_charlist(name), @tar_opts)
 
       name ->
         case file_lstat(name) do
           {:ok, %File.Stat{type: type}} when type in [:directory, :symlink] ->
-            :ok = :hex_erl_tar.add(tar, string_to_charlist(name), [])
+            :ok = :hex_erl_tar.add(tar, string_to_charlist(name), @tar_opts)
 
           _stat ->
             contents = File.read!(name)
             mode = File.stat!(name).mode
-            :ok = :hex_erl_tar.add(tar, contents, string_to_charlist(name), mode, [])
+            :ok = :hex_erl_tar.add(tar, contents, string_to_charlist(name), mode, @tar_opts)
         end
     end)
   end

--- a/lib/hex/tar.ex
+++ b/lib/hex/tar.ex
@@ -154,7 +154,11 @@ defmodule Hex.Tar do
   defp file_op(:read2, {fd, size}), do: :file.read(fd, size)
   defp file_op(:close, _fd), do: :ok
 
-  @tar_opts [atime: 0, mtime: 0, ctime: 0, uid: 0, gid: 0]
+  unix_epoch = :calendar.datetime_to_gregorian_seconds({{1970, 1, 1}, {0, 0, 0}})
+  y2k = :calendar.datetime_to_gregorian_seconds({{2000, 1, 1}, {0, 0, 0}})
+  epoch = y2k - unix_epoch
+
+  @tar_opts [atime: epoch, mtime: epoch, ctime: epoch, uid: 0, gid: 0]
 
   defp add_files(tar, files) do
     Enum.each(files, fn
@@ -260,7 +264,7 @@ defmodule Hex.Tar do
         if expected_checksum == actual_checksum do
           %{state | checksum: expected_checksum}
         else
-          {:error, {:checksum_mismatch, expected_checksum, actual_checksum}}
+          {:error, {:checksum_mismatch, expected_checksum, Base.encode16(actual_checksum)}}
         end
 
       :error ->

--- a/src/hex_erl_tar.hrl
+++ b/src/hex_erl_tar.hrl
@@ -21,9 +21,14 @@
 
 %% Options used when adding files to a tar archive.
 -record(add_opts, {
-	 read_info,          %% Fun to use for read file/link info.
-	 chunk_size = 0,     %% For file reading when sending to sftp. 0=do not chunk
-         verbose = false}).  %% Verbose on/off.
+          read_info,          %% Fun to use for read file/link info.
+          chunk_size = 0,     %% For file reading when sending to sftp. 0=do not chunk
+          verbose = false,    %% Verbose on/off.
+          atime = undefined,
+          mtime = undefined,
+          ctime = undefined,
+          uid = 0,
+          gid = 0}).
 -type add_opts() :: #add_opts{}.
 
 %% Options used when reading a tar archive.


### PR DESCRIPTION
Closes #474

The root cause was that FAT cannot store file timestamps before 1980-01-01 and we were trying to store 1970-01-01 for reproducible tars. Now we will store them as 2000-01-01 00:00:00.

This unfortunately means that tars created prior to this change will no longer be reproducible.