### PR TITLE
Adds organization to downloaded docs path

### DIFF
--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -77,7 +77,7 @@ defmodule Mix.Tasks.Hex.Docs do
   end
 
   defp fetch_docs(organization, [name, version]) do
-    target_dir = Path.join([docs_dir(), name, version])
+    target_dir = Path.join([docs_dir(), org_dir(organization), name, version])
 
     if File.exists?(target_dir) do
       Hex.Shell.info("Docs already fetched: #{target_dir}")
@@ -148,13 +148,13 @@ defmodule Mix.Tasks.Hex.Docs do
 
     page = Keyword.get(opts, :module, "index") <> ".html"
 
-    [docs_dir(), name, version, page]
+    [docs_dir(), org_dir(opts[:organization]), name, version, page]
     |> Path.join()
     |> open_file()
   end
 
   defp find_package_version(organization, name) do
-    path = Path.join(docs_dir(), name)
+    path = Path.join([docs_dir(), org_dir(organization), name])
 
     if File.exists?(path) do
       {false, find_latest_version(path)}
@@ -163,8 +163,8 @@ defmodule Mix.Tasks.Hex.Docs do
     end
   end
 
-  defp package_version_exists?(_organization, name, version) do
-    path = Path.join([docs_dir(), name, version])
+  defp package_version_exists?(organization, name, version) do
+    path = Path.join([docs_dir(), org_dir(organization), name, version])
     File.exists?(path)
   end
 
@@ -204,7 +204,7 @@ defmodule Mix.Tasks.Hex.Docs do
 
   if Mix.env() == :test do
     defp system_cmd(cmd, args) do
-      send self(), {:hex_system_cmd, cmd, args}
+      send(self(), {:hex_system_cmd, cmd, args})
     end
   else
     defp system_cmd(cmd, args) do
@@ -252,4 +252,7 @@ defmodule Mix.Tasks.Hex.Docs do
   defp docs_dir() do
     Path.join(Hex.State.fetch!(:home), "docs")
   end
+
+  defp org_dir(organization) when is_nil(organization), do: "hexpm"
+  defp org_dir(organization), do: "hexpm:#{organization}"
 end

--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -97,13 +97,13 @@ defmodule Mix.Tasks.Hex.Docs do
   end
 
   defp file_exists_in_fallback?(organization, name, version)
-       when organization in ["hexpm", "", nil] do
+       when is_nil(organization) do
     File.exists?(Path.join([docs_dir(), name, version]))
   end
 
   defp file_exists_in_fallback?(_organization, _name, _version), do: false
 
-  defp package_exists_in_fallback?(organization, name) when organization in ["hexpm", "", nil] do
+  defp package_exists_in_fallback?(organization, name) when is_nil(organization) do
     File.exists?(Path.join([docs_dir(), name]))
   end
 

--- a/test/mix/tasks/hex.docs_test.exs
+++ b/test/mix/tasks/hex.docs_test.exs
@@ -9,6 +9,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
     bypass_mirror()
     Hex.State.put(:home, tmp_path())
     docs_home = Path.join(Hex.State.fetch!(:home), "docs")
+    org_dir = "hexpm"
 
     auth = Hexpm.new_key(user: "user", pass: "hunter42")
     Hexpm.new_package(package, old_version, %{}, %{}, auth)
@@ -16,11 +17,11 @@ defmodule Mix.Tasks.Hex.DocsTest do
 
     in_tmp("docs", fn ->
       Mix.Tasks.Hex.Docs.run(["fetch", package])
-      fetched_msg = "Docs fetched: #{docs_home}/#{package}/#{latest_version}"
+      fetched_msg = "Docs fetched: #{docs_home}/#{org_dir}/#{package}/#{latest_version}"
       assert_received {:mix_shell, :info, [^fetched_msg]}
 
       Mix.Tasks.Hex.Docs.run(["fetch", package])
-      already_fetched_msg = "Docs already fetched: #{docs_home}/#{package}/#{latest_version}"
+      already_fetched_msg = "Docs already fetched: #{docs_home}/#{org_dir}/#{package}/#{latest_version}"
       assert_received {:mix_shell, :info, [^already_fetched_msg]}
     end)
   end
@@ -31,23 +32,21 @@ defmodule Mix.Tasks.Hex.DocsTest do
     bypass_mirror()
     Hex.State.put(:home, tmp_path())
 
