### PR TITLE
Raises an error if the arg passed is not a version

### DIFF
--- a/lib/mix/tasks/hex.install.ex
+++ b/lib/mix/tasks/hex.install.ex
@@ -31,6 +31,8 @@ defmodule Mix.Tasks.Hex.Install do
   end
 
   defp install(hex_version) do
+    raise_if_invalid_version(hex_version)
+
     hex_url = Hex.Repo.get_repo("hexpm").url
     csv_url = hex_url <> @hex_list_path
 
@@ -109,5 +111,12 @@ defmodule Mix.Tasks.Hex.Install do
 
   defp find_version(_versions, _elixir_version, _hex_version) do
     nil
+  end
+
+  defp raise_if_invalid_version(hex_version) do
+    case Version.parse(hex_version) do
+      {:ok, _version} -> :ok
+      :error -> Mix.raise("#{hex_version} is not a valid Hex version")
+    end
   end
 end

--- a/test/mix/tasks/hex.install_test.exs
+++ b/test/mix/tasks/hex.install_test.exs
@@ -1,0 +1,10 @@
+defmodule Mix.Tasks.Hex.InstallTest do
+  use HexTest.Case
+  @moduletag :integration
+
+  test "install/1" do
+    assert_raise Mix.Error, "package_name is not a valid Hex version", fn ->
+      Mix.Tasks.Hex.Install.run(["package_name"])
+    end
+  end
+end


### PR DESCRIPTION
<img width="994" alt="screen shot 2018-06-13 at 11 39 51 pm" src="https://user-images.githubusercontent.com/773380/41393985-6c329030-6f65-11e8-87b8-b9d3acda9f43.png">

Fixes: https://github.com/hexpm/hex/issues/574