### PR TITLE
Try all backtrack branches and select best solution

### DIFF
--- a/lib/mix/tasks/hex.search.ex
+++ b/lib/mix/tasks/hex.search.ex
@@ -47,7 +47,7 @@ defmodule Mix.Tasks.Hex.Search do
   end
 
   defp lookup_packages({:ok, {200, packages, _headers}}) do
-    include_organizations? = Enum.any?(packages, & &1["repository"] != "hexpm")
+    include_organizations? = Enum.any?(packages, &(&1["repository"] != "hexpm"))
 
     if include_organizations? do
       print_with_organizations(packages)

--- a/mix.exs
+++ b/mix.exs
@@ -140,7 +140,7 @@ defmodule Hex.MixProject do
     end
   end
 
-  defp archives_path do
+  defp archives_path() do
     if function_exported?(Mix.Local, :path_for, 1) do
       Mix.Local.path_for(:archive)
     else


### PR DESCRIPTION
When we decide which backtrack to take, backtrack current failed request
or backtrack its parents, we do not know which will lead to the best
solution. Instead of picking one we will try both and after resolution
is finished we will try to find the best solutions based on heuristics
such as using highest version number.

Resolution failures will have the same performance, but successful
resolutions with backtracks will be slower because they need to try more
backtracking branches.

Closes #571.