### PR TITLE
Windows tests

### DIFF
--- a/test/hex/mix_task_test.exs
+++ b/test/hex/mix_task_test.exs
@@ -327,7 +327,7 @@ defmodule Hex.MixTaskTest do
       File.write!("mix.lock", ~s(%{"ecto": {:hex, :ecto, "0.2.0"}}))
       Mix.Task.run("deps.update", ["ecto"])
 
-      assert_received {:mix_shell, :info, ["\e[32m  ecto 0.2.1\e[0m"]}
+      assert_received {:mix_shell, :info, ["  ecto 0.2.1"]}
     end)
   after
     purge([

--- a/test/hex/resolver_test.exs
+++ b/test/hex/resolver_test.exs
@@ -67,29 +67,29 @@ defmodule Hex.ResolverTest do
     deps = [bar: nil, foo: "~> 0.3.0"]
 
     assert resolve(deps) == """
-           \e[4mFailed to use "foo" because there are no packages that matches the requirement\e[0m
-             \e[1mmix.exs\e[0m specifies \e[31m~> 0.3.0\e[0m\n\e[0m
+           Failed to use "foo" because there are no packages that matches the requirement
+             mix.exs specifies ~> 0.3.0\n
            """
 
     deps = [foo: "~> 0.3.0", bar: nil]
 
     assert resolve(deps) == """
-           \e[4mFailed to use \"foo\" because there are no packages that matches the requirement\e[0m
-             \e[1mmix.exs\e[0m specifies \e[31m~> 0.3.0\e[0m\n\e[0m
+           Failed to use \"foo\" because there are no packages that matches the requirement
+             mix.exs specifies ~> 0.3.0\n
            """
 
     deps = [bar: "~> 0.3.0", foo: nil]
 
     assert resolve(deps) == """
-           \e[4mFailed to use "bar" because there are no packages that matches the requirement\e[0m
-             \e[1mmix.exs\e[0m specifies \e[31m~> 0.3.0\e[0m\n\e[0m
+           Failed to use "bar" because there are no packages that matches the requirement
+             mix.exs specifies ~> 0.3.0\n
            """
 
     deps = [foo: nil, bar: "~> 0.3.0"]
 
     assert resolve(deps) == """
-           \e[4mFailed to use "bar" because there are no packages that matches the requirement\e[0m
-             \e[1mmix.exs\e[0m specifies \e[31m~> 0.3.0\e[0m\n\e[0m
+           Failed to use "bar" because there are no packages that matches the requirement
+             mix.exs specifies ~> 0.3.0\n
            """
   end
 
@@ -109,33 +109,33 @@ defmodule Hex.ResolverTest do
     deps = [ex_plex: "~> 0.0.2", decimal: "0.1.0"]
 
     assert resolve(deps) == """
-           \e[4mFailed to use "decimal" (version 0.1.0) because\e[0m
-             \e[1mex_plex (version 0.0.2)\e[0m requires \e[31m0.1.1\e[0m
-             \e[1mmix.exs\e[0m specifies \e[32m0.1.0\e[0m\n\e[0m
+           Failed to use "decimal" (version 0.1.0) because
+             ex_plex (version 0.0.2) requires 0.1.1
+             mix.exs specifies 0.1.0\n
            """
 
     deps = [decimal: "0.1.0", ex_plex: "~> 0.0.2"]
 
     assert resolve(deps) == """
-           \e[4mFailed to use "decimal" (version 0.1.0) because\e[0m
-             \e[1mex_plex (version 0.0.2)\e[0m requires \e[31m0.1.1\e[0m
-             \e[1mmix.exs\e[0m specifies \e[32m0.1.0\e[0m\n\e[0m
+           Failed to use "decimal" (version 0.1.0) because
+             ex_plex (version 0.0.2) requires 0.1.1
+             mix.exs specifies 0.1.0\n
            """
 
     deps = [ex_plex: "0.0.2", decimal: nil]
 
     assert resolve(deps) == """
-           \e[4mFailed to use "decimal" (versions 0.0.1 to 0.2.1) because\e[0m
-             \e[1mex_plex (version 0.0.2)\e[0m requires \e[31m0.1.1\e[0m
-             \e[1mmix.exs\e[0m specifies \e[32m>= 0.0.0\e[0m\n\e[0m
+           Failed to use "decimal" (versions 0.0.1 to 0.2.1) because
+             ex_plex (version 0.0.2) requires 0.1.1
+             mix.exs specifies >= 0.0.0\n
            """
 
     deps = [decimal: nil, ex_plex: "0.0.2"]
 
     assert resolve(deps) == """
-           \e[4mFailed to use "decimal" (versions 0.0.1 to 0.2.1) because\e[0m
-             \e[1mex_plex (version 0.0.2)\e[0m requires \e[31m0.1.1\e[0m
-             \e[1mmix.exs\e[0m specifies \e[32m>= 0.0.0\e[0m\n\e[0m
+           Failed to use "decimal" (versions 0.0.1 to 0.2.1) because
+             ex_plex (version 0.0.2) requires 0.1.1
+             mix.exs specifies >= 0.0.0\n
            """
   end
 
@@ -207,36 +207,36 @@ defmodule Hex.ResolverTest do
     deps = [ex_plex: "0.1.0", decimal: nil]
 
     assert resolve(deps, locked) == """
-           \e[4mFailed to use "decimal" (version 0.0.1) because\e[0m
-             \e[1mex_plex (version 0.1.0)\e[0m requires \e[31m~> 0.1.0\e[0m
-             \e[1mmix.lock\e[0m specifies \e[32m0.0.1\e[0m\n\e[0m
+           Failed to use "decimal" (version 0.0.1) because
+             ex_plex (version 0.1.0) requires ~> 0.1.0
+             mix.lock specifies 0.0.1\n
            """
 
     locked = [decimal: "0.0.1"]
     deps = [decimal: nil, ex_plex: "0.1.0"]
 
     assert resolve(deps, locked) == """
-           \e[4mFailed to use "decimal" (version 0.0.1) because\e[0m
-             \e[1mex_plex (version 0.1.0)\e[0m requires \e[31m~> 0.1.0\e[0m
-             \e[1mmix.lock\e[0m specifies \e[32m0.0.1\e[0m\n\e[0m
+           Failed to use "decimal" (version 0.0.1) because
+             ex_plex (version 0.1.0) requires ~> 0.1.0
+             mix.lock specifies 0.0.1\n
            """
 
     locked = [decimal: "0.0.1"]
     deps = [ex_plex: "0.1.0", decimal: "~> 0.0.1"]
 
     assert resolve(deps, locked) == """
-           \e[4mFailed to use "decimal" (version 0.0.1) because\e[0m
-             \e[1mex_plex (version 0.1.0)\e[0m requires \e[31m~> 0.1.0\e[0m
-             \e[1mmix.lock\e[0m specifies \e[32m0.0.1\e[0m\n\e[0m
+           Failed to use "decimal" (version 0.0.1) because
+             ex_plex (version 0.1.0) requires ~> 0.1.0
+             mix.lock specifies 0.0.1\n
            """
 
     locked = [decimal: "0.0.1"]
     deps = [decimal: "~> 0.0.1", ex_plex: "0.1.0"]
 
     assert resolve(deps, locked) == """
-           \e[4mFailed to use "decimal" (version 0.0.1) because\e[0m
-             \e[1mex_plex (version 0.1.0)\e[0m requires \e[31m~> 0.1.0\e[0m
-             \e[1mmix.lock\e[0m specifies \e[32m0.0.1\e[0m\n\e[0m
+           Failed to use "decimal" (version 0.0.1) because
+             ex_plex (version 0.1.0) requires ~> 0.1.0
+             mix.lock specifies 0.0.1\n
            """
   end
 
@@ -244,9 +244,9 @@ defmodule Hex.ResolverTest do
     deps = [beta: "~> 1.0 and > 1.0.0"]
 
     assert resolve(deps) == """
-           \e[4mFailed to use "beta" because there are no packages that matches the requirement\e[0m
-             \e[1mmix.exs\e[0m specifies \e[31m~> 1.0 and > 1.0.0\e[0m *
-           \e[0m
+           Failed to use "beta" because there are no packages that matches the requirement
+             mix.exs specifies ~> 1.0 and > 1.0.0 *
+
            * This requirement does not match pre-releases. To match pre-releases include a pre-release in the requirement, such as: \"~> 2.0-beta\".\n
            """
 
@@ -258,9 +258,9 @@ defmodule Hex.ResolverTest do
     deps = [decimal: "~> 0.0.1", ex_plex: "0.2.0"]
 
     assert resolve(deps, []) == """
-           \e[4mFailed to use "decimal" (version 0.0.1) because\e[0m
-             \e[1mex_plex (version 0.2.0)\e[0m requires \e[31m~> 0.2.0\e[0m
-             \e[1mmix.exs\e[0m specifies \e[32m~> 0.0.1\e[0m\n\e[0m
+           Failed to use "decimal" (version 0.0.1) because
+             ex_plex (version 0.2.0) requires ~> 0.2.0
+             mix.exs specifies ~> 0.0.1\n
            """
   end
 
@@ -289,9 +289,9 @@ defmodule Hex.ResolverTest do
     deps = [{:repo2, :repo2_deps, ">= 0.0.0"}, {:hexpm, :phoenix, ">= 0.0.0"}]
 
     assert assert resolve(deps, [], %{"repos_deps" => "repo2", "phoenix" => "hexpm"}) == """
-                  \e[4mFailed to use \"poison\" because\e[0m
-                    \e[1mphoenix\e[0m requires repo \e[31mhexpm\e[0m
-                    \e[1mrepo2_deps\e[0m requires repo \e[31mrepo2\e[0m\n\e[0m
+                  Failed to use \"poison\" because
+                    phoenix requires repo hexpm
+                    repo2_deps requires repo repo2\n
                   """
   end
 

--- a/test/mix/tasks/hex.docs_test.exs
+++ b/test/mix/tasks/hex.docs_test.exs
@@ -177,7 +177,8 @@ defmodule Mix.Tasks.Hex.DocsTest do
       fetched_msg = "Docs fetched: #{docs_home}/#{org_dir}/#{package}/#{latest_version}"
       browser_open_msg = "#{docs_home}/#{org_dir}/#{package}/#{latest_version}/index.html"
       assert_received {:mix_shell, :info, [^fetched_msg]}
-      assert_received {:hex_system_cmd, _cmd, [^browser_open_msg]}
+      assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
+      assert Enum.fetch!(browser_open_cmd, -1) == browser_open_msg
     end)
   end
 
@@ -195,7 +196,8 @@ defmodule Mix.Tasks.Hex.DocsTest do
       fetched_msg = "Docs fetched: #{docs_home}/#{org_dir}/#{package}/#{version}"
       browser_open_msg = "#{docs_home}/#{org_dir}/#{package}/#{version}/index.html"
       assert_received {:mix_shell, :info, [^fetched_msg]}
-      assert_received {:hex_system_cmd, _cmd, [^browser_open_msg]}
+      assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
+      assert Enum.fetch!(browser_open_cmd, -1) == browser_open_msg
 
       Mix.Tasks.Hex.Docs.run(["fetch", package, version])
       already_fetched_msg = "Docs already fetched: #{docs_home}/#{org_dir}/#{package}/#{version}"
@@ -219,7 +221,8 @@ defmodule Mix.Tasks.Hex.DocsTest do
 
       Mix.Tasks.Hex.Docs.run(["offline", package, version])
       browser_open_msg = "#{docs_home}/#{package}/#{version}/index.html"
-      assert_received {:hex_system_cmd, _cmd, [^browser_open_msg]}
+      assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
+      assert Enum.fetch!(browser_open_cmd, -1) == browser_open_msg
     end)
   end
 
