### PR TITLE
Most of Hex is private API

### DIFF
--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -1,4 +1,6 @@
 defmodule Hex do
+  @moduledoc false
+
   use Application
 
   def start() do

--- a/lib/hex/api.ex
+++ b/lib/hex/api.ex
@@ -1,4 +1,6 @@
 defmodule Hex.API do
+  @moduledoc false
+
   alias Hex.HTTP
 
   @erlang_content 'application/vnd.hex+erlang'

--- a/lib/hex/api/auth.ex
+++ b/lib/hex/api/auth.ex
@@ -1,4 +1,6 @@
 defmodule Hex.API.Auth do
+  @moduledoc false
+
   alias Hex.API
 
   def get(domain, resource, auth) do

--- a/lib/hex/api/key.ex
+++ b/lib/hex/api/key.ex
@@ -1,4 +1,6 @@
 defmodule Hex.API.Key do
+  @moduledoc false
+
   alias Hex.API
 
   def new(name, permissions, auth) do
@@ -18,6 +20,8 @@ defmodule Hex.API.Key do
   end
 
   defmodule Organization do
+    @moduledoc false
+
     def new(organization, name, permissions, auth) do
       API.erlang_post_request(
         nil,

--- a/lib/hex/api/package.ex
+++ b/lib/hex/api/package.ex
@@ -1,4 +1,6 @@
 defmodule Hex.API.Package do
+  @moduledoc false
+
   alias Hex.API
 
   def get(repo, name, auth \\ []) do
@@ -12,6 +14,8 @@ defmodule Hex.API.Package do
   end
 
   defmodule Owner do
+    @moduledoc false
+
     def add(repo, package, owner, level, auth) do
       owner = URI.encode_www_form(owner)
       path = "packages/#{URI.encode(package)}/owners/#{URI.encode(owner)}"

--- a/lib/hex/api/release.ex
+++ b/lib/hex/api/release.ex
@@ -1,4 +1,6 @@
 defmodule Hex.API.Release do
+  @moduledoc false
+
   alias Hex.API
 
   def get(repo, name, version, auth \\ []) do

--- a/lib/hex/api/release_docs.ex
+++ b/lib/hex/api/release_docs.ex
@@ -1,4 +1,6 @@
 defmodule Hex.API.ReleaseDocs do
+  @moduledoc false
+
   alias Hex.API
 
   def get(repo, name, version) do

--- a/lib/hex/api/user.ex
+++ b/lib/hex/api/user.ex
@@ -1,4 +1,6 @@
 defmodule Hex.API.User do
+  @moduledoc false
+
   alias Hex.API
 
   def me(auth) do

--- a/lib/hex/config.ex
+++ b/lib/hex/config.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Config do
+  @moduledoc false
+
   def read() do
     case File.read(config_path()) do
       {:ok, binary} ->

--- a/lib/hex/crypto.ex
+++ b/lib/hex/crypto.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Crypto do
+  @moduledoc false
+
   alias Hex.Crypto.Encryption
 
   def encrypt(plain_text, password, tag \\ "") do

--- a/lib/hex/crypto/aes_cbc_hmac_sha2.ex
+++ b/lib/hex/crypto/aes_cbc_hmac_sha2.ex
@@ -1,13 +1,11 @@
 defmodule Hex.Crypto.AES_CBC_HMAC_SHA2 do
+  @moduledoc false
+  # Content Encryption with AES_CBC_HMAC_SHA2.
+  # See: https://tools.ietf.org/html/rfc7518#section-5.2.6
+
   alias Hex.Crypto.ContentEncryptor
 
   @behaviour ContentEncryptor
-
-  @moduledoc ~S"""
-  Content Encryption with AES_CBC_HMAC_SHA2.
-
-  See: https://tools.ietf.org/html/rfc7518#section-5.2.6
-  """
 
   @spec content_encrypt({binary, binary}, <<_::32>> | <<_::48>> | <<_::64>>, <<_::16>>) ::
           {binary, <<_::16>> | <<_::24>> | <<_::32>>}

--- a/lib/hex/crypto/aes_gcm.ex
+++ b/lib/hex/crypto/aes_gcm.ex
@@ -1,14 +1,13 @@
 defmodule Hex.Crypto.AES_GCM do
+  @moduledoc false
+  # Content Encryption with AES GCM
+  #
+  # See: https://tools.ietf.org/html/rfc7518#section-5.3
+  # See: http://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf
+
   alias Hex.Crypto.ContentEncryptor
 
   @behaviour ContentEncryptor
-
-  @moduledoc ~S"""
-  Content Encryption with AES GCM
-
-  See: https://tools.ietf.org/html/rfc7518#section-5.3
-  See: http://csrc.nist.gov/publications/nistpubs/800-38D/SP-800-38D.pdf
-  """
 
   @spec content_encrypt({binary, binary}, <<_::16>> | <<_::24>> | <<_::32>>, <<_::12>>) ::
           {binary, <<_::16>>}

--- a/lib/hex/crypto/content_encryptor.ex
+++ b/lib/hex/crypto/content_encryptor.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Crypto.ContentEncryptor do
+  @moduledoc false
+
   alias Hex.Crypto
   alias __MODULE__
 

--- a/lib/hex/crypto/encryption.ex
+++ b/lib/hex/crypto/encryption.ex
@@ -1,4 +1,5 @@
 defmodule Hex.Crypto.Encryption do
+  @moduledoc false
   alias Hex.Crypto
   alias Hex.Crypto.ContentEncryptor
   alias Hex.Crypto.KeyManager

--- a/lib/hex/crypto/key_manager.ex
+++ b/lib/hex/crypto/key_manager.ex
@@ -1,4 +1,5 @@
 defmodule Hex.Crypto.KeyManager do
+  @moduledoc false
   alias Hex.Crypto
   alias Hex.Crypto.ContentEncryptor
   alias __MODULE__

--- a/lib/hex/crypto/pbes2_hmac_sha2.ex
+++ b/lib/hex/crypto/pbes2_hmac_sha2.ex
@@ -1,16 +1,15 @@
 defmodule Hex.Crypto.PBES2_HMAC_SHA2 do
+  @moduledoc false
+  # Direct Key Derivation with PBES2 and HMAC-SHA-2.
+  #
+  # See: https://tools.ietf.org/html/rfc7518#section-4.8
+  # See: https://tools.ietf.org/html/rfc2898#section-6.2
+
   alias Hex.Crypto.ContentEncryptor
   alias Hex.Crypto.KeyManager
   alias Hex.Crypto.PKCS5
 
   @behaviour KeyManager
-
-  @moduledoc ~S"""
-  Direct Key Derivation with PBES2 and HMAC-SHA-2.
-
-  See: https://tools.ietf.org/html/rfc7518#section-4.8
-  See: https://tools.ietf.org/html/rfc2898#section-6.2
-  """
 
   @spec derive_key(String.t(), binary, pos_integer, non_neg_integer, :sha256 | :sha384 | :sha512) ::
           binary

--- a/lib/hex/crypto/pkcs5.ex
+++ b/lib/hex/crypto/pkcs5.ex
@@ -1,9 +1,7 @@
 defmodule Hex.Crypto.PKCS5 do
-  @moduledoc ~S"""
-  PKCS #5: Password-Based Cryptography Specification Version 2.0
-
-  See: https://tools.ietf.org/html/rfc2898
-  """
+  @moduledoc false
+  # PKCS #5: Password-Based Cryptography Specification Version 2.0
+  # See: https://tools.ietf.org/html/rfc2898
 
   def pbkdf2(password, salt, iterations, derived_key_length, hash)
       when is_binary(password) and is_binary(salt) and is_integer(iterations) and iterations >= 1 and

--- a/lib/hex/crypto/public_key.ex
+++ b/lib/hex/crypto/public_key.ex
@@ -1,7 +1,6 @@
 defmodule Hex.Crypto.PublicKey do
-  @doc """
-  Decodes a public key and raises if the key is invalid.
-  """
+  @moduledoc false
+
   def decode!(id, key) do
     [rsa_public_key] = :public_key.pem_decode(key)
     :public_key.pem_entry_decode(rsa_public_key)
@@ -16,9 +15,6 @@ defmodule Hex.Crypto.PublicKey do
       """)
   end
 
-  @doc """
-  Verifies the given binary has the proper signature using the system public keys.
-  """
   def verify(binary, hash, signature, keys, id) do
     Enum.any?(keys, fn key ->
       :public_key.verify(binary, hash, signature, decode!(id, key))

--- a/lib/hex/http.ex
+++ b/lib/hex/http.ex
@@ -1,4 +1,6 @@
 defmodule Hex.HTTP do
+  @moduledoc false
+
   @request_timeout 15_000
   @request_redirects 3
   @request_retries 2

--- a/lib/hex/http/certs.ex
+++ b/lib/hex/http/certs.ex
@@ -1,4 +1,6 @@
 defmodule Hex.HTTP.Certs do
+  @moduledoc false
+
   crt_file = Path.join(__DIR__, "ca-bundle.crt")
   crt = File.read!(crt_file)
 

--- a/lib/hex/http/ssl.ex
+++ b/lib/hex/http/ssl.ex
@@ -1,4 +1,6 @@
 defmodule Hex.HTTP.SSL do
+  @moduledoc false
+
   require Record
   alias Hex.HTTP.Certs
   alias Hex.HTTP.VerifyHostname

--- a/lib/hex/http/verify_hostname.ex
+++ b/lib/hex/http/verify_hostname.ex
@@ -1,4 +1,6 @@
 defmodule Hex.HTTP.VerifyHostname do
+  @moduledoc false
+
   # Based on https://github.com/deadtrickster/ssl_verify_hostname.erl
 
   require Record

--- a/lib/hex/mix.ex
+++ b/lib/hex/mix.ex
@@ -1,7 +1,6 @@
 defmodule Hex.Mix do
-  @moduledoc """
-  Utility functions around Mix dependencies.
-  """
+  @moduledoc false
+  # Utility functions around Mix dependencies.
 
   @type deps :: %{String.t() => {boolean, deps}}
 

--- a/lib/hex/option_parser.ex
+++ b/lib/hex/option_parser.ex
@@ -1,4 +1,6 @@
 defmodule Hex.OptionParser do
+  @moduledoc false
+
   if Version.compare(System.version(), "1.3.0") == :lt do
     def parse!(argv, opts \\ []) when is_list(argv) and is_list(opts) do
       case OptionParser.parse(argv, opts) do

--- a/lib/hex/parallel.ex
+++ b/lib/hex/parallel.ex
@@ -1,8 +1,7 @@
 defmodule Hex.Parallel do
-  @moduledoc """
-  Runs a number of jobs (with an upper bound) in parallel and
-  awaits them to finish.
-  """
+  @moduledoc false
+  # Runs a number of jobs (with an upper bound) in parallel and
+  # awaits them to finish.
 
   use GenServer
 

--- a/lib/hex/registry.ex
+++ b/lib/hex/registry.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Registry do
+  @moduledoc false
+
   @type repo :: String.t()
   @type package :: String.t()
   @type version :: String.t()

--- a/lib/hex/registry/server.ex
+++ b/lib/hex/registry/server.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Registry.Server do
+  @moduledoc false
+
   use GenServer
 
   @behaviour Hex.Registry

--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Repo do
+  @moduledoc false
+
   alias Hex.HTTP
 
   @public_keys_html "https://hex.pm/docs/public_keys"

--- a/lib/hex/resolver.ex
+++ b/lib/hex/resolver.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Resolver do
+  @moduledoc false
+
   import Hex.Mix
   require Record
   alias Hex.Resolver.Backtracks

--- a/lib/hex/resolver/backtracks.ex
+++ b/lib/hex/resolver/backtracks.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Resolver.Backtracks do
+  @moduledoc false
+
   require Record
 
   Record.defrecordp(:parent, [:name, :repo, :version, :requirement, :repo_requirement])

--- a/lib/hex/server.ex
+++ b/lib/hex/server.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Server do
+  @moduledoc false
+
   use GenServer
 
   @name __MODULE__

--- a/lib/hex/set.ex
+++ b/lib/hex/set.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Set do
+  @moduledoc false
+
   if Version.compare(System.version(), "1.1.0") == :lt do
     @module HashSet
   else

--- a/lib/hex/shell.ex
+++ b/lib/hex/shell.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Shell do
+  @moduledoc false
+
   def info(output) do
     validate_output!(output)
     Mix.shell().info(output)

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -1,4 +1,6 @@
 defmodule Hex.State do
+  @moduledoc false
+
   @name __MODULE__
   @api_url "https://hex.pm/api"
   @logged_keys ~w(http_proxy HTTP_PROXY https_proxy HTTPS_PROXY)

--- a/lib/hex/update_checker.ex
+++ b/lib/hex/update_checker.ex
@@ -1,4 +1,6 @@
 defmodule Hex.UpdateChecker do
+  @moduledoc false
+
   use GenServer
 
   @name __MODULE__

--- a/lib/hex/utils.ex
+++ b/lib/hex/utils.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Utils do
+  @moduledoc false
+
   def safe_deserialize_erlang("") do
     nil
   end

--- a/lib/hex/version.ex
+++ b/lib/hex/version.ex
@@ -1,9 +1,13 @@
 defmodule Hex.Version do
+  @moduledoc false
+
   defmodule Requirement do
+    @moduledoc false
     defstruct [:source, :req]
   end
 
   defmodule InvalidRequirementError do
+    @moduledoc false
     defexception [:requirement]
 
     def exception(requirement) when is_binary(requirement) do
@@ -16,6 +20,7 @@ defmodule Hex.Version do
   end
 
   defmodule InvalidVersionError do
+    @moduledoc false
     defexception [:version]
 
     def exception(version) when is_binary(version) do

--- a/lib/mix/tasks/hex.audit.ex
+++ b/lib/mix/tasks/hex.audit.ex
@@ -13,6 +13,7 @@ defmodule Mix.Tasks.Hex.Audit do
   if any retired dependencies are found.
   """
 
+  @impl true
   def run(_) do
     Hex.check_deps()
     Hex.start()

--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -83,6 +83,7 @@ defmodule Mix.Tasks.Hex.Build do
   @switches [unpack: :boolean, output: :string]
   @aliases [o: :output]
 
+  @impl true
   def run(args) do
     Hex.start()
     {opts, _args} = Hex.OptionParser.parse!(args, strict: @switches, aliases: @aliases)
@@ -116,6 +117,7 @@ defmodule Mix.Tasks.Hex.Build do
     %{checksum: ^checksum} = Hex.unpack_tar!({:binary, tar}, output)
   end
 
+  @doc false
   def prepare_package() do
     Mix.Project.get!()
     config = Mix.Project.config()
@@ -139,6 +141,7 @@ defmodule Mix.Tasks.Hex.Build do
     }
   end
 
