### PR TITLE
Adds new task to generate unencrypted key

### DIFF
--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -32,7 +32,7 @@ defmodule Hex.State do
         |> default(false)
         |> Kernel.not(),
       clean_pass: true,
-      hex_api_key: load_config(config, ["HEX_API_KEY"], [:"$unencrypted_key"]),
+      hex_api_key: load_config(config, ["HEX_API_KEY"], [:hex_api_key]),
       http_concurrency:
         load_config(config, ["HEX_HTTP_CONCURRENCY"], [:http_concurrency])
         |> to_integer()

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -17,6 +17,7 @@ defmodule Hex.State do
   def init(config) do
     %{
       api_key: load_config(config, [], [:"$encrypted_key", :encrypted_key]),
+      api_key_unencrypted: load_config(config, ["HEX_API_KEY"], [:api_key_unencrypted]),
       api_url:
         load_config(config, ["HEX_API_URL", "HEX_API"], [:api_url])
         |> trim_slash()
@@ -32,7 +33,6 @@ defmodule Hex.State do
         |> default(false)
         |> Kernel.not(),
       clean_pass: true,
-      hex_api_key: load_config(config, ["HEX_API_KEY"], [:hex_api_key]),
       http_concurrency:
         load_config(config, ["HEX_HTTP_CONCURRENCY"], [:http_concurrency])
         |> to_integer()

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -32,6 +32,7 @@ defmodule Hex.State do
         |> default(false)
         |> Kernel.not(),
       clean_pass: true,
+      hex_api_key: load_config(config, ["HEX_API_KEY"], [:"$unencrypted_key"]),
       http_concurrency:
         load_config(config, ["HEX_HTTP_CONCURRENCY"], [:http_concurrency])
         |> to_integer()

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -32,6 +32,8 @@ defmodule Mix.Tasks.Hex.Config do
       `HEX_HTTP_CONCURRENCY` (Default: `8`)
     * `http_timeout` - Sets the timeout for HTTP requests in seconds. Can be
       overridden by setting the environment variable `HEX_HTTP_TIMEOUT`
+    * `hex_api_key` - Your unencrypted api key. Can be overridden by setting the
+      environment variable `HEX_API_KEY` (Default: nil)
 
   `HEX_HOME` environment variable can be set to point to the directory where Hex
   stores the cache and configuration (Default: `~/.hex`)

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -32,7 +32,7 @@ defmodule Mix.Tasks.Hex.Config do
       `HEX_HTTP_CONCURRENCY` (Default: `8`)
     * `http_timeout` - Sets the timeout for HTTP requests in seconds. Can be
       overridden by setting the environment variable `HEX_HTTP_TIMEOUT`
-    * `hex_api_key` - Your unencrypted api key. Can be overridden by setting the
+    * `api_key_unencrypted` - Your unencrypted api key. Can be overridden by setting the
       environment variable `HEX_API_KEY` (Default: nil)
 
   `HEX_HOME` environment variable can be set to point to the directory where Hex

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -76,10 +76,11 @@ defmodule Mix.Tasks.Hex do
                            "Hex requires you to have a local password that applies only to this machine for security " <>
                            "purposes. Please enter it."
 
-  def generate_api_key(username, password, key_name, encrypt? \\ true) do
+  def generate_api_key(username, password, opts) do
     Hex.Shell.info("Generating API key...")
     {:ok, name} = :inet.gethostname()
-    key_name = key_name || List.to_string(name)
+    key_name = opts[:key_name] || List.to_string(name)
+    encrypt? = is_nil(opts[:encrypt]) || opts[:encrypt]
 
     case Hex.API.Key.new(key_name, user: username, pass: password) do
       {:ok, {201, body, _}} ->
@@ -124,7 +125,7 @@ defmodule Mix.Tasks.Hex do
     password = password_get("Account password:") |> Hex.string_trim()
 
     unless opts[:skip_organizations] do
-      case generate_api_key(username, password, opts[:key_name]) do
+      case generate_api_key(username, password, key_name: opts[:key_name]) do
         {:ok, key, password} ->
           Hex.Shell.info("Generating organization keys...")
           auth = [key: key]

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -87,7 +87,7 @@ defmodule Mix.Tasks.Hex do
           Hex.Shell.info(@local_password_prompt)
           prompt_encrypt_key(body["secret"])
         else
-          body["secret"]
+          Hex.Shell.info(body["secret"])
         end
 
       other ->

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -76,15 +76,19 @@ defmodule Mix.Tasks.Hex do
                            "Hex requires you to have a local password that applies only to this machine for security " <>
                            "purposes. Please enter it."
 
-  def generate_api_key(username, password, key_name) do
+  def generate_api_key(username, password, key_name, encrypt? \\ true) do
     Hex.Shell.info("Generating API key...")
     {:ok, name} = :inet.gethostname()
     key_name = key_name || List.to_string(name)
 
     case Hex.API.Key.new(key_name, user: username, pass: password) do
       {:ok, {201, body, _}} ->
-        Hex.Shell.info(@local_password_prompt)
-        prompt_encrypt_key(body["secret"])
+        if encrypt? do
+          Hex.Shell.info(@local_password_prompt)
+          prompt_encrypt_key(body["secret"])
+        else
+          body["secret"]
+        end
 
       other ->
         Mix.shell().error("Generation of API key failed")

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -161,7 +161,7 @@ defmodule Mix.Tasks.Hex do
 
   def auth_info() do
     key = Hex.State.fetch!(:api_key)
-    hex_api_key = Hex.State.fetch!(:hex_api_key)
+    hex_api_key = Hex.State.fetch!(:api_key_unencrypted)
 
     cond do
       hex_api_key -> [key: hex_api_key]

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -160,7 +160,7 @@ defmodule Mix.Tasks.Hex do
 
   def auth_info() do
     key = Hex.State.fetch!(:api_key)
-    hex_api_key = System.get_env("HEX_API_KEY")
+    hex_api_key = Hex.State.fetch!(:hex_api_key)
 
     cond do
       hex_api_key -> [key: hex_api_key]

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -80,7 +80,7 @@ defmodule Mix.Tasks.Hex do
     Hex.Shell.info("Generating API key...")
     {:ok, name} = :inet.gethostname()
     key_name = opts[:key_name] || List.to_string(name)
-    encrypt? = is_nil(opts[:encrypt]) || opts[:encrypt]
+    encrypt? = Keyword.get(opts, :encrypt, true)
 
     case Hex.API.Key.new(key_name, user: username, pass: password) do
       {:ok, {201, body, _}} ->

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -160,11 +160,12 @@ defmodule Mix.Tasks.Hex do
 
   def auth_info() do
     key = Hex.State.fetch!(:api_key)
+    hex_api_key = System.get_env("HEX_API_KEY")
 
-    if key do
-      [key: prompt_decrypt_key(key)]
-    else
-      authenticate_inline()
+    cond do
+      hex_api_key -> [key: hex_api_key]
+      key -> [key: prompt_decrypt_key(key)]
+      true -> authenticate_inline()
     end
   end
 

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -193,7 +193,7 @@ defmodule Mix.Tasks.Hex.Publish do
   end
 
   defp proceed?(build, organization, opts) do
-    confirm? = Keyword.get(opts, :confirm, show_confirmation_default())
+    confirm? = Keyword.get(opts, :confirm, true)
     meta = build.meta
     exclude_deps = build.exclude_deps
     package = build.package
@@ -359,8 +359,6 @@ defmodule Mix.Tasks.Hex.Publish do
 
   defp progress_fun(true, size), do: Mix.Tasks.Hex.progress(size)
   defp progress_fun(false, _size), do: Mix.Tasks.Hex.progress(nil)
-
-  defp show_confirmation_default(), do: is_nil(System.get_env("HEX_API_KEY"))
 
   defp auth_info() do
     hex_api_key = System.get_env("HEX_API_KEY")

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -107,11 +107,11 @@ defmodule Mix.Tasks.Hex.Publish do
 
     case args do
       ["package"] when revert ->
-        auth = auth_info()
+        auth = Mix.Tasks.Hex.auth_info()
         revert_package(build, organization, revert_version, auth)
 
       ["docs"] when revert ->
-        auth = auth_info()
+        auth = Mix.Tasks.Hex.auth_info()
         revert_docs(build, organization, revert_version, auth)
 
       [] when revert ->
@@ -119,13 +119,13 @@ defmodule Mix.Tasks.Hex.Publish do
 
       ["package"] ->
         if proceed?(build, organization, opts) do
-          auth = auth_info()
+          auth = Mix.Tasks.Hex.auth_info()
           create_release(build, organization, auth, opts)
         end
 
       ["docs"] ->
         docs_task(build, opts)
-        auth = auth_info()
+        auth = Mix.Tasks.Hex.auth_info()
         create_docs(build, organization, auth, opts)
 
       [] ->
@@ -146,7 +146,7 @@ defmodule Mix.Tasks.Hex.Publish do
     if proceed?(build, organization, opts) do
       Hex.Shell.info("Building docs...")
       docs_task(build, opts)
-      auth = auth_info()
+      auth = Mix.Tasks.Hex.auth_info()
       Hex.Shell.info("Publishing package...")
 
       if :ok == create_release(build, organization, auth, opts) do
@@ -240,7 +240,7 @@ defmodule Mix.Tasks.Hex.Publish do
   end
 
   defp revert(build, organization, version) do
-    auth = auth_info()
+    auth = Mix.Tasks.Hex.auth_info()
     Hex.Shell.info("Reverting package...")
     revert_package(build, organization, version, auth)
     Hex.Shell.info("Reverting docs...")
@@ -359,14 +359,4 @@ defmodule Mix.Tasks.Hex.Publish do
 
   defp progress_fun(true, size), do: Mix.Tasks.Hex.progress(size)
   defp progress_fun(false, _size), do: Mix.Tasks.Hex.progress(nil)
-
-  defp auth_info() do
-    hex_api_key = System.get_env("HEX_API_KEY")
-
-    if hex_api_key do
-      [key: hex_api_key]
-    else
-      Mix.Tasks.Hex.auth_info()
-    end
-  end
 end

--- a/lib/mix/tasks/hex.user.ex
+++ b/lib/mix/tasks/hex.user.ex
@@ -315,6 +315,6 @@ defmodule Mix.Tasks.Hex.User do
     # get key from API
     username = Hex.Shell.prompt("Username:") |> Hex.string_trim()
     password = Mix.Tasks.Hex.password_get("Account password:") |> Hex.string_trim()
-    Hex.Shell.info(Mix.Tasks.Hex.generate_api_key(username, password, nil, false))
+    Mix.Tasks.Hex.generate_api_key(username, password, nil, false)
   end
 end

--- a/lib/mix/tasks/hex.user.ex
+++ b/lib/mix/tasks/hex.user.ex
@@ -150,7 +150,7 @@ defmodule Mix.Tasks.Hex.User do
         list_keys()
 
       opts[:generate] ->
-        generate_unencrypted_key()
+        generate_unencrypted_key(opts)
 
       true ->
         invalid_args()
@@ -316,9 +316,10 @@ defmodule Mix.Tasks.Hex.User do
     end
   end
 
-  defp generate_unencrypted_key() do
+  defp generate_unencrypted_key(opts) do
+    key_name = opts[:key_name]
     username = Hex.Shell.prompt("Username:") |> Hex.string_trim()
     password = Mix.Tasks.Hex.password_get("Account password:") |> Hex.string_trim()
-    Mix.Tasks.Hex.generate_api_key(username, password, key_name: nil, encrypt: false)
+    Mix.Tasks.Hex.generate_api_key(username, password, key_name: key_name, encrypt: false)
   end
 end

--- a/lib/mix/tasks/hex.user.ex
+++ b/lib/mix/tasks/hex.user.ex
@@ -43,6 +43,11 @@ defmodule Mix.Tasks.Hex.User do
 
       mix hex.user key --generate
 
+  ## Command line options
+
+    * `--key-name KEY_NAME` - By default Hex will base the key name on your machine's
+      hostname, use this option to give your own name.
+
   ## Revoke key
 
   Removes given API key from account.
@@ -241,7 +246,7 @@ defmodule Mix.Tasks.Hex.User do
   defp create_user(username, email, password) do
     case Hex.API.User.new(username, email, password) do
       {:ok, {code, _, _}} when code in 200..299 ->
-        Mix.Tasks.Hex.generate_api_key(username, password, nil)
+        Mix.Tasks.Hex.generate_api_key(username, password, key_name: nil)
 
         Hex.Shell.info(
           "You are required to confirm your email to access your account, " <>
@@ -312,9 +317,8 @@ defmodule Mix.Tasks.Hex.User do
   end
 
   defp generate_unencrypted_key() do
-    # get key from API
     username = Hex.Shell.prompt("Username:") |> Hex.string_trim()
     password = Mix.Tasks.Hex.password_get("Account password:") |> Hex.string_trim()
-    Mix.Tasks.Hex.generate_api_key(username, password, nil, false)
+    Mix.Tasks.Hex.generate_api_key(username, password, key_name: nil, encrypt: false)
   end
 end

--- a/lib/mix/tasks/hex.user.ex
+++ b/lib/mix/tasks/hex.user.ex
@@ -81,6 +81,9 @@ defmodule Mix.Tasks.Hex.User do
       mix hex.user reset_password local
   """
 
+  # TODO: when you revoke the key that is used to set the config api_key_unencrypted, anytime you try to auth after that will fail.
+  # need to remove that config too.
+
   @switches [
     revoke_all: :boolean,
     revoke: :string,

--- a/lib/mix/tasks/hex.user.ex
+++ b/lib/mix/tasks/hex.user.ex
@@ -81,9 +81,6 @@ defmodule Mix.Tasks.Hex.User do
       mix hex.user reset_password local
   """
 
-  # TODO: when you revoke the key that is used to set the config api_key_unencrypted, anytime you try to auth after that will fail.
-  # need to remove that config too.
-
   @switches [
     revoke_all: :boolean,
     revoke: :string,
@@ -208,6 +205,8 @@ defmodule Mix.Tasks.Hex.User do
       deauth_organizations()
     end
 
+    remove_unencrypted_key()
+
     Hex.Shell.info(
       "Authentication credentials removed from the local machine. " <>
         "To authenticate again, run `mix hex.user auth` " <>
@@ -324,5 +323,10 @@ defmodule Mix.Tasks.Hex.User do
     username = Hex.Shell.prompt("Username:") |> Hex.string_trim()
     password = Mix.Tasks.Hex.password_get("Account password:") |> Hex.string_trim()
     Mix.Tasks.Hex.generate_api_key(username, password, key_name: key_name, encrypt: false)
+  end
+
+  defp remove_unencrypted_key() do
+    Mix.Tasks.Hex.Config.run(["api_key_unencrypted", "--delete"])
+    Hex.State.put(:api_key_uncrypted, nil)
   end
 end

--- a/lib/mix/tasks/hex.user.ex
+++ b/lib/mix/tasks/hex.user.ex
@@ -37,6 +37,12 @@ defmodule Mix.Tasks.Hex.User do
 
     * `--skip-organizations` - Skip deauthorizing all organizations.
 
+  ## Generate API key
+
+  Generates an unencrypted API key for your account
+
+      mix hex.user key --generate
+
   ## Revoke key
 
   Removes given API key from account.
@@ -75,7 +81,8 @@ defmodule Mix.Tasks.Hex.User do
     revoke: :string,
     list: :boolean,
     skip_organizations: :boolean,
-    key_name: :string
+    key_name: :string,
+    generate: :boolean
   ]
 
   def run(args) do
@@ -117,6 +124,7 @@ defmodule Mix.Tasks.Hex.User do
     mix hex.user whoami
     mix hex.user auth
     mix hex.user deauth
+    mix hex.user key --generate
     mix hex.user key --revoke-all
     mix hex.user key --revoke KEY_NAME
     mix hex.user key --list
@@ -135,6 +143,9 @@ defmodule Mix.Tasks.Hex.User do
 
       opts[:list] ->
         list_keys()
+
+      opts[:generate] ->
+        generate_unencrypted_key()
 
       true ->
         invalid_args()
@@ -298,5 +309,12 @@ defmodule Mix.Tasks.Hex.User do
         Hex.Shell.error("Key fetching failed")
         Hex.Utils.print_error_result(other)
     end
+  end
+
+  defp generate_unencrypted_key() do
+    # get key from API
+    username = Hex.Shell.prompt("Username:") |> Hex.string_trim()
+    password = Mix.Tasks.Hex.password_get("Account password:") |> Hex.string_trim()
+    Hex.Shell.info(Mix.Tasks.Hex.generate_api_key(username, password, nil, false))
   end
 end

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -198,9 +198,9 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert_received {:mix_shell, :info, [key]}
 
       System.put_env("HEX_API_KEY", key)
-      Mix.Tasks.Hex.Publish.run(["package"])
+      Mix.Tasks.Hex.Publish.run(["package", "--no-confirm"])
 
-      message = "Building released_name 0.0.1"
+      message = "Building release_a 0.0.1"
       assert_received {:mix_shell, :info, [^message]}
       assert {:ok, {200, _, _}} = Hex.API.Release.get("hexpm", "release_a", "0.0.1")
     end)

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -200,12 +200,8 @@ defmodule Mix.Tasks.Hex.PublishTest do
       System.put_env("HEX_API_KEY", key)
       Mix.Tasks.Hex.Publish.run(["package"])
 
-      message =
-        "Package published to http://localhost:4043/packages/release_a/0.0.1 " <>
-          "(003480ccb7e23538f486689bda4f8a5ee50ff495e04a0bfd31e95640b7a6a02a)"
-
+      message = "Building released_name 0.0.1"
       assert_received {:mix_shell, :info, [^message]}
-
       assert {:ok, {200, _, _}} = Hex.API.Release.get("hexpm", "release_a", "0.0.1")
     end)
   after

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -205,6 +205,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert {:ok, {200, _, _}} = Hex.API.Release.get("hexpm", "release_a", "0.0.1")
     end)
   after
