### PR TITLE
Instead of hex.docs online opening browser, test env sends message to…

### DIFF
--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -188,10 +188,7 @@ defmodule Mix.Tasks.Hex.Docs do
     start_command = start_command()
 
     if System.find_executable(start_command) do
-      case Mix.env() do
-        :test -> send self(), {:hex_open, path}
-        _ -> System.cmd(start_command, [path])
-      end
+      send_system_command(start_command, [path])
     else
       Mix.raise("Command not found: #{start_command}")
     end
@@ -202,6 +199,16 @@ defmodule Mix.Tasks.Hex.Docs do
       {:win32, _} -> "start"
       {:unix, :darwin} -> "open"
       {:unix, _} -> "xdg-open"
+    end
+  end
+
+  if Mix.env() == :test do
+    defp send_system_command(_cmd, args) do
+      send self(), {:hex_open, args}
+    end
+  else
+    defp send_system_command(cmd, args) do
+      System.cmd(cmd, args)
     end
   end
 

--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -204,7 +204,6 @@ defmodule Mix.Tasks.Hex.Docs do
 
   if Mix.env() == :test do
     defp system_cmd(cmd, args) do
-      send self(), {:hex_open, args}
       send self(), {:hex_system_cmd, cmd, args}
     end
   else

--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -188,7 +188,10 @@ defmodule Mix.Tasks.Hex.Docs do
     start_command = start_command()
 
     if System.find_executable(start_command) do
-      System.cmd(start_command, [path])
+      case Mix.env() do
+        :test -> send self(), {:hex_open, path}
+        _ -> System.cmd(start_command, [path])
+      end
     else
       Mix.raise("Command not found: #{start_command}")
     end

--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -188,7 +188,7 @@ defmodule Mix.Tasks.Hex.Docs do
     start_command = start_command()
 
     if System.find_executable(start_command) do
-      send_system_command(start_command, [path])
+      system_cmd(start_command, [path])
     else
       Mix.raise("Command not found: #{start_command}")
     end
@@ -203,11 +203,12 @@ defmodule Mix.Tasks.Hex.Docs do
   end
 
   if Mix.env() == :test do
-    defp send_system_command(_cmd, args) do
+    defp system_cmd(cmd, args) do
       send self(), {:hex_open, args}
+      send self(), {:hex_system_cmd, cmd, args}
     end
   else
-    defp send_system_command(cmd, args) do
+    defp system_cmd(cmd, args) do
       System.cmd(cmd, args)
     end
   end

--- a/test/mix/tasks/hex.docs_test.exs
+++ b/test/mix/tasks/hex.docs_test.exs
@@ -102,7 +102,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
       fetched_msg = "Docs fetched: #{docs_home}/#{package}/#{latest_version}"
       browser_open_msg = "#{docs_home}/#{package}/#{latest_version}/index.html"
       assert_received {:mix_shell, :info, [^fetched_msg]}
-      assert_received {:hex_open, ^browser_open_msg}
+      assert_received {:hex_open, [^browser_open_msg]}
     end)
   end
 
@@ -122,7 +122,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
       fetched_msg = "Docs fetched: #{docs_home}/#{package}/#{version}"
       browser_open_msg = "#{docs_home}/#{package}/#{version}/index.html"
       assert_received {:mix_shell, :info, [^fetched_msg]}
-      assert_received {:hex_open, ^browser_open_msg}
+      assert_received {:hex_open, [^browser_open_msg]}
 
       Mix.Tasks.Hex.Docs.run(["fetch", package, version])
       already_fetched_msg = "Docs already fetched: #{docs_home}/#{package}/#{version}"

--- a/test/mix/tasks/hex.docs_test.exs
+++ b/test/mix/tasks/hex.docs_test.exs
@@ -102,7 +102,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
       fetched_msg = "Docs fetched: #{docs_home}/#{package}/#{latest_version}"
       browser_open_msg = "#{docs_home}/#{package}/#{latest_version}/index.html"
       assert_received {:mix_shell, :info, [^fetched_msg]}
-      assert_received {:hex_open, [^browser_open_msg]}
+      assert_received {:hex_system_cmd, _cmd, [^browser_open_msg]}
     end)
   end
 
@@ -122,7 +122,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
       fetched_msg = "Docs fetched: #{docs_home}/#{package}/#{version}"
       browser_open_msg = "#{docs_home}/#{package}/#{version}/index.html"
       assert_received {:mix_shell, :info, [^fetched_msg]}
-      assert_received {:hex_open, [^browser_open_msg]}
+      assert_received {:hex_system_cmd, _cmd, [^browser_open_msg]}
 
       Mix.Tasks.Hex.Docs.run(["fetch", package, version])
       already_fetched_msg = "Docs already fetched: #{docs_home}/#{package}/#{version}"

--- a/test/mix/tasks/hex.docs_test.exs
+++ b/test/mix/tasks/hex.docs_test.exs
@@ -100,7 +100,9 @@ defmodule Mix.Tasks.Hex.DocsTest do
     in_tmp("docs", fn ->
       Mix.Tasks.Hex.Docs.run(["offline", package])
       fetched_msg = "Docs fetched: #{docs_home}/#{package}/#{latest_version}"
+      browser_open_msg = "#{docs_home}/#{package}/#{latest_version}/index.html"
       assert_received {:mix_shell, :info, [^fetched_msg]}
+      assert_received {:hex_open, ^browser_open_msg}
     end)
   end
 
@@ -118,7 +120,9 @@ defmodule Mix.Tasks.Hex.DocsTest do
     in_tmp("docs", fn ->
       Mix.Tasks.Hex.Docs.run(["offline", package, version])
       fetched_msg = "Docs fetched: #{docs_home}/#{package}/#{version}"
+      browser_open_msg = "#{docs_home}/#{package}/#{version}/index.html"
       assert_received {:mix_shell, :info, [^fetched_msg]}
+      assert_received {:hex_open, ^browser_open_msg}
 
       Mix.Tasks.Hex.Docs.run(["fetch", package, version])
       already_fetched_msg = "Docs already fetched: #{docs_home}/#{package}/#{version}"


### PR DESCRIPTION
… mailbox (which can now be tested.)

In response to @wojtekmach response that tests should not open browser windows, this change alters the behaviour of `browser_open/1` to instead send a message to the process mailbox in the test environment.
This prevents windows from opening, and also allows us to test that part of the code has been reached. Previously there was no real way to tell that a window was opened.