### PR TITLE
Prevents error when unauthenticated user authenticates while publishing

### DIFF
--- a/lib/hex/crypto/encryption.ex
+++ b/lib/hex/crypto/encryption.ex
@@ -28,6 +28,8 @@ defmodule Hex.Crypto.Encryption do
     end
   end
 
+  def decrypt({_tag, {:ok, hashed_string, _password}}, _opts), do: hashed_string
+
   def decrypt({tag, cipher_text}, opts) do
     {:ok, cipher_text} = Crypto.base64url_decode(cipher_text)
 

--- a/lib/hex/crypto/encryption.ex
+++ b/lib/hex/crypto/encryption.ex
@@ -28,8 +28,6 @@ defmodule Hex.Crypto.Encryption do
     end
   end
 
-  def decrypt({_tag, {:ok, hashed_string, _password}}, _opts), do: hashed_string
-
   def decrypt({tag, cipher_text}, opts) do
     {:ok, cipher_text} = Crypto.base64url_decode(cipher_text)
 

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -160,9 +160,8 @@ defmodule Mix.Tasks.Hex do
         [key: prompt_decrypt_key(key)]
 
       Hex.Shell.yes?("No authenticated user found. Do you want to authenticate now?") ->
-        if password = auth() do
-          key = Hex.State.fetch!(:api_key)
-          [key: decrypt_key(key, password)]
+        if {:ok, key, _password} = auth() do
+          [key: key]
         else
           no_auth_error()
         end

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -160,7 +160,9 @@ defmodule Mix.Tasks.Hex do
         [key: prompt_decrypt_key(key)]
 
       Hex.Shell.yes?("No authenticated user found. Do you want to authenticate now?") ->
-        if {:ok, key, _password} = auth() do
+        {:ok, key, _password} = auth()
+
+        if key do
           [key: key]
         else
           no_auth_error()

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -155,21 +155,25 @@ defmodule Mix.Tasks.Hex do
   end
 
   def auth_info() do
-    cond do
-      key = Hex.State.fetch!(:api_key) ->
-        [key: prompt_decrypt_key(key)]
+    key = Hex.State.fetch!(:api_key)
 
-      Hex.Shell.yes?("No authenticated user found. Do you want to authenticate now?") ->
-        {:ok, key, _password} = auth()
+    if key do
+      [key: prompt_decrypt_key(key)]
+    else
+      authenticate_inline()
+    end
+  end
 
-        if key do
-          [key: key]
-        else
-          no_auth_error()
-        end
+  defp authenticate_inline() do
+    authenticate? =
+      Hex.Shell.yes?("No authenticated user found. Do you want to authenticate now?")
 
-      true ->
-        no_auth_error()
+    if authenticate? do
+      {:ok, key, _password} = auth()
+      unless key, do: no_auth_error()
+      [key: key]
+    else
+      no_auth_error()
     end
   end
 


### PR DESCRIPTION
When a user is prompted to authenticate in the process of publishing a package, the authentication is already decrypted when it is passed to `Hex.Crypto.Encryption.decrypt/2`. This change recognizes that and passes the expected data back.