-    docs_home =
-      :home
-      |> Hex.State.fetch!()
-      |> Path.join("docs")
+    docs_home = Path.join(Hex.State.fetch!(:home), "docs")
+    org_dir = "hexpm"
 
     in_tmp("docs", fn ->
       Mix.Tasks.Hex.Docs.run(["fetch", package, version])
-      fetched_msg = "Docs fetched: #{docs_home}/#{package}/#{version}"
+      fetched_msg = "Docs fetched: #{docs_home}/#{org_dir}/#{package}/#{version}"
       assert_received {:mix_shell, :info, [^fetched_msg]}
 
       Mix.Tasks.Hex.Docs.run(["fetch", package, version])
-      already_fetched_msg = "Docs already fetched: #{docs_home}/#{package}/#{version}"
+      already_fetched_msg = "Docs already fetched: #{docs_home}/#{org_dir}/#{package}/#{version}"
       assert_received {:mix_shell, :info, [^already_fetched_msg]}
     end)
   end
 
-  test "fetch a package that does not exists" do
+  test "fetch a package that does not exist" do
     package = "package_not_found"
 
     not_found_msg = "No package with name #{package}"
@@ -92,6 +91,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
     bypass_mirror()
     Hex.State.put(:home, tmp_path())
     docs_home = Path.join(Hex.State.fetch!(:home), "docs")
+    org_dir = "hexpm"
 
     auth = Hexpm.new_key(user: "user", pass: "hunter42")
     Hexpm.new_package(package, old_version, %{}, %{}, auth)
@@ -99,8 +99,8 @@ defmodule Mix.Tasks.Hex.DocsTest do
 
     in_tmp("docs", fn ->
       Mix.Tasks.Hex.Docs.run(["offline", package])
-      fetched_msg = "Docs fetched: #{docs_home}/#{package}/#{latest_version}"
-      browser_open_msg = "#{docs_home}/#{package}/#{latest_version}/index.html"
+      fetched_msg = "Docs fetched: #{docs_home}/#{org_dir}/#{package}/#{latest_version}"
+      browser_open_msg = "#{docs_home}/#{org_dir}/#{package}/#{latest_version}/index.html"
       assert_received {:mix_shell, :info, [^fetched_msg]}
       assert_received {:hex_system_cmd, _cmd, [^browser_open_msg]}
     end)
@@ -112,20 +112,18 @@ defmodule Mix.Tasks.Hex.DocsTest do
     bypass_mirror()
     Hex.State.put(:home, tmp_path())
 
-    docs_home =
-      :home
-      |> Hex.State.fetch!()
-      |> Path.join("docs")
+    docs_home = Path.join(Hex.State.fetch!(:home), "docs")
+    org_dir = "hexpm"
 
     in_tmp("docs", fn ->
       Mix.Tasks.Hex.Docs.run(["offline", package, version])
-      fetched_msg = "Docs fetched: #{docs_home}/#{package}/#{version}"
-      browser_open_msg = "#{docs_home}/#{package}/#{version}/index.html"
+      fetched_msg = "Docs fetched: #{docs_home}/#{org_dir}/#{package}/#{version}"
+      browser_open_msg = "#{docs_home}/#{org_dir}/#{package}/#{version}/index.html"
       assert_received {:mix_shell, :info, [^fetched_msg]}
       assert_received {:hex_system_cmd, _cmd, [^browser_open_msg]}
 
       Mix.Tasks.Hex.Docs.run(["fetch", package, version])
-      already_fetched_msg = "Docs already fetched: #{docs_home}/#{package}/#{version}"
+      already_fetched_msg = "Docs already fetched: #{docs_home}/#{org_dir}/#{package}/#{version}"
       assert_received {:mix_shell, :info, [^already_fetched_msg]}
     end)
   end


### PR DESCRIPTION
Took a crack at changing the local directory for docs from an organization.
It follows the convention set by packages and puts all docs in `HEX_HOME/docs/hexpm/package/release` or `HEX_HOME/docs/hexpm:org/package/release`

This will still leave previously downloaded packages orphaned. It may be worth adding some logic to the open function to look in the old location as well, but that may cause problems. If, for instance, I:
- have a public package downloaded now called "abc"
- and later I make a private package also named "abc"
- then I use `mix hex.docs fetch abc --organization org`
that would potentially  fall back into the docs/ directory to look for previously downloaded packages and find the public one. Then it would never actually download my private package docs.
It is hard to guess how many users that would affect. Perhaps it is just worth putting in the release notes or changelog that previously fetched packages are inaccessible, or maybe just a tip to use `mv ~/.hex/docs/* ~/.hex/docs/hexpm/`
