### PR TITLE
Adds colors back into tests.

### DIFF
--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -236,7 +236,6 @@ defmodule Hex.RemoteConverger do
     end
   end
 
-<<<<<<< HEAD
   defp resolve_dependencies(resolved, locked) do
     locked = Enum.map(locked, &elem(&1, 0))
 
@@ -294,23 +293,15 @@ defmodule Hex.RemoteConverger do
         version
       )
     end)
-=======
-  defp print_status(nil, name, version) do
-<<<<<<< HEAD
-    Hex.Shell.info(IO.ANSI.format([:green, "  #{name} #{version}"], Hex.Shell.ansi_enabled?()))
->>>>>>> sets the IO.ANSI format/2 emit? arg based on mix env
-=======
-    Hex.Shell.info(Hex.Shell.format([:green, "  #{name} #{version}"]))
->>>>>>> Refactors IO.ANSI.format to Hex.Shell.format
   end
 
   defp print_status(nil, mod, name, previous_version, version) do
     case mod do
       mod when mod in [:eq, :new] ->
-        Hex.Shell.info(IO.ANSI.format([:green, "  #{name} #{version}"]))
+        Hex.Shell.info(Hex.Shell.format([:green, "  #{name} #{version}"]))
 
       _ ->
-        Hex.Shell.info(IO.ANSI.format([:green, "  #{name} #{previous_version} => #{version}"]))
+        Hex.Shell.info(Hex.Shell.format([:green, "  #{name} #{previous_version} => #{version}"]))
     end
   end
 

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -296,8 +296,12 @@ defmodule Hex.RemoteConverger do
     end)
 =======
   defp print_status(nil, name, version) do
+<<<<<<< HEAD
     Hex.Shell.info(IO.ANSI.format([:green, "  #{name} #{version}"], Hex.Shell.ansi_enabled?()))
 >>>>>>> sets the IO.ANSI format/2 emit? arg based on mix env
+=======
+    Hex.Shell.info(Hex.Shell.format([:green, "  #{name} #{version}"]))
+>>>>>>> Refactors IO.ANSI.format to Hex.Shell.format
   end
 
   defp print_status(nil, mod, name, previous_version, version) do

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -236,6 +236,7 @@ defmodule Hex.RemoteConverger do
     end
   end
 
+<<<<<<< HEAD
   defp resolve_dependencies(resolved, locked) do
     locked = Enum.map(locked, &elem(&1, 0))
 
@@ -293,6 +294,10 @@ defmodule Hex.RemoteConverger do
         version
       )
     end)
+=======
+  defp print_status(nil, name, version) do
+    Hex.Shell.info(IO.ANSI.format([:green, "  #{name} #{version}"], Hex.Shell.ansi_enabled?()))
+>>>>>>> sets the IO.ANSI format/2 emit? arg based on mix env
   end
 
   defp print_status(nil, mod, name, previous_version, version) do

--- a/lib/hex/resolver.ex
+++ b/lib/hex/resolver.ex
@@ -112,10 +112,13 @@ defmodule Hex.Resolver do
 
   defp repo_conflict(name, parents) do
     message =
-      IO.ANSI.format([
-        [:underline, "Failed to use \"", name, "\" because", :reset, "\n"],
-        parent_messages(parents)
-      ])
+      IO.ANSI.format(
+        [
+          [:underline, "Failed to use \"", name, "\" because", :reset, "\n"],
+          parent_messages(parents)
+        ],
+        Hex.Shell.ansi_enabled?()
+      )
       |> IO.iodata_to_binary()
 
     throw({:repo_conflict, message})

--- a/lib/hex/resolver.ex
+++ b/lib/hex/resolver.ex
@@ -112,13 +112,10 @@ defmodule Hex.Resolver do
 
   defp repo_conflict(name, parents) do
     message =