+    Hex.State.put(:hex_api_key, nil)
     purge([ReleaseSimple.MixProject])
   end
 

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -205,7 +205,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert {:ok, {200, _, _}} = Hex.API.Release.get("hexpm", "release_a", "0.0.1")
     end)
   after
-    Hex.State.put(:api_key_uncrypted, nil)
+    Hex.State.put(:api_key_unencrypted, nil)
     purge([ReleaseSimple.MixProject])
   end
 

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -197,15 +197,15 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert_received {:mix_shell, :info, ["Generating API key..."]}
       assert_received {:mix_shell, :info, [key]}
 
-      Hex.State.put(:hex_api_key, key)
-      Mix.Tasks.Hex.Publish.run(["package", "--no-confirm"])
+      Hex.State.put(:api_key_unencrypted, key)
+      Mix.Tasks.Hex.Publish.run(["package", "--no-confirm", "--no-progress"])
 
       message = "Building release_a 0.0.1"
       assert_received {:mix_shell, :info, [^message]}
       assert {:ok, {200, _, _}} = Hex.API.Release.get("hexpm", "release_a", "0.0.1")
     end)
   after
-    Hex.State.put(:hex_api_key, nil)
+    Hex.State.put(:api_key_uncrypted, nil)
     purge([ReleaseSimple.MixProject])
   end
 

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -197,7 +197,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert_received {:mix_shell, :info, ["Generating API key..."]}
       assert_received {:mix_shell, :info, [key]}
 
