### PR TITLE
Always add *.DS_Store to :exclude_patterns

### DIFF
--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -276,7 +276,7 @@ defmodule Mix.Tasks.Hex.Build do
   @doc false
   def package(package, config) do
     files = package[:files] || @default_files
-    exclude_patterns = package[:exclude_patterns] || []
+    exclude_patterns = (package[:exclude_patterns] || []) ++ [~r/\W\.DS_Store$/]
 
     files =
       files


### PR DESCRIPTION
Prevent Apple Desktop Services Store (`*.DS_Store`) files from slipping into Hex packages using the `exclude_patterns` package option introduced in https://github.com/hexpm/hex/pull/512.

Given that the issue affects a large number of popular Elixir packages (e.g., Ecto and gen_stage), [@josevalim proposed](https://github.com/elixir-ecto/ecto/pull/3221#issuecomment-581791936) that an overarching solution is to be preferred over a [case-by-case one](https://github.com/elixir-ecto/ecto/pull/3221).

This is an initial implementation based on vague requirements and I welcome suggestions on how to improve it.