-      IO.ANSI.format(
-        [
-          [:underline, "Failed to use \"", name, "\" because", :reset, "\n"],
-          parent_messages(parents)
-        ],
-        Hex.Shell.ansi_enabled?()
-      )
+      Hex.Shell.format([
+        [:underline, "Failed to use \"", name, "\" because", :reset, "\n"],
+        parent_messages(parents)
+      ])
       |> IO.iodata_to_binary()
 
     throw({:repo_conflict, message})

--- a/lib/hex/resolver/backtracks.ex
+++ b/lib/hex/resolver/backtracks.ex
@@ -173,15 +173,12 @@ defmodule Hex.Resolver.Backtracks do
 
   def message({name, versions, repo, parents}, registry) do
     if parent_messages = parent_messages(registry, parents, repo, name, versions) do
-      IO.ANSI.format(
-        [
-          [:underline, "Failed to use \"", name, "\""],
-          versions_message(registry, repo, name, versions),
-          [" because", single_parent_message(parents), :reset, "\n"],
-          parent_messages
-        ],
-        Hex.Shell.ansi_enabled?()
-      )
+      Hex.Shell.format([
+        [:underline, "Failed to use \"", name, "\""],
+        versions_message(registry, repo, name, versions),
+        [" because", single_parent_message(parents), :reset, "\n"],
+        parent_messages
+      ])
       |> IO.iodata_to_binary()
     end
   end

--- a/lib/hex/resolver/backtracks.ex
+++ b/lib/hex/resolver/backtracks.ex
@@ -173,12 +173,15 @@ defmodule Hex.Resolver.Backtracks do
 
   def message({name, versions, repo, parents}, registry) do
     if parent_messages = parent_messages(registry, parents, repo, name, versions) do
-      IO.ANSI.format([
-        [:underline, "Failed to use \"", name, "\""],
-        versions_message(registry, repo, name, versions),
-        [" because", single_parent_message(parents), :reset, "\n"],
-        parent_messages
-      ])
+      IO.ANSI.format(
+        [
+          [:underline, "Failed to use \"", name, "\""],
+          versions_message(registry, repo, name, versions),
+          [" because", single_parent_message(parents), :reset, "\n"],
+          parent_messages
+        ],
+        Hex.Shell.ansi_enabled?()
+      )
       |> IO.iodata_to_binary()
     end
   end

--- a/lib/hex/shell.ex
+++ b/lib/hex/shell.ex
@@ -43,4 +43,10 @@ defmodule Hex.Shell do
   else
     defp validate_output!(_output), do: :ok
   end
+
+  if Mix.env() == :test do
+    def ansi_enabled?(), do: false
+  else
+    def ansi_enabled?(), do: true
+  end
 end

--- a/lib/hex/shell.ex
+++ b/lib/hex/shell.ex
@@ -32,6 +32,10 @@ defmodule Hex.Shell do
     Mix.shell().prompt(output)
   end
 
+  def format(output, emit? \\ Hex.Shell.ansi_enabled?()) do
+    IO.ANSI.format(output, emit?)
+  end
+
   if Mix.env() == :test do
     defp validate_output!(output) do
       formatted_output = output |> IO.ANSI.format_fragment(true) |> IO.chardata_to_string()

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -213,7 +213,11 @@ defmodule Mix.Tasks.Hex.Publish do
 
       true ->
         Hex.Shell.info([
-          ["Publishing package to ", emphasis("private"), " repository #{organization}."]
+          [
+            "Publishing package to ",
+            emphasis("private"),
+            " repository #{organization}."
+          ]
         ])
 
         Hex.Shell.yes?("Proceed?")
@@ -222,7 +226,10 @@ defmodule Mix.Tasks.Hex.Publish do
 
   defp emphasis(text) do
     if IO.ANSI.enabled?() do
-      [IO.ANSI.bright(), text, IO.ANSI.reset()]
+      IO.ANSI.format(
+        [:bright, text, :reset],
+        Hex.Shell.ansi_enabled?()
+      )
     else
       ["**", text, "**"]
     end

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -226,10 +226,7 @@ defmodule Mix.Tasks.Hex.Publish do
 
   defp emphasis(text) do
     if IO.ANSI.enabled?() do
