### PR TITLE
clarify publish messaging around ownership

### DIFF
--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -313,10 +313,10 @@ defmodule Mix.Tasks.Hex.Publish do
 
   defp do_print_owner_prompt(organizations) do
     Hex.Shell.info(
-      "You are a member of organizations, select if you wish to publish " <>
-        "the package with yourself as owner or an organization as owner. " <>
+      "You are a member of organizations. Would you like to publish " <>
+        "the package with yourself as owner or an organization as owner? " <>
         "If you publish with an organization as owner your package will " <>
-        "be public but managed by selected the organization."
+        "be public but managed by the selected organization."
     )
 
     Hex.Shell.info("")

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -313,7 +313,7 @@ defmodule Mix.Tasks.Hex.Publish do
 
   defp do_print_owner_prompt(organizations) do
     Hex.Shell.info(
-      "You are a member of organizations. Would you like to publish " <>
+      "You are a member of one or multiple organizations. Would you like to publish " <>
         "the package with yourself as owner or an organization as owner? " <>
         "If you publish with an organization as owner your package will " <>
         "be public but managed by the selected organization."


### PR DESCRIPTION
I think this makes it slightly easier to understand the messaging about ownership that shows when publishing a new package.

I'm happy to make any desired changes.