### PR TITLE
Raise errors when top-level file in package matches semver pattern

### DIFF
--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -134,11 +134,11 @@ defmodule Hex do
     files =
       Enum.map(files, fn
         {filename, contents} ->
-          if filename_matches_semver?(filename), do: Mix.raise(semver_error_text)
+          if filename_matches_semver?(filename), do: Mix.raise(semver_error_text())
           {string_to_charlist(filename), contents}
 
         filename ->
-          if filename_matches_semver?(filename), do: Mix.raise(semver_error_text)
+          if filename_matches_semver?(filename), do: Mix.raise(semver_error_text())
           string_to_charlist(filename)
       end)
 

--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -170,14 +170,14 @@ defmodule Hex do
     end
   end
 
-  defp filename_matches_semver?(filename) do
+  def filename_matches_semver?(filename) do
     case Version.parse(to_string(filename)) do
       {:ok, _struct} -> true
       _ -> false
     end
   end
 
-  defp semver_error_text do
+  def semver_error_text do
     "Invalid filename: top-level filenames cannot match a semantic version pattern."
   end
 end

--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -133,13 +133,8 @@ defmodule Hex do
   def create_tar!(metadata, files, output) do
     files =
       Enum.map(files, fn
-        {filename, contents} ->
-          if filename_matches_semver?(filename), do: Mix.raise(semver_error_text())
-          {string_to_charlist(filename), contents}
-
-        filename ->
-          if filename_matches_semver?(filename), do: Mix.raise(semver_error_text())
-          string_to_charlist(filename)
+        {filename, contents} -> {string_to_charlist(filename), contents}
+        filename -> string_to_charlist(filename)
       end)
 
     case :mix_hex_tarball.create(metadata, files) do

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -295,48 +295,6 @@ defmodule Mix.Tasks.Hex.PublishTest do
     purge([ReleaseDeps.MixProject])
   end
 
-  test "raise for invalid filename" do
-    Mix.Project.push(ReleaseFilesSemVer.MixProject)
-
-    in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
-      setup_auth("user", "hunter42")
-
-      error_msg = "Invalid filename: top-level filenames cannot match a semantic version pattern."
-
-      assert_raise Mix.Error, error_msg, fn ->
-        File.write!("myfile.txt", "hello")
-        File.write!("1.0.0", "semver")
-        send(self(), {:mix_shell_input, :yes?, true})
-        send(self(), {:mix_shell_input, :prompt, "hunter42"})
-        Mix.Tasks.Hex.Publish.run(["package", "--no-progress"])
-      end
-    end)
-  after
-    purge([ReleaseFilesSemVer.MixProject])
-  end
-
-  test "raise for invalid directory name" do
-    Mix.Project.push(ReleaseFilesSemVer.MixProject)
-
-    in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
-      setup_auth("user", "hunter42")
-
-      error_msg = "Invalid filename: top-level filenames cannot match a semantic version pattern."
-
-      assert_raise Mix.Error, error_msg, fn ->
-        File.write!("myfile.txt", "hello")
-        File.mkdir!("1.0.0")
-        send(self(), {:mix_shell_input, :yes?, true})
-        send(self(), {:mix_shell_input, :prompt, "hunter42"})
-        Mix.Tasks.Hex.Publish.run(["package", "--no-progress"])
-      end
-    end)
-  after
-    purge([ReleaseFilesSemVer.MixProject])
-  end
-
   test "raise for missing metadata" do
     Mix.Project.push(ReleaseMeta.MixProject)
 

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -253,6 +253,27 @@ defmodule Mix.Tasks.Hex.PublishTest do
     purge([ReleaseFilesSemVer.MixProject])
   end
 
+  test "raise for invalid directory name" do
+    Mix.Project.push(ReleaseFilesSemVer.MixProject)
+
+    in_tmp(fn ->
+      Hex.State.put(:home, tmp_path())
+      setup_auth("user", "hunter42")
+
+      error_msg = "Invalid filename: top-level filenames cannot match a semantic version pattern."
+
+      assert_raise Mix.Error, error_msg, fn ->
+        File.write!("myfile.txt", "hello")
+        File.mkdir!("1.0.0")
+        send(self(), {:mix_shell_input, :yes?, true})
+        send(self(), {:mix_shell_input, :prompt, "hunter42"})
+        Mix.Tasks.Hex.Publish.run(["package", "--no-progress"])
+      end
+    end)
+  after
+    purge([ReleaseFilesSemVer.MixProject])
+  end
+
   test "raise for missing metadata" do
     Mix.Project.push(ReleaseMeta.MixProject)
 

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -198,6 +198,8 @@ defmodule HexTest.Case do
       {:hexpm, :foo, "0.2.0", []},
       {:hexpm, :foo, "0.2.1", []},
       {:hexpm, :has_optional, "0.1.0", [{:ex_doc, "~> 0.0.1", true}]},
+      {:hexpm, :invalid_dirname, "0.1.0", []},
+      {:hexpm, :invalid_filename, "0.1.0", []},
       {:hexpm, :jose, "0.2.0", []},
       {:hexpm, :jose, "0.2.1", []},
       {:hexpm, :only_doc, "0.1.0", [{:ex_doc, ">= 0.0.0", true}]},

--- a/test/support/release_samples.ex
+++ b/test/support/release_samples.ex
@@ -159,6 +159,21 @@ defmodule ReleaseExcludePatterns.MixProject do
   end
 end
 
+defmodule ReleaseFilesSemVer.MixProject do
+  def project do
+    [
+      app: :release_j,
+      version: "0.0.1",
+      description: "foo",
+      package: [
+        files: ["myfile.txt", "1.0.0"],
+        licenses: ["MIT"],
+        links: %{"a" => "http://a"}
+      ]
+    ]
+  end
+end
+
 defmodule ReleaseRepo.MixProject do
   def project do
     [

--- a/test/support/release_samples.ex
+++ b/test/support/release_samples.ex
@@ -159,21 +159,6 @@ defmodule ReleaseExcludePatterns.MixProject do
   end
 end
 
-defmodule ReleaseFilesSemVer.MixProject do
-  def project do
-    [
-      app: :release_j,
-      version: "0.0.1",
-      description: "foo",
-      package: [
-        files: ["myfile.txt", "1.0.0"],
-        licenses: ["MIT"],
-        links: %{"a" => "http://a"}
-      ]
-    ]
-  end
-end
-
 defmodule ReleaseRepo.MixProject do
   def project do
     [


### PR DESCRIPTION
This resolves part 2 of https://github.com/hexpm/hex/issues/591

I would like to submit part 1 in a different pull request since the issues are different enough.
