### PR TITLE
fixes issue saving write key when reseting local password

### DIFF
--- a/lib/mix/tasks/hex.user.ex
+++ b/lib/mix/tasks/hex.user.ex
@@ -182,13 +182,15 @@ defmodule Mix.Tasks.Hex.User do
 
   defp reset_local_password() do
     encrypted_key = Hex.State.fetch!(:api_key_write)
+    read_key = Hex.State.fetch!(:api_key_read)
 
     unless encrypted_key do
       Mix.raise("No authorized user found. Run `mix hex.user auth`")
     end
 
     decrypted_key = Mix.Tasks.Hex.prompt_decrypt_key(encrypted_key, "Current local password")
-    Mix.Tasks.Hex.prompt_encrypt_key(decrypted_key, "New local password")
+    Mix.Tasks.Hex.prompt_encrypt_key(decrypted_key, read_key, "New local password")
+    Hex.Shell.info("Password changed")
   end
 
   defp deauth() do

--- a/test/mix/tasks/hex.user_test.exs
+++ b/test/mix/tasks/hex.user_test.exs
@@ -222,6 +222,7 @@ defmodule Mix.Tasks.Hex.UserTest do
 
       Mix.Tasks.Hex.update_keys(Mix.Tasks.Hex.encrypt_key("hunter42", "qwerty"))
       first_key = Hex.Config.read()[:"$write_key"]
+      read_key = Hex.Config.read()[:"$read_key"]
 
       send(self(), {:mix_shell_input, :prompt, "hunter42"})
       send(self(), {:mix_shell_input, :prompt, "hunter43"})
@@ -229,6 +230,7 @@ defmodule Mix.Tasks.Hex.UserTest do
       Mix.Tasks.Hex.User.run(["reset_password", "local"])
 
       assert Hex.Config.read()[:"$write_key"] != first_key
+      assert Hex.Config.read()[:"$read_key"] == read_key
 
       send(self(), {:mix_shell_input, :prompt, "wrong"})
       send(self(), {:mix_shell_input, :prompt, "hunter43"})


### PR DESCRIPTION
I noticed a bug with the reset_password local task today. It ends up saving the read_key as "New local password" (see gif)
![2018-08-19 09 42 24](https://user-images.githubusercontent.com/773380/44310514-e8bd2f80-a394-11e8-91f1-dc75113aa5c5.gif)

This PR fixes that to save the read_key correctly and also updates the label and gives a success message after.
![2018-08-19 19 28 03](https://user-images.githubusercontent.com/773380/44315980-1da5a280-a3e6-11e8-8a23-13c195cd79ad.gif)


