### PR TITLE
remove reliance on colors for hex.outdated

### DIFF
--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -100,8 +100,7 @@ defmodule Mix.Tasks.Hex.Outdated do
     Hex.Shell.info("")
     Mix.Tasks.Hex.print_table(header, values)
 
-    message =
-      "Up-to-date indicates if the requirement matches the latest version."
+    message = "Up-to-date indicates if the requirement matches the latest version."
 
     Hex.Shell.info(["\n", message])
 

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -95,14 +95,13 @@ defmodule Mix.Tasks.Hex.Outdated do
       |> Hex.Shell.info()
     end
 
-    header = ["Source", "Requirement"]
+    header = ["Source", "Requirement", "Up-to-date"]
     values = Enum.map(requirements, &format_single_row(&1, latest))
     Hex.Shell.info("")
     Mix.Tasks.Hex.print_table(header, values)
 
     message =
-      "A green requirement means that it matches the latest version, " <>
-        "a red requirement means that that it does not match the latest version."
+      "Up-to-date indicates if the requirement matches the latest version."
 
     Hex.Shell.info(["\n", message])
 
@@ -141,7 +140,8 @@ defmodule Mix.Tasks.Hex.Outdated do
   defp format_single_row([source, req], latest) do
     req_matches? = version_match?(latest, req)
     req_color = if req_matches?, do: :green, else: :red
-    [[:bright, source], [req_color, req || ""]]
+    up_to_date? = if req_matches?, do: "Yes", else: "No"
+    [[:bright, source], [req_color, req || ""], up_to_date?]
   end
 
   defp all(lock, opts) do
@@ -158,13 +158,12 @@ defmodule Mix.Tasks.Hex.Outdated do
     if Enum.empty?(values) do
       Hex.Shell.info("No hex dependencies")
     else
-      header = ["Dependency", "Current", "Latest", "Update possible"]
+      header = ["Dependency", "Current", "Latest", "Up-to-date", "Update possible"]
       Mix.Tasks.Hex.print_table(header, values)
 
       message =
-        "A green version in latest means you have the latest version of a given package, " <>
-          "a red version means there is a newer version available. Update possible indicates " <>
-          "if your current requirement matches the latest version.\n" <>
+        "Up-to-date indicates if you have the latest version of a given package.\n" <>
+          "Update possible indicates if your current requirement matches the latest version.\n" <>
           "Run `mix hex.outdated APP` to see requirements for a specific dependency."
 
       Hex.Shell.info(["\n" | message])
@@ -221,6 +220,7 @@ defmodule Mix.Tasks.Hex.Outdated do
   defp format_all_row([package, lock, latest, requirements]) do
     outdated? = Hex.Version.compare(lock, latest) == :lt
     latest_color = if outdated?, do: :red, else: :green
+    up_to_date? = if outdated?, do: [:red, "No"], else: [:green, "Yes"]
 
     req_matches? = Enum.all?(requirements, &version_match?(latest, &1))
 
@@ -235,6 +235,7 @@ defmodule Mix.Tasks.Hex.Outdated do
       [:bright, package],
       lock,
       [latest_color, latest],
+      up_to_date?,
       [update_possible_color, update_possible]
     ]
   end

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -141,7 +141,7 @@ defmodule Mix.Tasks.Hex.Outdated do
     req_matches? = version_match?(latest, req)
     req_color = if req_matches?, do: :green, else: :red
     up_to_date? = if req_matches?, do: "Yes", else: "No"
-    [[:bright, source], [req_color, req || ""], up_to_date?]
+    [[:bright, source], [req_color, req || ""], [reg_color, up_to_date?]]
   end
 
   defp all(lock, opts) do

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -141,7 +141,7 @@ defmodule Mix.Tasks.Hex.Outdated do
     req_matches? = version_match?(latest, req)
     req_color = if req_matches?, do: :green, else: :red
     up_to_date? = if req_matches?, do: "Yes", else: "No"
-    [[:bright, source], [req_color, req || ""], [reg_color, up_to_date?]]
+    [[:bright, source], [req_color, req || ""], [req_color, up_to_date?]]
   end
 
   defp all(lock, opts) do

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -93,7 +93,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           [:bright, "bar", :reset],
           ["         ", "0.1.0", :reset],
           ["    ", :green, "0.1.0", :reset],
-          ["   ", :green, "", :reset],
+          ["   ", :green, "Yes", :reset],
+          ["         ", :green, "", :reset],
           "                 "
         ]
         |> IO.ANSI.format()
@@ -121,7 +122,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           [:bright, "bar", :reset],
           ["         ", "0.1.0", :reset],
           ["    ", :green, "0.1.0", :reset],
