### PR TITLE
Fix old-style mix.lock support

### DIFF
--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -100,6 +100,9 @@ defmodule Mix.Tasks.Hex.Outdated do
   defp get_requirements_from_lock(app, lock) do
     Enum.flat_map(lock, fn {source, lock} ->
       case Hex.Utils.lock(lock) do
+        %{deps: nil} ->
+          []
+
         %{deps: deps} ->
           Enum.flat_map(deps, fn {dep_app, req, _opts} ->
             if app == dep_app, do: [[Atom.to_string(source), req]], else: []


### PR DESCRIPTION
In the past when an application dependency did not have any dependencies the
mix.lock file was generated as a 3-tuple:
```
  "oauther": {:hex, :oauther, "1.0.2"},
```

While old, this is still valid. Currently `mix hex.outdated` is breaking if any
of the mix.lock contents use the 3-tuple format.

Here is an example of a mix.lock file that has a mix.lock that has an entry with
the old format:
https://github.com/ueberauth/ueberauth_example/blob/7e4d8b41c08d344a606a59554265d385555000a1/mix.lock

Running `mix hex.outdated` in that repository will give you the following error
without this change:

```
jason@jdesktop ~/d/f/ueberauth_example> mix hex.outdated
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil
    (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir) lib/enum.ex:141: Enumerable.reduce/3
    (elixir) lib/enum.ex:3015: Enum.flat_map/2
    (elixir) lib/enum.ex:1040: anonymous fn/3 in Enum.flat_map/2
    (stdlib) maps.erl:257: :maps.fold_1/3
    (elixir) lib/enum.ex:1956: Enum.flat_map/2
    (hex) lib/mix/tasks/hex.outdated.ex:162: anonymous fn/4 in Mix.Tasks.Hex.Outdated.get_versions/4
    (elixir) lib/enum.ex:2986: Enum.flat_map_list/2
```

I tried to add a test for this but I didn't see a way to add the test case to `hex.outdated_test.exs` since the mix.lock parsing isn't happening there.

Also a better fix would probably be to change the way that `destructure` is used when parsing a mix.lock file at:
https://github.com/axelson/hex/blob/aa3536a0a782acd046a776f31228a53b8e371c3b/lib/hex/utils.ex#L289

Fixes #667 