### PR TITLE
Show more detailed message when fetch times out

### DIFF
--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -310,11 +310,12 @@ defmodule Hex.SCM do
           {:error, "Request failed (#{code})"}
 
         {:error, :timeout} ->
-          reason = """
-          Request failed (:timeout)
-          If this happens consistently, adjust your concurrency and timeout settings:
-          `HEX_HTTP_CONCURRENCY=1 HEX_HTTP_TIMEOUT=120 mix deps.get`.
-          """
+          reason = [
+            "Request failed (:timeout)",
+            :reset,
+            "\nIf this happens consistently, adjust your concurrency and timeout settings:",
+            "\n`HEX_HTTP_CONCURRENCY=1 HEX_HTTP_TIMEOUT=120 mix deps.get`."
+          ]
 
           {:error, reason}
 

--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -309,6 +309,15 @@ defmodule Hex.SCM do
         {:ok, {code, _body, _headers}} ->
           {:error, "Request failed (#{code})"}
 
+        {:error, :timeout} ->
+          reason = """
+          Request failed (:timeout)
+          If this happens consistently, adjust your concurrency and timeout settings:
+          `HEX_HTTP_CONCURRENCY=1 HEX_HTTP_TIMEOUT=120 mix deps.get`.
+          """
+
+          {:error, reason}
+
         {:error, reason} ->
           {:error, "Request failed (#{inspect(reason)})"}
       end

--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -314,7 +314,7 @@ defmodule Hex.SCM do
             "Request failed (:timeout)",
             :reset,
             "\nIf this happens consistently, adjust your concurrency and timeout settings:",
-            "\n`HEX_HTTP_CONCURRENCY=1 HEX_HTTP_TIMEOUT=120 mix deps.get`."
+            "\n\n    HEX_HTTP_CONCURRENCY=1 HEX_HTTP_TIMEOUT=120 mix deps.get"
           ]
 
           {:error, reason}


### PR DESCRIPTION
This is in response to https://github.com/hexpm/hex/issues/540

I thought we could offer a little more detail in the error message since it seems like it happens fairly regularly to people with poor connectivity. I would like to get feedback on the idea in general and the message itself.

The first commit is very red and bold.
The second commit puts the support message in regular text.

Also, does anyone know how to write a good test for this ?

First commit:
![screen shot 2018-04-15 at 10 48 13 am](https://user-images.githubusercontent.com/773380/38780930-eb0129b6-409a-11e8-9b6a-0f67c0434ba2.png)

Second commit:
![screen shot 2018-04-15 at 7 43 57 pm](https://user-images.githubusercontent.com/773380/38786481-88b70b04-40e5-11e8-895f-2a5174f944e7.png)