-          ["   ", :green, "", :reset],
+          ["   ", :green, "Yes", :reset],
+          ["         ", :green, "", :reset],
           "                 "
         ]
         |> IO.ANSI.format()
@@ -132,7 +134,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           [:bright, "foo", :reset],
           ["         ", "0.1.0", :reset],
           ["    ", :red, "0.1.1", :reset],
-          ["   ", :green, "Yes", :reset],
+          ["   ", :red, "No", :reset],
+          ["          ", :green, "Yes", :reset],
           "              "
         ]
         |> IO.ANSI.format()
@@ -144,6 +147,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["      ", "0.0.1", :reset],
           ["    ", :red, "0.1.0", :reset],
           ["   ", :red, "No", :reset],
+          ["          ", :red, "No", :reset],
           "               "
         ]
         |> IO.ANSI.format()
@@ -178,6 +182,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["         ", "0.1.0", :reset],
           ["    ", :red, "0.1.1", :reset],
           ["   ", :red, "No", :reset],
+          ["          ", :red, "No", :reset],
           "               "
         ]
         |> IO.ANSI.format()
@@ -204,8 +209,9 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           [:bright, "beta", :reset],
           ["        ", "1.0.0", :reset],
           ["    ", :green, "1.0.0", :reset],
-          ["   ", :green, "", :reset],
-          "                 "
+          ["   ", :green, "Yes", :reset],
+          ["         ", :green, :reset],
+          ["                 "]
         ]
         |> IO.ANSI.format()
         |> List.to_string()
@@ -221,6 +227,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["        ", "1.0.0", :reset],
           ["    ", :red, "1.1.0-beta", :reset],
           ["  ", :red, "No", :reset],
+          ["          ", :red, "No", :reset],
           "               "
         ]
         |> IO.ANSI.format()
@@ -253,21 +260,60 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
       assert_received {:mix_shell, :info, [^msg]}
 
       mix =
-        [:bright, "mix.exs", :reset, "   ", :green, ">= 0.0.0", :reset, "     "]
+        [
+          :bright,
+          "mix.exs",
+          :reset,
+          "   ",
+          :green,
+          ">= 0.0.0",
+          :reset,
+          "     ",
+          :green,
+          "Yes",
+          :reset,
+          "         "
+        ]
         |> IO.ANSI.format()
         |> List.to_string()
 
       assert_received {:mix_shell, :info, [^mix]}
 
       ecto =
-        [:bright, "ecto", :reset, "      ", :red, "~> 0.0.1", :reset, "     "]
+        [
+          :bright,
+          "ecto",
+          :reset,
+          "      ",
+          :red,
+          "~> 0.0.1",
+          :reset,
+          "     ",
+          :red,
+          "No",
+          :reset,
+          "          "
+        ]
         |> IO.ANSI.format()
         |> List.to_string()
 
       assert_received {:mix_shell, :info, [^ecto]}
 
       postgrex =
-        [:bright, "postgrex", :reset, "  ", :red, "0.0.1", :reset, "        "]
+        [
+          :bright,
+          "postgrex",
+          :reset,
+          "  ",
+          :red,
+          "0.0.1",
+          :reset,
+          "        ",
+          :red,
+          "No",
+          :reset,
+          "          "
+        ]
         |> IO.ANSI.format()
         |> List.to_string()
 
@@ -359,6 +405,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
             ["      ", "0.0.1", :reset],
             ["    ", :red, "0.1.0", :reset],
             ["   ", :red, "No", :reset],
+            ["          ", :red, "No", :reset],
             "               "
           ]
           |> IO.ANSI.format()
@@ -369,7 +416,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
             [:bright, "bar", :reset],
             ["         ", "0.1.0", :reset],
             ["    ", :green, "0.1.0", :reset],
-            ["   ", :green, "", :reset],
+            ["   ", :green, "Yes", :reset],
+            ["         ", :green, "", :reset],
             "                 "
           ]
           |> IO.ANSI.format()
@@ -380,7 +428,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
             [:bright, "foo", :reset],
             ["         ", "0.1.1", :reset],
             ["    ", :green, "0.1.1", :reset],
-            ["   ", :green, "", :reset],
+            ["   ", :green, "Yes", :reset],
+            ["         ", :green, "", :reset],
             "                 "
           ]
           |> IO.ANSI.format()


### PR DESCRIPTION
Closes: #774 
Since Windows does not support the ANSI codes, giving instructions or docs that express meaning through color fails. This might also affect color-blind users. This change add more visual cues.

![image](https://user-images.githubusercontent.com/773380/77133290-36de5d00-6a28-11ea-8f2e-642a73a5e04a.png)
![image](https://user-images.githubusercontent.com/773380/77133318-4b225a00-6a28-11ea-8be6-03d1c12eada5.png)
