### PR TITLE
Add :exclude_patterns to hex package options

### DIFF
--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -57,6 +57,8 @@ defmodule Mix.Tasks.Hex.Build do
       can include wildcards. Defaults to `["lib", "priv", ".formatter.exs",
       "mix.exs", "README*", "readme*", "LICENSE*", "license*", "CHANGELOG*",
       "changelog*", "src"]`.
+    * `:exclude_patterns` - List of patterns matching files and directories to
+      exclude from the package.
     * `:maintainers` - List of names and/or emails of maintainers.
     * `:licenses` - List of licenses used by the package.
     * `:links` - Map of links relevant to the package.
@@ -252,7 +254,15 @@ defmodule Mix.Tasks.Hex.Build do
   end
 
   def package(package, config) do
-    files = expand_paths(package[:files] || @default_files, File.cwd!())
+    files = package[:files] || @default_files
+    exclude_patterns = package[:exclude_patterns] || []
+
+    files =
+      files
+      |> expand_paths(File.cwd!())
+      |> Enum.reject(fn path ->
+        Enum.any?(exclude_patterns, &(path =~ &1))
+      end)
 
     package
     |> Map.put(:files, files)

--- a/test/mix/tasks/hex.build_test.exs
+++ b/test/mix/tasks/hex.build_test.exs
@@ -81,6 +81,30 @@ defmodule Mix.Tasks.Hex.BuildTest do
     purge([ReleaseFiles.MixProject])
   end
 
+  test "create with excluded files" do
+    Mix.Project.push(ReleaseExcludePatterns.MixProject)
+
+    in_tmp(fn ->
+      Hex.State.put(:home, tmp_path())
+
+      File.write!("myfile.txt", "hello")
+      File.write!("exclude.txt", "world")
+      File.chmod!("myfile.txt", 0o100644)
+      File.chmod!("exclude.txt", 0o100644)
+
+      Mix.Tasks.Hex.Build.run([])
+
+      extract("release_i-0.0.1.tar", "unzip")
+
+      assert File.read!("unzip/myfile.txt") == "hello"
+      assert File.stat!("unzip/myfile.txt").mode == 0o100644
+
+      refute File.exists?("unzip/exclude")
+    end)
+  after
+    purge([ReleaseExcludePatterns.MixProject])
+  end
+
   test "create with custom output path" do
     Mix.Project.push(Sample.MixProject)
 

--- a/test/support/release_samples.ex
+++ b/test/support/release_samples.ex
@@ -149,6 +149,23 @@ defmodule ReleaseFiles.MixProject do
   end
 end
 
+defmodule ReleaseExcludePatterns.MixProject do
+  def project do
+    [
+      app: :release_i,
+      version: "0.0.1",
+      description: "foo",
+      package: [
+        files: ["myfile.txt"],
+        exclude_patterns: ["exclude.txt"],
+        licenses: ["MIT"],
+        links: %{"a" => "http://a"},
+        maintainers: ["maintainers"]
+      ]
+    ]
+  end
+end
+
 defmodule ReleaseRepo.MixProject do
   def project do
     [


### PR DESCRIPTION
As discussed in #506, this PR allows the option of `:exclude_patterns` in the Hex configs in order to list files you want to ignore in a package release.

This is my first Hex contribution so feedback and comments welcomed! Happy to fix things if this isn't the right approach.