+  @doc false
   def print_info(meta, organization, exclude_deps, package_files) do
     if meta[:requirements] != [] do
       Hex.Shell.info("  Dependencies:")
@@ -256,6 +259,7 @@ defmodule Mix.Tasks.Hex.Build do
     end
   end
 
+  @doc false
   def package(package, config) do
     files = package[:files] || @default_files
     exclude_patterns = package[:exclude_patterns] || []
@@ -283,6 +287,7 @@ defmodule Mix.Tasks.Hex.Build do
     end
   end
 
+  @doc false
   def check_umbrella_project!(config) do
     if Mix.Project.umbrella?(config) do
       Mix.raise("Hex does not support umbrella projects")

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -57,6 +57,7 @@ defmodule Mix.Tasks.Hex.Config do
     "http_timeout"
   ]
 
+  @impl true
   def run(args) do
     Hex.start()
     {opts, args} = Hex.OptionParser.parse!(args, strict: @switches)

--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -39,6 +39,7 @@ defmodule Mix.Tasks.Hex.Docs do
   @elixir_apps ~w(eex elixir ex_unit iex logger mix)
   @switches [module: :string, organization: :string, latest: :boolean]
 
+  @impl true
   def run(args) do
     Hex.start()
     {opts, args} = Hex.OptionParser.parse!(args, strict: @switches)

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -13,6 +13,7 @@ defmodule Mix.Tasks.Hex do
   See `mix help hex.config` to see all available configuration options.
   """
 
+  @impl true
   def run(_args) do
     Hex.start()
 
@@ -24,8 +25,9 @@ defmodule Mix.Tasks.Hex do
     Hex.Shell.info("Further information can be found here: https://hex.pm/docs/tasks")
   end
 
-  def line_break(), do: Hex.Shell.info("")
+  defp line_break(), do: Hex.Shell.info("")
 
+  @doc false
   def print_table(header, values) do
     header = Enum.map(header, &[:underline, &1])
     widths = widths([header | values])
@@ -66,6 +68,7 @@ defmodule Mix.Tasks.Hex do
     end)
   end
 
+  @doc false
   def auth(opts \\ []) do
     username = Hex.Shell.prompt("Username:") |> Hex.string_trim()
     account_password = Mix.Tasks.Hex.password_get("Account password:") |> Hex.string_trim()
@@ -76,6 +79,7 @@ defmodule Mix.Tasks.Hex do
                            "Hex requires you to have a local password that applies only to this machine for security " <>
                            "purposes. Please enter it."
 
+  @doc false
   def generate_user_key(key_name, permissions, opts) do
     case Hex.API.Key.new(key_name, permissions, opts) do
       {:ok, {201, body, _}} ->
@@ -88,6 +92,7 @@ defmodule Mix.Tasks.Hex do
     end
   end
 
+  @doc false
   def generate_all_user_keys(username, password, opts \\ []) do
     Hex.Shell.info("Generating keys...")
     auth = [user: username, pass: password]
@@ -125,6 +130,7 @@ defmodule Mix.Tasks.Hex do
     end
   end
 
+  @doc false
   def generate_organization_key(organization_name, key_name, permissions, auth \\ nil) do
     auth = auth || auth_info(:write)
 
@@ -139,6 +145,7 @@ defmodule Mix.Tasks.Hex do
     end
   end
 
+  @doc false
   def general_key_name(nil) do
     {:ok, hostname} = :inet.gethostname()
     List.to_string(hostname)
@@ -148,22 +155,26 @@ defmodule Mix.Tasks.Hex do
     key
   end
 
+  @doc false
   def api_key_name(key, extra \\ nil) do
     {:ok, hostname} = :inet.gethostname()
     name = "#{key || hostname}-api"
     if extra, do: "#{name}-#{extra}", else: name
   end
 
+  @doc false
   def repository_key_name(organization, key) do
     {:ok, hostname} = :inet.gethostname()
     "#{key || hostname}-repository-#{organization}"
   end
 
+  @doc false
   def repositories_key_name(key) do
     {:ok, hostname} = :inet.gethostname()
     "#{key || hostname}-repositories"
   end
 
+  @doc false
   def update_keys(write_key, read_key \\ nil) do
     Hex.Config.update(
       "$write_key": write_key,
@@ -176,6 +187,7 @@ defmodule Mix.Tasks.Hex do
     Hex.State.put(:api_key_read, read_key)
   end
 
+  @doc false
   def auth_organization(name, key) do
     repo = Hex.Repo.get_repo(name) || Hex.Repo.default_hexpm_repo()
     repo = Map.put(repo, :auth_key, key)
@@ -185,6 +197,7 @@ defmodule Mix.Tasks.Hex do
     |> Hex.Config.update_repos()
   end
 
+  @doc false
   def auth_info(permission, opts \\ [])
 
   def auth_info(:write, opts) do
@@ -229,6 +242,7 @@ defmodule Mix.Tasks.Hex do
     Mix.raise("No authenticated user found. Run `mix hex.user auth`")
   end
 
+  @doc false
   def prompt_encrypt_key(write_key, read_key, challenge \\ "Local password") do
     password = password_get("#{challenge}:") |> Hex.string_trim()
     confirm = password_get("#{challenge} (confirm):") |> Hex.string_trim()
@@ -242,6 +256,7 @@ defmodule Mix.Tasks.Hex do
     update_keys(encrypted_write_key, read_key)
   end
 
+  @doc false
   def prompt_decrypt_key(encrypted_key, challenge \\ "Local password") do
     password = password_get("#{challenge}:") |> Hex.string_trim()
 
@@ -255,14 +270,17 @@ defmodule Mix.Tasks.Hex do
     end
   end
 
+  @doc false
   def encrypt_key(password, key) do
     Hex.Crypto.encrypt(key, password, @apikey_tag)
   end
 
+  @doc false
   def decrypt_key(password, key) do
     Hex.Crypto.decrypt(key, password, @apikey_tag)
   end
 
+  @doc false
   def required_opts(opts, required) do
     Enum.map(required, fn req ->
       unless Keyword.has_key?(opts, req) do
@@ -271,10 +289,12 @@ defmodule Mix.Tasks.Hex do
     end)
   end
 
+  @doc false
   def convert_permissions([]) do
     nil
   end
 
+  @doc false
   def convert_permissions(permissions) do
     Enum.map(permissions, fn permission ->
       permission = String.downcase(permission)
@@ -285,6 +305,7 @@ defmodule Mix.Tasks.Hex do
 
   # Password prompt that hides input by every 1ms
   # clearing the line with stderr
+  @doc false
   def password_get(prompt) do
     if Hex.State.fetch!(:clean_pass) do
       password_clean(prompt)
@@ -318,6 +339,7 @@ defmodule Mix.Tasks.Hex do
 
   @progress_steps 25
 
+  @doc false
   def progress(nil) do
     fn _ -> nil end
   end
@@ -340,8 +362,10 @@ defmodule Mix.Tasks.Hex do
   end
 
   if Mix.env() == :test do
+    @doc false
     def set_exit_code(code), do: throw({:exit_code, code})
   else
+    @doc false
     def set_exit_code(code), do: System.at_exit(fn _ -> System.halt(code) end)
   end
 end

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -23,6 +23,7 @@ defmodule Mix.Tasks.Hex.Info do
 
   @switches [organization: :string]
 
+  @impl true
   def run(args) do
     Hex.start()
     {opts, args} = Hex.OptionParser.parse!(args, strict: @switches)

--- a/lib/mix/tasks/hex.install.ex
+++ b/lib/mix/tasks/hex.install.ex
@@ -13,6 +13,7 @@ defmodule Mix.Tasks.Hex.Install do
       mix hex.install VERSION
   """
 
