### PR TITLE
Bring back listing Hex tasks in `mix hex`

### DIFF
--- a/lib/hex.ex
+++ b/lib/hex.ex
@@ -65,10 +65,16 @@ defmodule Hex do
         _other -> string
       end
     end
+
+    def string_pad_trailing(string, count) do
+      filler_size = max(count - byte_size(string), 0)
+      string <> String.duplicate(" ", filler_size)
+    end
   else
     def string_trim(string), do: String.trim(string)
     def string_trim_leading(string, trim), do: String.trim_leading(string, trim)
     def string_trim_trailing(string, trim), do: String.trim_trailing(string, trim)
+    def string_pad_trailing(string, count), do: String.pad_trailing(string, count)
     def to_charlist(term), do: Kernel.to_charlist(term)
     def string_to_charlist(string), do: String.to_charlist(string)
   end

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -20,15 +20,16 @@ defmodule Mix.Tasks.Hex do
     Hex.Shell.info("Hex v" <> Hex.version())
     Hex.Shell.info("Hex is a package manager for the Erlang ecosystem.")
 
-    Hex.Shell.info("Available tasks:")
-    line_break()
-
     print_available_tasks()
 
     Hex.Shell.info("Further information can be found here: https://hex.pm/docs")
   end
 
   defp print_available_tasks() do
+    line_break()
+    Hex.Shell.info("Available tasks:")
+    line_break()
+
     pattern = "hex."
     modules = Enum.filter(load_tasks(), &String.contains?(Mix.Task.task_name(&1), pattern))
     {docs, max} = build_task_doc_list(modules)

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -19,10 +19,46 @@ defmodule Mix.Tasks.Hex do
 
     Hex.Shell.info("Hex v" <> Hex.version())
     Hex.Shell.info("Hex is a package manager for the Erlang ecosystem.")
+
+    Hex.Shell.info("Available tasks:")
     line_break()
-    Hex.Shell.info("To list Hex tasks run: mix help --search hex.")
-    line_break()
+
+    print_available_tasks()
+
     Hex.Shell.info("Further information can be found here: https://hex.pm/docs")
+  end
+
+  defp print_available_tasks() do
+    pattern = "hex."
+    modules = Enum.filter(load_tasks(), &String.contains?(Mix.Task.task_name(&1), pattern))
+    {docs, max} = build_task_doc_list(modules)
+    display_doc_list(docs, max)
+    line_break()
+  end
+
+  defp load_tasks() do
+    Enum.filter(Mix.Task.load_all(), &(Mix.Task.moduledoc(&1) != false))
+  end
+
+  defp build_task_doc_list(modules) do
+    Enum.reduce(modules, {[], 0}, fn module, {docs, max} ->
+      if doc = Mix.Task.shortdoc(module) do
+        task = "mix " <> Mix.Task.task_name(module)
+        {[{task, doc} | docs], max(byte_size(task), max)}
+      else
+        {docs, max}
+      end
+    end)
+  end
+
+  defp display_doc_list(docs, max) do
+    Enum.each(Enum.sort(docs), fn {task, doc} ->
+      Mix.shell().info(format_task(task, max, doc))
+    end)
+  end
+
+  defp format_task(task, max, doc) do
+    Hex.string_pad_trailing(task, max) <> " # " <> doc
   end
 
   defp line_break(), do: Hex.Shell.info("")

--- a/test/mix/tasks/hex_test.exs
+++ b/test/mix/tasks/hex_test.exs
@@ -4,5 +4,6 @@ defmodule Mix.Tasks.HexTest do
   test "run without args shows help" do
     Mix.Tasks.Hex.run([])
     assert_received {:mix_shell, :info, ["Hex is a package manager for the Erlang ecosystem."]}
+    assert_received {:mix_shell, :info, ["mix hex.config" <> _]}
   end
 end


### PR DESCRIPTION
This reverts commit dedd914c97a393c768bfa79e39787b6dc28a224e.