### PR TITLE
show a message when dependencies may contain breaking changes

### DIFF
--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -255,7 +255,7 @@ defmodule Hex.RemoteConverger do
         |> version_string_or_nil()
 
       change = categorize_dependency_change(previous_version, version)
-      warning = warning_string(previous_version, version)
+      warning = warning_message(previous_version, version)
       Map.put(acc, change, acc[change] ++ [{name, repo, previous_version, version, warning}])
     end)
   end
@@ -282,9 +282,9 @@ defmodule Hex.RemoteConverger do
     Version.compare(version, previous_version)
   end
 
-  defp warning_string(nil, _version), do: nil
+  defp warning_message(nil, _version), do: nil
 
-  defp warning_string(previous_version, version) do
+  defp warning_message(previous_version, version) do
     prev_ver =
       case Version.parse(previous_version) do
         {:ok, version} -> version

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -285,17 +285,8 @@ defmodule Hex.RemoteConverger do
   defp warning_message(nil, _version), do: nil
 
   defp warning_message(previous_version, version) do
-    prev_ver =
-      case Version.parse(previous_version) do
-        {:ok, version} -> version
-        :error -> nil
-      end
-
-    new_ver =
-      case Version.parse(version) do
-        {:ok, version} -> version
-        :error -> nil
-      end
+    prev_ver = Hex.Version.parse!(previous_version)
+    new_ver = Hex.Version.parse!(version)
 
     cond do
       Hex.Version.major_version_change?(prev_ver, new_ver) -> " (major)"

--- a/lib/hex/version.ex
+++ b/lib/hex/version.ex
@@ -240,4 +240,19 @@ defmodule Hex.Version do
   defp allow_pre_available? do
     Code.ensure_loaded?(Version) and function_exported?(Version, :match?, 3)
   end
+
+  def major_version_change?(%Version{major: major1}, %Version{major: major2})
+      when major1 != major2,
+      do: true
+
+  def major_version_change?(_version1, _version2), do: false
+
+  def breaking_minor_version_change?(%Version{major: 0, minor: minor1}, %Version{
+        major: 0,
+        minor: minor2
+      })
+      when minor1 != minor2,
+      do: true
+
+  def breaking_minor_version_change?(_version1, _version2), do: false
 end

--- a/lib/hex/version.ex
+++ b/lib/hex/version.ex
@@ -241,18 +241,11 @@ defmodule Hex.Version do
     Code.ensure_loaded?(Version) and function_exported?(Version, :match?, 3)
   end
 
-  def major_version_change?(%Version{major: major1}, %Version{major: major2})
-      when major1 != major2,
-      do: true
+  def major_version_change?(%Version{} = version1, %Version{} = version2) do
+    version1.major != version2.major
+  end
 
-  def major_version_change?(_version1, _version2), do: false
-
-  def breaking_minor_version_change?(%Version{major: 0, minor: minor1}, %Version{
-        major: 0,
-        minor: minor2
-      })
-      when minor1 != minor2,
-      do: true
-
-  def breaking_minor_version_change?(_version1, _version2), do: false
+  def breaking_minor_version_change?(%Version{} = version1, %Version{} = version2) do
+    version1.major == 0 and version2.major == 0 and version1.minor != version2.minor
+  end
 end

--- a/test/hex/version_test.exs
+++ b/test/hex/version_test.exs
@@ -22,4 +22,30 @@ defmodule Hex.VersionTest do
 
     assert :error = V.parse_requirement("foo")
   end
+
+  test "major_version_change?/2" do
+    {:ok, ver1} = Version.parse("0.1.0")
+    {:ok, ver2} = Version.parse("0.2.0")
+    {:ok, ver3} = Version.parse("1.0.0")
+    {:ok, ver4} = Version.parse("1.1.0")
+    {:ok, ver5} = Version.parse("2.2.0")
+
+    assert V.major_version_change?(ver3, ver5)
+    assert V.major_version_change?(ver1, ver3)
+    refute V.major_version_change?(ver1, ver2)
+    refute V.major_version_change?(ver3, ver4)
+  end
+
+  test "breaking_minor_version_change?/2" do
+    {:ok, ver1} = Version.parse("0.1.0")
+    {:ok, ver2} = Version.parse("0.2.0")
+    {:ok, ver3} = Version.parse("1.0.0")
+    {:ok, ver4} = Version.parse("1.1.0")
+    {:ok, ver5} = Version.parse("2.2.0")
+
+    assert V.breaking_minor_version_change?(ver1, ver2)
+    assert V.breaking_minor_version_change?(ver2, ver1)
+    refute V.breaking_minor_version_change?(ver3, ver4)
+    refute V.breaking_minor_version_change?(ver3, ver5)
+  end
 end


### PR DESCRIPTION
Fixes #676 

![screen shot 2019-03-05 at 10 17 10 am](https://user-images.githubusercontent.com/773380/53825752-4598c580-3f34-11e9-9803-cf400bbe579b.png)

This will show a warning when the major version changes (up or down) on a >= 1.0 dependency or the minor version changes (up or down) on a < 1.0 dependency.