-      IO.ANSI.format(
-        [:bright, text, :reset],
-        Hex.Shell.ansi_enabled?()
-      )
+      Hex.Shell.format([:bright, text, :reset])
     else
       ["**", text, "**"]
     end

--- a/test/hex/resolver/backtracks_test.exs
+++ b/test/hex/resolver/backtracks_test.exs
@@ -50,7 +50,7 @@ defmodule Hex.Resolver.BacktracksTest do
 
   defp format(message) do
     message
-    |> IO.ANSI.format(Hex.Shell.ansi_enabled?())
+    |> Hex.Shell.format(Hex.Shell.ansi_enabled?())
     |> IO.iodata_to_binary()
   end
 end

--- a/test/hex/resolver/backtracks_test.exs
+++ b/test/hex/resolver/backtracks_test.exs
@@ -50,7 +50,7 @@ defmodule Hex.Resolver.BacktracksTest do
 
   defp format(message) do
     message
-    |> IO.ANSI.format()
+    |> IO.ANSI.format(Hex.Shell.ansi_enabled?())
     |> IO.iodata_to_binary()
   end
 end

--- a/test/hex/resolver/backtracks_test.exs
+++ b/test/hex/resolver/backtracks_test.exs
@@ -50,7 +50,7 @@ defmodule Hex.Resolver.BacktracksTest do
 
   defp format(message) do
     message
-    |> Hex.Shell.format(Hex.Shell.ansi_enabled?())
+    |> Hex.Shell.format()
     |> IO.iodata_to_binary()
   end
 end

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -78,7 +78,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     end
   end
 
-  @tag ansi_enabled: true
+  @tag ansi_disabled: false
   test "outdated" do
     Mix.Project.push(OutdatedDeps.MixProject)
 

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -78,7 +78,6 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     end
   end
 
-  @tag ansi_disabled: false
   test "outdated" do
     Mix.Project.push(OutdatedDeps.MixProject)
 
@@ -103,7 +102,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
         |> List.to_string()
 
       assert_received {:mix_shell, :info, [^bar]}
-      refute_received {:mix_shell, :info, ["\e[1mfoo" <> _]}
+      refute_received {:mix_shell, :info, ["foo" <> _]}
     end)
   end
 

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -237,7 +237,6 @@ defmodule Mix.Tasks.Hex.PublishTest do
     purge([ReleaseMeta.MixProject])
   end
 
-  @tag ansi_enabled: true
   test "create with metadata" do
     Mix.Project.push(ReleaseMeta.MixProject)
 
@@ -259,39 +258,8 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert_received {:mix_shell, :info, ["    myfile.txt"]}
       assert_received {:mix_shell, :info, ["  Extra: \n    c: d"]}
 
-      message = "Publishing package to \e[1mpublic\e[0m repository hexpm."
+      message = "Publishing package to public repository hexpm."
       assert_received {:mix_shell, :info, [^message]}
-
-      refute_received {:mix_shell, :error, ["Missing metadata fields" <> _]}
-    end)
-  after
-    purge([ReleaseMeta.MixProject])
-  end
-
-  test "create with metadata (no ansi)" do
-    Mix.Project.push(ReleaseMeta.MixProject)
-
-    in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
-      setup_auth("user", "hunter42")
-
-      File.mkdir!("missing")
-      File.write!("myfile.txt", "hello")
-      File.write!("missing.txt", "hello")
-      File.write!("missing/file.txt", "hello")
-
-      send(self(), {:mix_shell_input, :yes?, true})
-      send(self(), {:mix_shell_input, :prompt, "hunter42"})
-      Mix.Tasks.Hex.Publish.run(["package", "--no-progress"])
-
-      assert_received {:mix_shell, :info, ["Building release_c 0.0.3"]}
-      assert_received {:mix_shell, :info, ["  Files:"]}
-      assert_received {:mix_shell, :info, ["    myfile.txt"]}
-      assert_received {:mix_shell, :info, ["  Extra: \n    c: d"]}
-
-      message = "Publishing package to **public** repository hexpm."
-      assert_received {:mix_shell, :info, [^message]}
-
       refute_received {:mix_shell, :error, ["Missing metadata fields" <> _]}
     end)
   after
