### PR TITLE
Adds offline and online tasks to clarify open flags

### DIFF
--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -38,6 +38,14 @@ defmodule Mix.Tasks.Hex.Docs do
       ["open" | remaining] ->
         open_docs(remaining, opts)
 
+      ["online" | remaining] ->
+        opts = Keyword.merge(opts, offline: false)
+        open_docs(remaining, opts)
+
+      ["offline" | remaining] ->
+        opts = Keyword.merge(opts, offline: true)
+        open_docs(remaining, opts)
+
       _ ->
         Mix.raise("""
         Invalid arguments, expected one of:

--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -5,29 +5,26 @@ defmodule Mix.Tasks.Hex.Docs do
 
   @moduledoc """
   Fetches or opens documentation of a package.
+  
+  ### Fetch documentation for offline use
+
+  Fetches documentation for the specified package that you can later open with
+  `mix hex.docs offline`.
 
       mix hex.docs fetch PACKAGE [VERSION]
-
-  It will retrieve and decompress the specified version of the documentation
-  for a package. If you do not specify the `version` argument, this task will
-  retrieve the latest documentation available in the mirror.
+  
+  ### Open a browser window with offline documentation
 
       mix hex.docs offline PACKAGE [VERSION]
-
-  Opens a local version available in your filesystem.
-
+      
+  ### Open a browser window with online documentation
+  
       mix hex.docs online PACKAGE [VERSION]
-
-  Opens documentation on hex.pm.
 
   ## Command line options
 
     * `--module Some.Module` - Open a specified module documentation page inside desired package
     * `--organization ORGANIZATION` - The organization the package belongs to
-
-  It will open the specified version of the documentation for a package in a
-  Web browser. If you do not specify the `version` argument, this task will
-  open the latest documentation.
   """
 
   @switches [module: :string, organization: :string]

--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -14,6 +14,17 @@ defmodule Mix.Tasks.Hex.Docs do
 
       mix hex.docs open PACKAGE [VERSION]
 
+  Opens documentation without fetching it.
+
+      mix hex.docs offline PACKAGE [VERSION]
+
+  Opens a local version available in your filesystem. Alias for open with the
+  --offline flag.
+
+      mix hex.docs online PACKAGE [VERSION]
+
+  Opens documentation on hex.pm. Alias for open.
+
   ## Command line options
 
     * `--offline` - Open a local version available in your filesystem

--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -5,20 +5,20 @@ defmodule Mix.Tasks.Hex.Docs do
 
   @moduledoc """
   Fetches or opens documentation of a package.
-  
+
   ### Fetch documentation for offline use
 
   Fetches documentation for the specified package that you can later open with
   `mix hex.docs offline`.
 
       mix hex.docs fetch PACKAGE [VERSION]
-  
+
   ### Open a browser window with offline documentation
 
       mix hex.docs offline PACKAGE [VERSION]
-      
+
   ### Open a browser window with online documentation
-  
+
       mix hex.docs online PACKAGE [VERSION]
 
   ## Command line options
@@ -162,7 +162,7 @@ defmodule Mix.Tasks.Hex.Docs do
   end
 
   defp package_version_exists?(_organization, name, version) do
-    path = Path.join(docs_dir(), [name, version])
+    path = Path.join([docs_dir(), name, version])
     File.exists?(path)
   end
 


### PR DESCRIPTION
Adds `mix hex.docs offline` and `mix hex.docs online` to clarify open task without using flags.
https://github.com/hexpm/hex/issues/502

There is a second component to this issue, and I might suggest it be handled in another pull request since the scope is quite different. @michalmuskala has started work on that functionality in the past. It sounds like it might be worth picking up where he left off.