-      System.put_env("HEX_API_KEY", key)
+      Hex.State.put(:hex_api_key, key)
       Mix.Tasks.Hex.Publish.run(["package", "--no-confirm"])
 
       message = "Building release_a 0.0.1"
@@ -205,7 +205,6 @@ defmodule Mix.Tasks.Hex.PublishTest do
       assert {:ok, {200, _, _}} = Hex.API.Release.get("hexpm", "release_a", "0.0.1")
     end)
   after
-    System.delete_env("HEX_API_KEY")
     purge([ReleaseSimple.MixProject])
   end
 

--- a/test/mix/tasks/hex.user_test.exs
+++ b/test/mix/tasks/hex.user_test.exs
@@ -242,4 +242,17 @@ defmodule Mix.Tasks.Hex.UserTest do
       assert_received {:mix_shell, :error, ["Wrong password. Try again"]}
     end)
   end
+
+  test "key --generate" do
+    in_tmp(fn ->
+      Hex.State.put(:home, System.cwd!())
+      Hexpm.new_user("userkeygenerate", "userkeygenerate@mail.com", "password", "password")
+      send(self(), {:mix_shell_input, :prompt, "userkeygenerate"})
+      send(self(), {:mix_shell_input, :prompt, "password"})
+      Mix.Tasks.Hex.User.run(["key", "--generate"])
+      assert_received {:mix_shell, :info, ["Generating API key..."]}
+      assert_received {:mix_shell, :info, [key]}
+      assert is_binary(key)
+    end)
+  end
 end

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -230,7 +230,7 @@ defmodule HexTest.Case do
   Hex.State.put(:hexpm_pk, File.read!(Path.join(__DIR__, "../fixtures/test_pub.pem")))
   Hex.State.put(:api_url, "http://localhost:4043/api")
   Hex.State.put(:api_key, nil)
