### PR TITLE
Changes hex.config to output all config settings and where they are derived from

### DIFF
--- a/lib/hex/api.ex
+++ b/lib/hex/api.ex
@@ -30,7 +30,11 @@ defmodule Hex.API do
       %{'content-length' => Hex.to_charlist(byte_size(body))}
       |> Map.merge(headers(opts))
 
-    opts = [timeout: Hex.State.fetch!(:http_timeout) || @tar_timeout]
+    opts = [
+      timeout:
+        Hex.State.fetch!(:http_timeout, fn val -> if is_integer(val), do: val * 1000 end) ||
+          @tar_timeout
+    ]
 
     HTTP.request(:post, url(repo, path), headers, encode_tar(body, progress), opts)
     |> handle_response()

--- a/lib/hex/http.ex
+++ b/lib/hex/http.ex
@@ -7,7 +7,12 @@ defmodule Hex.HTTP do
 
   def request(method, url, headers, body, opts \\ []) do
     headers = build_headers(headers)
-    timeout = opts[:timeout] || Hex.State.fetch!(:http_timeout) || @request_timeout
+
+    timeout =
+      opts[:timeout] ||
+        Hex.State.fetch!(:http_timeout, fn val -> if is_integer(val), do: val * 1000 end) ||
+        @request_timeout
+
     http_opts = build_http_opts(url, timeout)
     opts = [body_format: :binary]
     request = build_request(url, headers, body)

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -126,6 +126,12 @@ defmodule Hex.State do
     end)
   end
 
