### PR TITLE
Micro-optimize http options building

### DIFF
--- a/lib/hex/http.ex
+++ b/lib/hex/http.ex
@@ -28,12 +28,12 @@ defmodule Hex.HTTP do
   end
 
   defp build_http_opts(url, timeout) do
-    [
+    proxy_config(url) ++ [
       relaxed: true,
       timeout: timeout,
       ssl: Hex.HTTP.SSL.ssl_opts(url),
       autoredirect: false
-    ] ++ proxy_config(url)
+    ]
   end
 
   defp build_request(url, headers, body) do


### PR DESCRIPTION
Since `proxy_config/1` returns either an empty list or a one-element list, hopefully this commit could make it slightly more efficient.