-  Hex.State.put(:hex_api_key, nil)
+  Hex.State.put(:api_key_unencrypted, nil)
   Hex.State.update!(:repos, &put_in(&1["hexpm"].url, "http://localhost:4043/repo"))
   Hex.State.update!(:repos, &put_in(&1["hexpm"].public_key, public_key))
   Hex.State.update!(:repos, &put_in(&1["hexpm"].auth_key, nil))

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -230,6 +230,7 @@ defmodule HexTest.Case do
   Hex.State.put(:hexpm_pk, File.read!(Path.join(__DIR__, "../fixtures/test_pub.pem")))
   Hex.State.put(:api_url, "http://localhost:4043/api")
   Hex.State.put(:api_key, nil)
+  Hex.State.put(:hex_api_key, nil)
   Hex.State.update!(:repos, &put_in(&1["hexpm"].url, "http://localhost:4043/repo"))
   Hex.State.update!(:repos, &put_in(&1["hexpm"].public_key, public_key))
   Hex.State.update!(:repos, &put_in(&1["hexpm"].auth_key, nil))


### PR DESCRIPTION
Fixes for https://github.com/hexpm/hex/issues/547

Adds a new task, `mix hex.user key --generate` that generates and outputs an unencrypted user key.
Allows including that key in ENV VAR `HEX_API_KEY` when publishing. That will authenticate the user and turn off the confirmation message.

Please give feedback if there is anything that doesnt look right or could be done better.