### PR TITLE
Remove the tarball if the tarball is unable to open or has an invalid…

### DIFF
--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -142,13 +142,14 @@ defmodule Hex.SCM do
       try do
         Hex.unpack_tar!(path, dest)
       rescue
-        e ->
-          File.rm!(path)
-          e
+        exception ->
+          stacktrace = System.stacktrace()
+          File.rm(path)
+          reraise(exception, stacktrace)
       end
 
     if tar_checksum != registry_checksum do
-      File.rm!(path)
+      File.rm(path)
       raise("Checksum mismatch against registry")
     end
 

--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -137,9 +137,20 @@ defmodule Hex.SCM do
 
     File.rm_rf!(dest)
     registry_checksum = Hex.Registry.Server.checksum(repo, to_string(name), lock.version)
-    %{checksum: tar_checksum, metadata: meta} = Hex.unpack_tar!(path, dest)
 
-    if tar_checksum != registry_checksum, do: raise("Checksum mismatch against registry")
+    %{checksum: tar_checksum, metadata: meta} =
+      try do
+        Hex.unpack_tar!(path, dest)
+      rescue
+        e ->
+          File.rm!(path)
+          e
+      end
+
+    if tar_checksum != registry_checksum do
+      File.rm!(path)
+      raise("Checksum mismatch against registry")
+    end
 
     build_tools = guess_build_tools(meta)
 


### PR DESCRIPTION
Issue #674 . As discussed in the issue, just remove the tarball if the tarball is invalid.
No unit test is included due to the absence in unit test for the origin function.
Any idea on adding the unit test for this pull request? Or it is okay to skip it?