@@ -238,7 +241,8 @@ defmodule Mix.Tasks.Hex.DocsTest do
 
   test "open docs online" do
     Mix.Tasks.Hex.Docs.run(["online", "ecto"])
-    assert_received {:hex_system_cmd, _cmd, ["https://hexdocs.pm/ecto"]}
+    assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
+    assert Enum.fetch!(browser_open_cmd, -1) == "https://hexdocs.pm/ecto"
   end
 
   test "open the version of a package this app uses online" do
@@ -248,7 +252,8 @@ defmodule Mix.Tasks.Hex.DocsTest do
     in_tmp("docs", fn ->
       Mix.Dep.Lock.write(%{docs_package: {:hex, :docs_package, "1.1.1"}})
       Mix.Tasks.Hex.Docs.run(["online", "docs_package"])
-      assert_received {:hex_system_cmd, _cmd, ["https://hexdocs.pm/docs_package/1.1.1"]}
+      assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
+      assert Enum.fetch!(browser_open_cmd, -1) == "https://hexdocs.pm/docs_package/1.1.1"
     end)
   end
 
@@ -259,7 +264,8 @@ defmodule Mix.Tasks.Hex.DocsTest do
     in_tmp("docs", fn ->
       Mix.Dep.Lock.write(%{docs_package: {:hex, :docs_package, "1.1.1"}})
       Mix.Tasks.Hex.Docs.run(["online", "docs_package", "--latest"])
-      assert_received {:hex_system_cmd, _cmd, ["https://hexdocs.pm/docs_package"]}
+      assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
+      assert Enum.fetch!(browser_open_cmd, -1) == "https://hexdocs.pm/docs_package"
     end)
   end
 
