### PR TITLE
Adding support for custom CA file (#146)

### DIFF
--- a/lib/hex/http/certs.ex
+++ b/lib/hex/http/certs.ex
@@ -1,19 +1,14 @@
 defmodule Hex.HTTP.Certs do
+  crt_file = Path.join(__DIR__, "ca-bundle.crt")
+  crt = File.read!(crt_file)
+
+  pems = :public_key.pem_decode(crt)
+  ders = Enum.map(pems, fn {:Certificate, der, _} -> der end)
+
+  @der_encoded ders
+  @external_resource crt_file
+
   def cacerts do
-    case Hex.State.fetch(:ders) do
-      {:ok, value} -> value
-      :error -> decode_and_store_ca_certs()
-    end
-  end
-
-  defp decode_and_store_ca_certs() do
-    crt_file = Hex.State.fetch!(:cafile)
-    crt = File.read!(crt_file)
-
-    pems = :public_key.pem_decode(crt)
-    ders = Enum.map(pems, fn {:Certificate, der, _} -> der end)
-
-    Hex.State.put(:ders, ders)
-    ders
+    @der_encoded
   end
 end

--- a/lib/hex/http/certs.ex
+++ b/lib/hex/http/certs.ex
@@ -1,14 +1,19 @@
 defmodule Hex.HTTP.Certs do
-  crt_file = Path.join(__DIR__, "ca-bundle.crt")
-  crt = File.read!(crt_file)
-
-  pems = :public_key.pem_decode(crt)
-  ders = Enum.map(pems, fn {:Certificate, der, _} -> der end)
-
-  @der_encoded ders
-  @external_resource crt_file
-
   def cacerts do
-    @der_encoded
+    case Hex.State.fetch(:ders) do
+      {:ok, value} -> value
+      :error -> decode_and_store_ca_certs()
+    end
+  end
+
+  defp decode_and_store_ca_certs() do
+    crt_file = Hex.State.fetch!(:cafile)
+    crt = File.read!(crt_file)
+
+    pems = :public_key.pem_decode(crt)
+    ders = Enum.map(pems, fn {:Certificate, der, _} -> der end)
+
+    Hex.State.put(:ders, ders)
+    ders
   end
 end

--- a/lib/hex/http/ssl.ex
+++ b/lib/hex/http/ssl.ex
@@ -26,6 +26,13 @@ defmodule Hex.HTTP.SSL do
 
   @secure_ssl_version {5, 3, 7}
 
+  @common_ssl_opts [
+    secure_renegotiate: true,
+    reuse_sessions: true,
+    honor_cipher_order: true,
+    versions: @default_versions
+  ]
+
   Record.defrecordp(
     :certificate,
     :OTPCertificate,
@@ -52,14 +59,22 @@ defmodule Hex.HTTP.SSL do
     check?
   end
 
+  def custom_cafile? do
+    Hex.State.get(:custom_cafile) != nil
+  end
+
   def ssl_opts(url) do
     hostname = Hex.string_to_charlist(URI.parse(url).host)
     ciphers = filter_ciphers(@default_ciphers)
 
-    if secure_ssl?() do
-      verify_fun = {&VerifyHostname.verify_fun/3, check_hostname: hostname}
-      partial_chain = &partial_chain(Certs.cacerts(), &1)
+    ssl_opts(hostname, ciphers, secure_ssl?(), custom_cafile?())
+  end
 
+  defp ssl_opts(hostname, ciphers, true, false) do
+    verify_fun = {&VerifyHostname.verify_fun/3, check_hostname: hostname}
+    partial_chain = &partial_chain(Certs.cacerts(), &1)
+
+    @common_ssl_opts ++
       [
         verify: :verify_peer,
         depth: 4,
@@ -67,23 +82,32 @@ defmodule Hex.HTTP.SSL do
         cacerts: Certs.cacerts(),
         verify_fun: verify_fun,
         server_name_indication: hostname,
-        secure_renegotiate: true,
-        reuse_sessions: true,
-        honor_cipher_order: true,
-        versions: @default_versions,
         ciphers: ciphers
       ]
-    else
+  end
+
+  defp ssl_opts(hostname, ciphers, true, true) do
+    verify_fun = {&VerifyHostname.verify_fun/3, check_hostname: hostname}
+    cacertfile = Hex.State.fetch!(:custom_cafile)
+
+    @common_ssl_opts ++
+      [
+        verify: :verify_peer,
+        depth: 4,
+        cacertfile: cacertfile,
+        verify_fun: verify_fun,
+        server_name_indication: hostname,
+        ciphers: ciphers
+      ]
+  end
+
+  defp ssl_opts(hostname, ciphers, _verify, _custom_cafile) do
+    @common_ssl_opts ++
       [
         verify: :verify_none,
         server_name_indication: hostname,
-        secure_renegotiate: true,
-        reuse_sessions: true,
-        honor_cipher_order: true,
-        versions: @default_versions,
         ciphers: ciphers
       ]
-    end
   end
 
   def partial_chain(cacerts, certs) do

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -4,7 +4,6 @@ defmodule Hex.State do
   @logged_keys ~w(http_proxy HTTP_PROXY https_proxy HTTPS_PROXY)
   @default_home "~/.hex"
   @pbkdf2_iters 32_768
-  @default_cafile Path.join(__DIR__, "http/ca-bundle.crt")
 
   def start_link() do
     config = Hex.Config.read()
@@ -51,7 +50,7 @@ defmodule Hex.State do
       pbkdf2_iters: @pbkdf2_iters,
       repos: Hex.Config.read_repos(config),
       ssl_version: ssl_version(),
-      cafile: load_config(config, ["HEX_CAFILE"], [:cafile]) |> default(@default_cafile)
+      custom_cafile: load_config(config, ["HEX_CAFILE"], [:cafile])
     }
   end
 

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -4,6 +4,7 @@ defmodule Hex.State do
   @logged_keys ~w(http_proxy HTTP_PROXY https_proxy HTTPS_PROXY)
   @default_home "~/.hex"
   @pbkdf2_iters 32_768
+  @default_cafile Path.join(__DIR__, "http/ca-bundle.crt")
 
   def start_link() do
     config = Hex.Config.read()
@@ -49,7 +50,8 @@ defmodule Hex.State do
       offline?: load_config(config, ["HEX_OFFLINE"], [:offline]) |> to_boolean() |> default(false),
       pbkdf2_iters: @pbkdf2_iters,
       repos: Hex.Config.read_repos(config),
-      ssl_version: ssl_version()
+      ssl_version: ssl_version(),
+      cafile: load_config(config, ["HEX_CAFILE"], [:cafile]) |> default(@default_cafile)
     }
   end
 

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -32,6 +32,8 @@ defmodule Mix.Tasks.Hex.Config do
       `HEX_HTTP_CONCURRENCY` (Default: `8`)
     * `http_timeout` - Sets the timeout for HTTP requests in seconds. Can be
       overridden by setting the environment variable `HEX_HTTP_TIMEOUT`
+    * `cafile` - Use a custom cafile instead of the default ca shipped with hex.
+      Can be overriden by setting the environment variable `HEX_CAFILE`
 
   `HEX_HOME` environment variable can be set to point to the directory where Hex
   stores the cache and configuration (Default: `~/.hex`)


### PR DESCRIPTION
When working in a corporate environment, sometimes someone decides that we are not to be trusted,
and force a https proxy into the network, enabling monitoring of all traffic.