### PR TITLE
hex.info documentation fix

### DIFF
--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -14,8 +14,8 @@ defmodule Mix.Tasks.Hex.Info do
   If `package` is given, print information about the package. This includes all
   released versions and package metadata.
 
-  If `package` and `version` is given print release information. This includes
-  remote Git URL and Git ref, and all package dependencies.
+  If `package` and `version` is given, print release information. This includes
+  remote Git URL and Git ref, as well as all package dependencies.
 
   ## Command line options
 
@@ -103,7 +103,7 @@ defmodule Mix.Tasks.Hex.Info do
     stable_active_releases =
       Enum.filter(
         releases,
-        &(Hex.Version.stable?(&1["version"]) and not(&1["version"] in retirements))
+        &(Hex.Version.stable?(&1["version"]) and not (&1["version"] in retirements))
       )
 
     List.first(stable_active_releases) || List.first(releases)

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -14,8 +14,7 @@ defmodule Mix.Tasks.Hex.Info do
   If `package` is given, print information about the package. This includes all
   released versions and package metadata.
 
-  If `package` and `version` is given, print release information. This includes
-  remote Git URL and Git ref, as well as all package dependencies.
+  If `package` and `version` is given, print release information.
 
   ## Command line options
 


### PR DESCRIPTION
The documentation at the top of hex.info had a missing comma, and I tried to clarify the docs when package and version are given.