@@ -277,7 +283,8 @@ defmodule Mix.Tasks.Hex.DocsTest do
       fetched_msg = "Docs fetched: #{docs_home}/hexpm/#{package}/#{version}"
       browser_open_msg = "#{docs_home}/hexpm/#{package}/#{version}/index.html"
       assert_received {:mix_shell, :info, [^fetched_msg]}
-      assert_received {:hex_system_cmd, _cmd, [^browser_open_msg]}
+      assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
+      assert Enum.fetch!(browser_open_cmd, -1) == browser_open_msg
       assert File.exists?("#{docs_home}/hexpm/#{package}/#{version}")
     end)
   end

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -78,6 +78,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     end
   end
 
+  @tag ansi_enabled: true
   test "outdated" do
     Mix.Project.push(OutdatedDeps.MixProject)
 

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -310,7 +310,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       send(self(), {:mix_shell_input, :prompt, "hunter42"})
       Mix.Tasks.Hex.Publish.run(["package", "--no-progress"])
 
-      message = "Publishing package to \e[1mprivate\e[0m repository myorg."
+      message = "Publishing package to **private** repository myorg."
       assert_received {:mix_shell, :info, [^message]}
 
       assert_received {:mix_shell, :info, ["Package published to myrepo html_url" <> _]}
