### PR TITLE
Backtrack children before parents

### DIFF
--- a/lib/hex/resolver.ex
+++ b/lib/hex/resolver.ex
@@ -87,7 +87,7 @@ defmodule Hex.Resolver do
 
           not version_match?(version, req) ->
             Backtracks.add(info(info, :backtracks), repo, name, version, parents)
-            backtrack_parents([parent], info, activated) || backtrack(name, info, activated)
+            backtrack(name, info, activated) || backtrack_parents([parent], info, activated)
 
           true ->
             activated = Map.put(activated, name, active)


### PR DESCRIPTION
This will probably make the resolver slower when there are many
backtracks but the user most likely want the latest version of top-level
dependencies over transitive dependencies.