### PR TITLE
Updates hex.owner documentation

### DIFF
--- a/lib/mix/tasks/hex.owner.ex
+++ b/lib/mix/tasks/hex.owner.ex
@@ -11,17 +11,17 @@ defmodule Mix.Tasks.Hex.Owner do
 
   ## Add owner
 
-  Adds an owner to package by specifying the package name and email of the new
-  owner.
+  Adds an owner to package by specifying the package name and email or username
+  of the new owner.
 
-      mix hex.owner add PACKAGE EMAIL
+      mix hex.owner add PACKAGE EMAIL or USERNAME
 
   ## Remove owner
 
-  Removes an owner to package by specifying the package name and email of the new
-  owner.
+  Removes an owner to package by specifying the package name and email or username
+  of the new owner.
 
-      mix hex.owner remove PACKAGE EMAIL
+      mix hex.owner remove PACKAGE EMAIL or USERNAME
 
   ## List owners
 
@@ -65,8 +65,8 @@ defmodule Mix.Tasks.Hex.Owner do
         Mix.raise("""
         Invalid arguments, expected one of:
 
-        mix hex.owner add PACKAGE EMAIL
-        mix hex.owner remove PACKAGE EMAIL
+        mix hex.owner add PACKAGE EMAIL|USERNAME
+        mix hex.owner remove PACKAGE EMAIL|USERNAME
         mix hex.owner list PACKAGE
         mix hex.owner packages
         """)


### PR DESCRIPTION
fixes: https://github.com/hexpm/hex/issues/611

Documents that you can add/remove owners by username as well as email.

![2018-10-10 22 49 08](https://user-images.githubusercontent.com/773380/46781470-09dc3580-ccdf-11e8-92b6-60b6657693a7.gif)