+  @impl true
   def run(args) do
     case args do
       [version] ->

--- a/lib/mix/tasks/hex.organization.ex
+++ b/lib/mix/tasks/hex.organization.ex
@@ -98,6 +98,7 @@ defmodule Mix.Tasks.Hex.Organization do
     permission: [:string, :keep]
   ]
 
+  @impl true
   def run(args) do
     Hex.start()
     {opts, args} = Hex.OptionParser.parse!(args, switches: @switches)

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -25,6 +25,7 @@ defmodule Mix.Tasks.Hex.Outdated do
 
   @switches [all: :boolean, pre: :boolean]
 
+  @impl true
   def run(args) do
     Hex.check_deps()
     Hex.start()

--- a/lib/mix/tasks/hex.owner.ex
+++ b/lib/mix/tasks/hex.owner.ex
@@ -42,6 +42,7 @@ defmodule Mix.Tasks.Hex.Owner do
 
   @switches [organization: :string, level: :string]
 
+  @impl true
   def run(args) do
     Hex.start()
     {opts, args} = Hex.OptionParser.parse!(args, strict: @switches)
@@ -120,7 +121,7 @@ defmodule Mix.Tasks.Hex.Owner do
     end
   end
 
-  def list_owned_packages() do
+  defp list_owned_packages() do
     auth = Mix.Tasks.Hex.auth_info(:read)
 
     case Hex.API.User.me(auth) do

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -99,6 +99,7 @@ defmodule Mix.Tasks.Hex.Publish do
     dry_run: :boolean
   ]
 