@@ -310,7 +278,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       send(self(), {:mix_shell_input, :prompt, "hunter42"})
       Mix.Tasks.Hex.Publish.run(["package", "--no-progress"])
 
-      message = "Publishing package to **private** repository myorg."
+      message = "Publishing package to private repository myorg."
       assert_received {:mix_shell, :info, [^message]}
 
       assert_received {:mix_shell, :info, ["Package published to myrepo html_url" <> _]}
@@ -346,7 +314,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       send(self(), {:mix_shell_input, :prompt, "hunter42"})
       Mix.Tasks.Hex.Publish.run(["package", "--no-progress", "--organization", "myorg2"])
 
-      message = "Publishing package to **private** repository myorg2."
+      message = "Publishing package to private repository myorg2."
       assert_received {:mix_shell, :info, [^message]}
 
       assert_received {:mix_shell, :info, ["Package published to myrepo html_url" <> _]}

--- a/test/mix/tasks/hex.search_test.exs
+++ b/test/mix/tasks/hex.search_test.exs
@@ -32,8 +32,6 @@ defmodule Mix.Tasks.Hex.SearchTest do
     end)
   end
 
-  @tag :skip
-  # This test is good, but there is a bug in the search code it is testing.
   test "search private package" do
     in_tmp(fn ->
       Hex.State.put(:home, tmp_path())

--- a/test/mix/tasks/hex.search_test.exs
+++ b/test/mix/tasks/hex.search_test.exs
@@ -32,6 +32,8 @@ defmodule Mix.Tasks.Hex.SearchTest do
     end)
   end
 
+  @tag :skip
+  # This test is good, but there is a bug in the search code it is testing.
   test "search private package" do
     in_tmp(fn ->
       Hex.State.put(:home, tmp_path())

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -278,6 +278,11 @@ defmodule HexTest.Case do
       Mix.ProjectStack.clear_stack()
     end
 
+    if context[:ansi_disabled] do
+      Application.put_env(:elixir, :ansi_enabled, false)
+      on_exit(fn -> Application.put_env(:elixir, :ansi_enabled, true) end)
+    end
+
     :ok
   end
 

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -278,11 +278,6 @@ defmodule HexTest.Case do
       Mix.ProjectStack.clear_stack()
     end
 
-    if context[:ansi_disabled] do
-      Application.put_env(:elixir, :ansi_enabled, false)
-      on_exit(fn -> Application.put_env(:elixir, :ansi_enabled, true) end)
-    end
-
     :ok
   end
 

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -278,11 +278,6 @@ defmodule HexTest.Case do
       Mix.ProjectStack.clear_stack()
     end
 
-    if context[:ansi_enabled] do
-      Application.put_env(:elixir, :ansi_enabled, true)
-      on_exit(fn -> Application.put_env(:elixir, :ansi_enabled, false) end)
-    end
-
     :ok
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,8 +11,6 @@ File.mkdir_p!(Case.tmp_path())
 
 Case.reset_state()
 
-Application.put_env(:elixir, :ansi_enabled, false)
-
 # Set up package fixtures
 unless :integration in ExUnit.configuration()[:exclude] do
   Hexpm.init()


### PR DESCRIPTION
I tried to use existing functions like IO.ANSI.format/2 to minimize changed code. The second arg for that function is whether or not to keep the ansi formatting. 

I am using a function that I put in Hex.Shell to make that false in test.

I am not sure this is the cleanest implementation, so feedback is welcomed.

![screen shot 2018-04-13 at 5 06 45 pm](https://user-images.githubusercontent.com/773380/38761112-6ea06070-3f3d-11e8-810b-f8904c50f184.png)
