### PR TITLE
Adds passive option to hex.audit to allow normal exit when retired packages are found

### DIFF
--- a/lib/mix/tasks/hex.audit.ex
+++ b/lib/mix/tasks/hex.audit.ex
@@ -11,11 +11,18 @@ defmodule Mix.Tasks.Hex.Audit do
   maintainers. The task will display a message describing
   the reason for retirement and exit with a non-zero code
   if any retired dependencies are found.
+
+  ## Command line options
+
+    * `--passive` - exits task normally even when retired packages are found
   """
 
-  def run(_) do
+  @switches [passive: :boolean]
+
+  def run(args) do
     Hex.check_deps()
     Hex.start()
+    {opts, _args} = Hex.OptionParser.parse!(args, strict: @switches)
 
     lock = Mix.Dep.Lock.read()
     deps = Mix.Dep.loaded([]) |> Enum.filter(&(&1.scm == Hex.SCM))
@@ -34,7 +41,7 @@ defmodule Mix.Tasks.Hex.Audit do
         header = ["Dependency", "Version", "Retirement reason"]
         Mix.Tasks.Hex.print_table(header, packages)
         Hex.Shell.error("Found retired packages")
-        Mix.Tasks.Hex.set_exit_code(1)
+        if opts[:passive], do: :ok, else: Mix.Tasks.Hex.set_exit_code(1)
     end
   end
 

--- a/test/mix/tasks/hex.audit_test.exs
+++ b/test/mix/tasks/hex.audit_test.exs
@@ -36,6 +36,26 @@ defmodule Mix.Tasks.Hex.AuditTest do
     end)
   end
 
+  test "audit (retired package without a message) --passive", context do
+    with_test_package("0.1.0", context, fn ->
+      retire_test_package("0.1.0", "security")
+
+      assert Mix.Task.run("hex.audit", ["--passive"]) == :ok
+      assert_output_row(@package_name, "0.1.0", "(security)")
+      assert_received {:mix_shell, :error, ["Found retired packages"]}
+    end)
+  end
+
+  test "audit (retired package with a custom message) --passive", context do
+    with_test_package("0.2.0", context, fn ->
+      retire_test_package("0.2.0", "invalid", "Superseded by v1.0.0")
+
+      assert Mix.Task.run("hex.audit", ["--passive"]) == :ok
+      assert_output_row(@package_name, "0.2.0", "(invalid) Superseded by v1.0.0")
+      assert_received {:mix_shell, :error, ["Found retired packages"]}
+    end)
+  end
+
   test "audit (no retired packages)", context do
     with_test_package("1.0.0", context, fn ->
       Mix.Task.run("hex.audit")


### PR DESCRIPTION
In response to https://github.com/hexpm/hex/issues/588

This adds an optional --passive flag to hex.audit to force the task to exit normally even if retired dependencies are found.