+  @impl true
   def run(args) do
     Hex.check_deps()
     Hex.start()

--- a/lib/mix/tasks/hex.repo.ex
+++ b/lib/mix/tasks/hex.repo.ex
@@ -59,6 +59,7 @@ defmodule Mix.Tasks.Hex.Repo do
 
   @switches [url: :string, public_key: :string, auth_key: :string]
 
+  @impl true
   def run(args) do
     Hex.start()
     {opts, args} = Hex.OptionParser.parse!(args, strict: @switches)

--- a/lib/mix/tasks/hex.retire.ex
+++ b/lib/mix/tasks/hex.retire.ex
@@ -34,6 +34,7 @@ defmodule Mix.Tasks.Hex.Retire do
 
   @switches [message: :string, unretire: :boolean, organization: :string]
 
+  @impl true
   def run(args) do
     Hex.start()
     {opts, args} = Hex.OptionParser.parse!(args, strict: @switches)

--- a/lib/mix/tasks/hex.search.ex
+++ b/lib/mix/tasks/hex.search.ex
@@ -18,6 +18,7 @@ defmodule Mix.Tasks.Hex.Search do
 
   @switches [organization: :string, all_organizations: :boolean]
 
+  @impl true
   def run(args) do
     Hex.start()
     {opts, args} = Hex.OptionParser.parse!(args, strict: @switches)