@@ -346,7 +346,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       send(self(), {:mix_shell_input, :prompt, "hunter42"})
       Mix.Tasks.Hex.Publish.run(["package", "--no-progress", "--organization", "myorg2"])
 
-      message = "Publishing package to \e[1mprivate\e[0m repository myorg2."
+      message = "Publishing package to **private** repository myorg2."
       assert_received {:mix_shell, :info, [^message]}
 
       assert_received {:mix_shell, :info, ["Package published to myrepo html_url" <> _]}

--- a/test/mix/tasks/hex.search_test.exs
+++ b/test/mix/tasks/hex.search_test.exs
@@ -4,8 +4,8 @@ defmodule Mix.Tasks.Hex.SearchTest do
 
   test "search" do
     Mix.Tasks.Hex.Search.run(["doc"])
-    assert_received {:mix_shell, :info, ["ex_doc\e[0m" <> ex_doc]}
-    assert_received {:mix_shell, :info, ["only_doc\e[0m" <> only_doc]}
+    assert_received {:mix_shell, :info, ["ex_doc" <> ex_doc]}
+    assert_received {:mix_shell, :info, ["only_doc" <> only_doc]}
     assert ex_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/ex_doc"
     assert only_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/only_doc"
   end
@@ -29,8 +29,8 @@ defmodule Mix.Tasks.Hex.SearchTest do
       send(self(), {:mix_shell_input, :prompt, "hunter42"})
       Mix.Tasks.Hex.Search.run(["doc"])
 
-      assert_received {:mix_shell, :info, ["ex_doc\e[0m" <> ex_doc]}
-      assert_received {:mix_shell, :info, ["only_doc\e[0m" <> only_doc]}
+      assert_received {:mix_shell, :info, ["ex_doc" <> ex_doc]}
+      assert_received {:mix_shell, :info, ["only_doc" <> only_doc]}
       assert ex_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/ex_doc"
       assert only_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/only_doc"
     end)

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -37,12 +37,25 @@ defmodule HexTest.Case do
     Path.join(fixture_path(), extension)
   end
 
+  defp escape_path(path) do
+    case :os.type() do
+      {:win32, _} -> String.replace(path, ~R'[~#%&*{}\\:<>?/+|"]', "_")
+      _ -> path
+    end
+  end
+
   defmacro test_name do
-    Path.join(["#{__CALLER__.module}", "#{elem(__CALLER__.function, 0)}"])
+    module = escape_path("#{__CALLER__.module}")
+    function = escape_path("#{elem(__CALLER__.function, 0)}")
+
+    Path.join([module, function])
   end
 
   defmacro in_tmp(fun) do
-    path = Path.join(["#{__CALLER__.module}", "#{elem(__CALLER__.function, 0)}"])
+    module = escape_path("#{__CALLER__.module}")
+    function = escape_path("#{elem(__CALLER__.function, 0)}")
+
+    path = Path.join([module, function])
 
     quote do
       in_tmp(unquote(path), unquote(fun))

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -264,6 +264,11 @@ defmodule HexTest.Case do
       Mix.ProjectStack.clear_stack()
     end
 
+    if context[:ansi_enabled] do
+      Application.put_env(:elixir, :ansi_enabled, true)
+      on_exit(fn -> Application.put_env(:elixir, :ansi_enabled, false) end)
+    end
+
     :ok
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,6 +11,8 @@ File.mkdir_p!(Case.tmp_path())
 
 Case.reset_state()
 
+Application.put_env(:elixir, :ansi_enabled, false)
+
 # Set up package fixtures
 unless :integration in ExUnit.configuration()[:exclude] do
   Hexpm.init()


### PR DESCRIPTION
So first a fix to the test that was broken by the hex.docs open fix.
Second a fix to the resolver tests where Elixir thinks ANSI is unsupported.

There's still 9 test failures, all in the integration suite.  See https://github.com/hexpm/hex/issues/525 for details.