### PR TITLE
Fix mix hex.outdated version sort assumption

### DIFF
--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -215,9 +215,7 @@ defmodule Mix.Tasks.Hex.Outdated do
         end)
       end
 
-    versions
-    |> Enum.sort_by(&Hex.Version.parse!/1)
-    |> List.last()
+    Enum.max_by(versions, &Hex.Version.parse!/1)
   end
 
   defp format_all_row([package, lock, latest, requirements]) do

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -215,7 +215,9 @@ defmodule Mix.Tasks.Hex.Outdated do
         end)
       end
 
-    List.last(versions)
+    versions
+    |> Enum.sort_by(&Hex.Version.parse!/1)
+    |> List.last()
   end
 
   defp format_all_row([package, lock, latest, requirements]) do


### PR DESCRIPTION
When using mini_repo, this function is returning versions in a
different order than hex.outdated is expecting. To wit, one of our
applications is returning:

```elixir
["12.2.0", "12.1.5", "12.1.3", "12.0.0"]
```

This causes the `List.last/1` command here to return the incorrect
value.

I wasn't sure the best way to unit test this, but it's working for me
locally, so I figured I would open the PR as is and we could discuss
ways to test this behavior.