### PR TITLE
Adds dry run option to publish tasks

### DIFF
--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -232,6 +232,24 @@ defmodule Mix.Tasks.Hex.PublishTest do
     purge([ReleaseName.MixProject])
   end
 
+  test "publish package and docs with dry run" do
+    Mix.Project.push(ReleaseName.MixProject)
+
+    in_tmp(fn ->
+      Hex.State.put(:home, tmp_path())
+      setup_auth("user", "hunter42")
+
+      send(self(), {:mix_shell_input, :prompt, "hunter42"})
+      Mix.Tasks.Hex.Publish.run(["--dry-run", "--yes"])
+      message = "Building released_name 0.0.1"
+      assert_received {:mix_shell, :info, [^message]}
+      refute_received {:mix_shell, :info, ["Package published to" <> _]}
+      refute_received {:mix_shell, :info, ["Docs published to" <> _]}
+    end)
+  after
+    purge([ReleaseName.MixProject])
+  end
+
   test "create with key" do
     Mix.Project.push(ReleaseSimple.MixProject)
 


### PR DESCRIPTION
Fixes: https://github.com/hexpm/hex/issues/607

Adds a `--dry-run` option to publish, publish docs, and publish package.
Includes unit test

Having the case statements in the else block seems a little awkward to me, if you guys have any better patterns or ideas please mention them. Also, feel free to edit the documentation message for the new flag.

![2018-09-17 22 26 02](https://user-images.githubusercontent.com/773380/45664419-edc2eb00-bac8-11e8-997f-f0b966bddda5.gif)
