### PR TITLE
Add `cacerts_path` config option

### DIFF
--- a/lib/hex/http/certs.ex
+++ b/lib/hex/http/certs.ex
@@ -13,4 +13,10 @@ defmodule Hex.HTTP.Certs do
   def cacerts do
     @der_encoded
   end
+
+  def decode_runtime(path) do
+    crt = File.read!(path)
+    pems = :public_key.pem_decode(crt)
+    Enum.map(pems, fn {:Certificate, der, _} -> der end)
+  end
 end

--- a/lib/hex/http/ssl.ex
+++ b/lib/hex/http/ssl.ex
@@ -55,7 +55,7 @@ defmodule Hex.HTTP.SSL do
   end
 
   def get_ca_certs do
-    case Hex.State.fetch!(:alt_crt_path) do
+    case Hex.State.fetch!(:cacerts_path) do
       nil -> Certs.cacerts()
       path -> Certs.decode_runtime(path)
     end

--- a/lib/hex/http/ssl.ex
+++ b/lib/hex/http/ssl.ex
@@ -54,6 +54,13 @@ defmodule Hex.HTTP.SSL do
     check?
   end
 
+  def get_ca_certs do
+    case Hex.State.fetch!(:alt_crt_path) do
+      nil -> Certs.cacerts()
+      path -> Certs.decode_runtime(path)
+    end
+  end
+
   def ssl_opts(url) do
     hostname = Hex.string_to_charlist(URI.parse(url).host)
     ciphers = filter_ciphers(@default_ciphers)
@@ -66,7 +73,7 @@ defmodule Hex.HTTP.SSL do
         verify: :verify_peer,
         depth: 4,
         partial_chain: partial_chain,
-        cacerts: Certs.cacerts(),
+        cacerts: get_ca_certs(),
         verify_fun: verify_fun,
         server_name_indication: hostname,
         secure_renegotiate: true,

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -90,8 +90,8 @@ defmodule Hex.State do
       config: [:diff_command],
       default: Mix.Tasks.Hex.Package.default_diff_command()
     },
-    alt_crt_path: %{
-      env: ["HEX_ALT_CRT_PATH"],
+    cacerts_path: %{
+      env: ["HEX_CACERTS_PATH"],
       default: nil,
       config: [:alt_crt_path]
     }

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -89,6 +89,11 @@ defmodule Hex.State do
       env: ["HEX_DIFF_COMMAND"],
       config: [:diff_command],
       default: Mix.Tasks.Hex.Package.default_diff_command()
+    },
+    alt_crt_path: %{
+      env: ["HEX_ALT_CRT_PATH"],
+      default: nil,
+      config: [:alt_crt_path]
     }
   }
 

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -93,7 +93,7 @@ defmodule Hex.State do
     cacerts_path: %{
       env: ["HEX_CACERTS_PATH"],
       default: nil,
-      config: [:alt_crt_path]
+      config: [:cacerts_path]
     }
   }
 

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -49,8 +49,9 @@ defmodule Mix.Tasks.Hex.Config do
       (Default: `nil`)
     * `mirror_url` - Hex mirror URL. Can be overridden by setting the
       environment variable `HEX_MIRROR` (Default: `nil`)
-    * `cacerts_path` - Path of ca certs for SSL requests. This is useful in an
-       Enterprise environment where self-signed certs are being injected.
+    * `cacerts_path` - Path to the CA certificate store PEM file. If not set,
+      a CA bundle that ships with Hex is used. Can be overriden by setting the
+      environment variable `HEX_CACERTS_PATH`. (Default: `nil`)
 
   `HEX_HOME` environment variable can be set to point to the directory where Hex
   stores the cache and configuration (Default: `~/.hex`)

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -49,6 +49,8 @@ defmodule Mix.Tasks.Hex.Config do
       (Default: `nil`)
     * `mirror_url` - Hex mirror URL. Can be overridden by setting the
       environment variable `HEX_MIRROR` (Default: `nil`)
+    * `cacerts_path` - Path of ca certs for SSL requests. This is useful in an
+       Enterprise environment where self-signed certs are being injected.
 
   `HEX_HOME` environment variable can be set to point to the directory where Hex
   stores the cache and configuration (Default: `~/.hex`)


### PR DESCRIPTION
This changes allows the option to specify a custom CA instead of the ones that get compiled into hex. 

Use Case: ssl breaks when using a self signed CA such as in an enterprise environment. 
Current workout: enable unsafe_https. (this is not ideal) 

Reference: https://github.com/hexpm/hex/issues/690
Reference: https://github.com/hexpm/hex/issues/146

This change allows an option to be specified "HEX_ALT_CRT_PATH" which will load that CA instead of the ones that are compiled in. 


I tested as so:
`mix hex.config unsafe_https false  `
`iex -S mix`
`Hex.State.fetch!(:unsafe_https)` Confirm this is false 

Fetch a package from hex:
`Hex.API.Package.get("hexpm", "timex")`

This is the error I get inside a self signed ssl world: 

> {:error,
>  {:failed_connect,
>   [
>     {:to_address, {'hex.pm', 443}},
>     {:inet, [:inet],
>      {:tls_alert,
>       {:unknown_ca,
>        'TLS client: In state certify at ssl_handshake.erl:1666 generated CLIENT ALERT: Fatal - Unknown CA\n'}}}
>   ]}}

Rerun the app with the HEX_ALT_CRT_PATH specified: 
`HEX_ALT_CRT_PATH=/tmp/hl-ca-bundle.crt iex -S mix`
Fetch a package from hex:
`Hex.API.Package.get("hexpm", "timex")`

This is the 200 we get back: 