+  def fetch!(key, transform) do
+    key
+    |> fetch!()
+    |> transform.()
+  end
+
   def fetch_source!(key) do
     Agent.get(@name, fn state ->
       case Map.fetch(state, key) do
@@ -234,8 +240,8 @@ defmodule Hex.State do
   defp version_pad([major, minor, patch | _]), do: [major, minor, patch]
 
   def http_timeout(nil), do: nil
-  def http_timeout(seconds) when is_integer(seconds), do: seconds * 1000
-  def http_timeout(seconds), do: http_timeout(to_integer(seconds))
+  def http_timeout(seconds) when is_integer(seconds), do: seconds
+  def http_timeout(seconds), do: to_integer(seconds)
 
   def id(arg), do: arg
 end

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -106,23 +106,17 @@ defmodule Mix.Tasks.Hex.Config do
   end
 
   defp read(key) when is_binary(key) and key in @valid_read_keys do
-    case Map.fetch(Hex.State.get_all(), :"#{key}") do
-      {:ok, {{:env, env_var}, value}} ->
+    case Map.fetch!(Hex.State.get_all(), :"#{key}") do
+      {{:env, env_var}, value} ->
         Hex.Shell.info("#{label(key)}: #{inspect(value, pretty: true)} (using `#{env_var}`)")
 
-      {:ok, {{:config, _key}, value}} ->
+      {{:config, _key}, value} ->
         Hex.Shell.info(
           "#{label(key)}: #{inspect(value, pretty: true)} (using `#{config_path()}`)"
         )
 
-      {:ok, {:default, value}} ->
+      {:default, value} ->
         Hex.Shell.info("#{label(key)}: #{inspect(value, pretty: true)} (default)")
-
-      {:ok, {:computed, value}} ->
-        Hex.Shell.info("#{label(key)}: #{inspect(value, pretty: true)} (computed)")
-
-      :error ->
-        Mix.raise("The key #{key} is not valid")
     end
   end
 

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -27,14 +27,15 @@ defmodule Mix.Tasks.Hex.Config do
       setting the environment variable `HEX_UNSAFE_REGISTRY` (Default:
       `false`)
     * `http_proxy` - HTTP proxy server. Can be overridden by setting the
-      environment variable `HTTP_PROXY`
+      environment variable `HTTP_PROXY` (Default: `nil`)
     * `https_proxy` - HTTPS proxy server. Can be overridden by setting the
-      environment variable `HTTPS_PROXY`
+      environment variable `HTTPS_PROXY` (Default: `nil`)
     * `http_concurrency` - Limits the number of concurrent HTTP requests in
       flight. Can be overridden by setting the environment variable
       `HEX_HTTP_CONCURRENCY` (Default: `8`)
     * `http_timeout` - Sets the timeout for HTTP requests in seconds. Can be
       overridden by setting the environment variable `HEX_HTTP_TIMEOUT`
+      (Default: `nil`)
 
   `HEX_HOME` environment variable can be set to point to the directory where Hex
   stores the cache and configuration (Default: `~/.hex`)
@@ -45,9 +46,19 @@ defmodule Mix.Tasks.Hex.Config do
   """
 
   @switches [delete: :boolean]
-  @valid_keys [
-    "api_key",
+  @valid_write_keys [
     "api_url",
+    "offline",
+    "unsafe_https",
+    "unsafe_registry",
+    "http_proxy",
+    "https_proxy",
+    "http_concurrency",
+    "http_timeout"
+  ]
+
+  @valid_read_keys [
+    "api_key_write_unencrypted",
     "offline",
     "unsafe_https",
     "unsafe_registry",
@@ -89,26 +100,40 @@ defmodule Mix.Tasks.Hex.Config do
   end
 
   defp list() do
-    Enum.each(config(), fn {key, value} ->
-      Hex.Shell.info("#{key}: #{inspect(value, pretty: true)}")
+    Enum.each(@valid_read_keys, fn key ->
+      read(key)
     end)
   end
 
-  defp read(key) do
-    case Keyword.fetch(config(), :"#{key}") do
-      {:ok, value} ->
-        Hex.Shell.info(inspect(value, pretty: true))
+  defp read(key) when is_binary(key) and key in @valid_read_keys do
+    case Map.fetch(Hex.State.get_all(), :"#{key}") do
+      {:ok, {{:env, env_var}, value}} ->
+        Hex.Shell.info("#{label(key)}: #{inspect(value, pretty: true)} (using `#{env_var}`)")
+
+      {:ok, {{:config, _key}, value}} ->
+        Hex.Shell.info(
+          "#{label(key)}: #{inspect(value, pretty: true)} (using `#{config_path()}`)"
+        )
+
+      {:ok, {:default, value}} ->
+        Hex.Shell.info("#{label(key)}: #{inspect(value, pretty: true)} (default)")
+
+      {:ok, {:computed, value}} ->
+        Hex.Shell.info("#{label(key)}: #{inspect(value, pretty: true)} (computed)")
 
       :error ->
-        Mix.raise("Config does not contain key #{key}")
+        Mix.raise("The key #{key} is not valid")
     end
   end
+
+  defp read(key) when is_atom(key), do: read(to_string(key))
+  defp read(key), do: Mix.raise("The key #{key} is not valid")
 
   defp delete(key) do
     Hex.Config.remove([String.to_atom(key)])
   end
 
-  defp set(key, value) when key in @valid_keys do
+  defp set(key, value) when key in @valid_write_keys do
     Hex.Config.update([{:"#{key}", value}])
   end
 
@@ -116,9 +141,16 @@ defmodule Mix.Tasks.Hex.Config do
     Mix.raise("Invalid key #{key}")
   end
 
-  defp config() do
-    Hex.Config.read()
-    |> Enum.reject(fn {key, _value} -> String.starts_with?(Atom.to_string(key), "$") end)
-    |> Keyword.delete(:encrypted_key)
+  defp config_path() do
+    :home
+    |> Hex.State.fetch!()
+    |> Path.join("hex.config")
+  end
+
+  defp label(key) do
+    case key do
+      "api_key_write_unencrypted" -> "api_key"
+      _ -> key
+    end
   end
 end

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -115,7 +115,7 @@ defmodule Mix.Tasks.Hex.Config do
       {{:config, _key}, value} ->
         print_value(key, value, verbose, "(using `#{config_path()}`)")
 
-      {:default, value} ->
+      {_, value} ->
         print_value(key, value, verbose, "(default)")
     end
   end

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -58,6 +58,7 @@ defmodule Mix.Tasks.Hex.Config do
   ]
 
   @valid_read_keys [
+    "api_url",
     "api_key_write_unencrypted",
     "offline",
     "unsafe_https",
@@ -65,7 +66,8 @@ defmodule Mix.Tasks.Hex.Config do
     "http_proxy",
     "https_proxy",
     "http_concurrency",
-    "http_timeout"
+    "http_timeout",
+    "home"
   ]
 
   @impl true

--- a/test/mix/tasks/hex.config_test.exs
+++ b/test/mix/tasks/hex.config_test.exs
@@ -7,6 +7,7 @@ defmodule Mix.Tasks.Hex.ConfigTest do
 
       Mix.Tasks.Hex.Config.run([])
 
+      assert_received {:mix_shell, :info, ["api_url:" <> _]}
       assert_received {:mix_shell, :info, ["api_key: nil (default)"]}
       assert_received {:mix_shell, :info, ["offline: false (default)"]}
       assert_received {:mix_shell, :info, ["unsafe_https: false (default)"]}
@@ -15,6 +16,7 @@ defmodule Mix.Tasks.Hex.ConfigTest do
       assert_received {:mix_shell, :info, ["https_proxy: nil (default)"]}
       assert_received {:mix_shell, :info, ["http_concurrency: 8 (default)"]}
       assert_received {:mix_shell, :info, ["http_timeout: nil (default)"]}
+      assert_received {:mix_shell, :info, ["home:" <> _]}
     end)
   end
 

--- a/test/mix/tasks/hex.config_test.exs
+++ b/test/mix/tasks/hex.config_test.exs
@@ -5,19 +5,38 @@ defmodule Mix.Tasks.Hex.ConfigTest do
     in_tmp(fn ->
       Hex.State.put(:home, File.cwd!())
 
-      assert_raise Mix.Error, "Config does not contain key offline", fn ->
-        Mix.Tasks.Hex.Config.run(["offline"])
-      end
+      Mix.Tasks.Hex.Config.run([])
 
-      Mix.Tasks.Hex.Config.run(["offline", "true"])
-      Mix.Tasks.Hex.Config.run(["offline"])
-      assert_received {:mix_shell, :info, ["\"true\""]}
+      assert_received {:mix_shell, :info, ["api_key: nil (computed)"]}
+      assert_received {:mix_shell, :info, ["offline: false (default)"]}
+      assert_received {:mix_shell, :info, ["unsafe_https: false (default)"]}
+      assert_received {:mix_shell, :info, ["unsafe_registry: false (default)"]}
+      assert_received {:mix_shell, :info, ["http_proxy: nil (default)"]}
+      assert_received {:mix_shell, :info, ["https_proxy: nil (default)"]}
+      assert_received {:mix_shell, :info, ["http_concurrency: 8 (default)"]}
+      assert_received {:mix_shell, :info, ["http_timeout: nil (default)"]}
+    end)
+  end
+
+  test "config key" do
+    in_tmp(fn ->
+      Hex.State.put(:home, File.cwd!())
 
       Mix.Tasks.Hex.Config.run(["offline", "--delete"])
 
-      assert_raise Mix.Error, "Config does not contain key offline", fn ->
-        Mix.Tasks.Hex.Config.run(["offline"])
-      end
+      Mix.Tasks.Hex.Config.run(["offline"])
+      assert_received {:mix_shell, :info, ["offline: false (default)"]}
+
+      System.put_env("HEX_OFFLINE", "true")
+      Hex.State.refresh()
+      Mix.Tasks.Hex.Config.run(["offline"])
+      assert_received {:mix_shell, :info, ["offline: true (using `HEX_OFFLINE`)"]}
+
+      System.delete_env("HEX_OFFLINE")
+      Hex.State.refresh()
+
+      Mix.Tasks.Hex.Config.run(["offline"])
+      assert_received {:mix_shell, :info, ["offline: false (default)"]}
 
       assert_raise Mix.Error, "Invalid key foo", fn ->
         Mix.Tasks.Hex.Config.run(["foo", "bar"])

--- a/test/mix/tasks/hex.config_test.exs
+++ b/test/mix/tasks/hex.config_test.exs
@@ -7,7 +7,7 @@ defmodule Mix.Tasks.Hex.ConfigTest do
 
       Mix.Tasks.Hex.Config.run([])
 
-      assert_received {:mix_shell, :info, ["api_key: nil (computed)"]}
+      assert_received {:mix_shell, :info, ["api_key: nil (default)"]}
       assert_received {:mix_shell, :info, ["offline: false (default)"]}
       assert_received {:mix_shell, :info, ["unsafe_https: false (default)"]}
       assert_received {:mix_shell, :info, ["unsafe_registry: false (default)"]}
@@ -25,18 +25,18 @@ defmodule Mix.Tasks.Hex.ConfigTest do
       Mix.Tasks.Hex.Config.run(["offline", "--delete"])
 
       Mix.Tasks.Hex.Config.run(["offline"])
-      assert_received {:mix_shell, :info, ["offline: false (default)"]}
+      assert_received {:mix_shell, :info, ["false"]}
 
       System.put_env("HEX_OFFLINE", "true")
       Hex.State.refresh()
       Mix.Tasks.Hex.Config.run(["offline"])
-      assert_received {:mix_shell, :info, ["offline: true (using `HEX_OFFLINE`)"]}
+      assert_received {:mix_shell, :info, ["true"]}
 
       System.delete_env("HEX_OFFLINE")
       Hex.State.refresh()
 
       Mix.Tasks.Hex.Config.run(["offline"])
-      assert_received {:mix_shell, :info, ["offline: false (default)"]}
+      assert_received {:mix_shell, :info, ["false"]}
 
       assert_raise Mix.Error, "Invalid key foo", fn ->
         Mix.Tasks.Hex.Config.run(["foo", "bar"])


### PR DESCRIPTION
Fixes #638 

There is a new module attr now for read keys. This was to accommodate the `api_key` but could also be useful if we want to show more attrs in read than we accept on write.

I added a fetch!/2 for the purpose of running transforms on the fetched value. It seemed like the best way given how we were using them. With the series of logical ORs, fetch! needs to return nil  sometimes, and multiplying nil * 1000 seemed like a bad idea :D 

![2018-12-17 16 02 12](https://user-images.githubusercontent.com/773380/50121246-609d4880-0215-11e9-80f8-baeaed8aa140.gif)