--- a/lib/mix/tasks/hex.user.ex
+++ b/lib/mix/tasks/hex.user.ex
@@ -93,6 +93,7 @@ defmodule Mix.Tasks.Hex.User do
     permission: [:string, :keep]
   ]
 
+  @impl true
   def run(args) do
     Hex.start()
     {opts, args} = Hex.OptionParser.parse!(args, strict: @switches)


### PR DESCRIPTION
The only things left are Mix tasks which brings me to...

WDYT about hosting task docs on hexdocs.pm? I think it provides following benefits:
1. it looks exactly the same as any other Mix tasks docs
2. We'll take advantage of all future improvements to ExDoc (e.g. full-text search)
3. (minor) we reduce tiny maintenance burden of keeping task docs html up to date. Btw, not a big deal now but may come in handy when Hex reaches v1.0 and we'd differentiate between v1.0 and v1.1 etc.
4. (minor) with recent changes to ExDoc we may even be able to eventually autolink things like: `mix hex.publish` to https://hexdocs.pm/hex/Mix.Tasks.Hex.Publish.html so we make that more discoverable too.

The downside is we're no longer on a single page and we might have to change bob to set it up.

Here's a stab at it (that would be separate PR):

![screenshot 2018-11-06 at 00 44 44](https://user-images.githubusercontent.com/76071/48033851-563f5780-e15d-11e8-847a-67c319939813.png)