> {:ok,
>  {200,
>   %{
>     "docs_html_url" => "https://hexdocs.pm/timex/",
>     "downloads" => %{
>       "all" => 10929378,
>       "day" => 63714,
>       "recent" => 3252289,
>       "week" => 306078
>     },
>     "html_url" => "https://hex.pm/packages/timex",
>     "inserted_at" => "2014-04-23T04:00:39Z",
>     "meta" => %{
>       "description" => "Timex is a rich, comprehensive Date/Time library for Elixir projects, with full timezone support via the :tzdata package.\nIf you need to manipulate dates, times, datetimes, timestamps, etc., then Timex is for you!",
>       "licenses" => ["MIT"],
>       "links" => %{
>         "Changelog" => "https://github.com/bitwalker/timex/blob/master/CHANGELOG.md",
>         "GitHub" => "https://github.com/bitwalker/timex"
>       },
>       "maintainers" => []
>     },
>     "name" => "timex",
>     "owners" => [
>       %{
>         "email" => "paulschoenfelder@gmail.com",
>         "url" => "https://hex.pm/api/users/bitwalker",
>         "username" => "bitwalker"
>       }
>     ],
>     "releases" => [
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2019-06-27T20:19:38Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.6.1",
>         "version" => "3.6.1"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2019-06-26T22:41:04Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.6.0",
>         "version" => "3.6.0"
>       },
>       %{ 
>         "has_docs" => true,
>         "inserted_at" => "2019-01-18T16:42:47Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.5.0",
>         "version" => "3.5.0"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2018-11-03T18:08:04Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.4.2",
>         "version" => "3.4.2"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2018-09-19T17:17:55Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.4.1",
>         "version" => "3.4.1"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2018-05-08T23:25:18Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.3.0",
>         "version" => "3.3.0"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2018-04-14T01:07:14Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.2.2",
>         "version" => "3.2.2"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2018-02-20T18:39:16Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.2.1",
>         "version" => "3.2.1"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2018-02-20T18:31:38Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.2.0",
>         "version" => "3.2.0"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2018-01-30T21:36:58Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.25",
>         "version" => "3.1.25"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-07-19T02:54:32Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.24",
>         "version" => "3.1.24"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-07-17T17:07:28Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.23",
>         "version" => "3.1.23"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-07-17T15:01:37Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.22",
>         "version" => "3.1.22"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-07-01T16:38:46Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.21",
>         "version" => "3.1.21"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-06-28T19:33:45Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.20",
>         "version" => "3.1.20"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-06-27T22:17:13Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.19",
>         "version" => "3.1.19"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-06-27T18:08:23Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.18",
>         "version" => "3.1.18"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-06-21T21:21:00Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.17",
>         "version" => "3.1.17"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-06-21T18:14:14Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.16",
>         "version" => "3.1.16"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-05-17T22:22:44Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.15",
>         "version" => "3.1.15"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-02-17T15:22:38Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.13",
>         "version" => "3.1.13"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-02-13T04:43:15Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.12",
>         "version" => "3.1.12"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-02-09T17:58:15Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.11",
>         "version" => "3.1.11"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-02-07T20:16:23Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.10",
>         "version" => "3.1.10"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-02-02T02:12:57Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.9",
>         "version" => "3.1.9"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-01-19T20:57:44Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.8",
>         "version" => "3.1.8"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-01-05T03:32:48Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.7",
>         "version" => "3.1.7"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2017-01-03T21:15:35Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.6",
>         "version" => "3.1.6"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2016-11-06T19:43:37Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.5",
>         "version" => "3.1.5"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2016-11-06T05:55:24Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.4",
>         "version" => "3.1.4"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2016-10-28T15:45:26Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.3",
>         "version" => "3.1.3"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2016-10-27T17:05:34Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.2",
>         "version" => "3.1.2"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2016-10-25T21:22:15Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.1",
>         "version" => "3.1.1"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2016-10-11T21:16:45Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.1.0",
>         "version" => "3.1.0"
>       },
>       %{
>         "has_docs" => true,
>         "inserted_at" => "2016-08-18T14:44:54Z",
>         "url" => "https://hex.pm/api/packages/timex/releases/3.0.8",
>         ...
>       },
>       %{"has_docs" => true, "inserted_at" => "2016-08-15T18:05:46Z", ...},
>       %{"has_docs" => true, ...},
>       %{...},
>       ...
>     ],
>     "repository" => "hexpm",
>     "retirements" => %{
>       "3.1.25" => %{
>         "message" => "Incorrect Elixir version requirement",
>         "reason" => "invalid"
>       }
>     },
>     "updated_at" => "2019-08-11T12:55:00Z",
>     "url" => "https://hex.pm/api/packages/timex"
>   },
>   %{
>     'alt-svc' => 'clear',
>     'cache-control' => 'public, max-age=60',
>     'content-length' => '17024',
>     'content-type' => 'application/vnd.hex+erlang; charset=utf-8',
>     'date' => 'Thu, 21 Nov 2019 13:56:20 GMT',
>     'etag' => 'a17d2c81bc6739e508bcbb6ed2665c79',
>     'last-modified' => 'Sun, 11 Aug 2019 12:55:00 GMT',
>     'server' => 'Cowboy',
>     'strict-transport-security' => 'max-age=31536000',
>     'vary' => 'accept, accept-encoding, accept-encoding',
>     'via' => '1.1 google',
>     'x-ratelimit-limit' => '100',
>     'x-ratelimit-remaining' => '98',
>     'x-ratelimit-reset' => '1574344620',
>     'x-request-id' => 'FdkyDi5fdBNbaLEAPljR'
>   }}}
> 

The case inside Hex.HTTP.SSL.get_ca_certs/0 should be enough to maintain default behaviour if alt_crt_path is not set. 

Any feedback would be appreciated!
