### PR TITLE
adds link to diffs page in footer of hex.outdated

### DIFF
--- a/lib/hex/api/short_url.ex
+++ b/lib/hex/api/short_url.ex
@@ -5,7 +5,7 @@ defmodule Hex.API.ShortURL do
 
   def create(url) do
     case API.erlang_post_request(nil, "short_url", %{url: url}) do
-      {:ok, {201, %{"short_url" => short_url}, _resp_headers}} -> short_url
+      {:ok, {201, %{"url" => short_url}, _resp_headers}} -> short_url
       _error -> :error
     end
   end

--- a/lib/hex/api/short_url.ex
+++ b/lib/hex/api/short_url.ex
@@ -5,7 +5,7 @@ defmodule Hex.API.ShortURL do
 
   def create(url) do
     case API.erlang_post_request(nil, "short_url", %{url: url}) do
-      {:ok, {201, %{"url" => short_url}, _resp_headers}} -> short_url
+      {:ok, {201, %{"url" => short_url}, _resp_headers}} -> {:ok, short_url}
       _error -> :error
     end
   end

--- a/lib/hex/api/short_url.ex
+++ b/lib/hex/api/short_url.ex
@@ -1,0 +1,12 @@
+defmodule Hex.API.ShortURL do
+  @moduledoc false
+
+  alias Hex.API
+
+  def create(url) do
+    case API.erlang_post_request(nil, "short_url", %{url: url}) do
+      {:ok, {201, %{"short_url" => short_url}, _resp_headers}} -> short_url
+      _error -> :error
+    end
+  end
+end

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -168,7 +168,7 @@ defmodule Mix.Tasks.Hex.Outdated do
 
       diff_message = maybe_diff_message(diff_links)
 
-      Hex.Shell.info(["\n" | base_message <> diff_message])
+      Hex.Shell.info(["\n", base_message, diff_message])
       if any_outdated?(versions), do: Mix.Tasks.Hex.set_exit_code(1)
     end
   end

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -264,7 +264,7 @@ defmodule Mix.Tasks.Hex.Outdated do
   defp maybe_diff_message([]), do: ""
 
   defp maybe_diff_message(diff_links) do
-    "\nTo view the diffs in each available update, visit:\n" <>
+    "\n\nTo view the diffs in each available update, visit:\n" <>
       diff_link(diff_links)
   end
 

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -273,7 +273,7 @@ defmodule Mix.Tasks.Hex.Outdated do
 
     case Hex.API.ShortURL.create(long_url) do
       :error -> long_url
-      short_url -> short_url
+      {:ok, short_url} -> short_url
     end
   end
 end

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -159,7 +159,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
 
       assert_received {:mix_shell, :info,
                        [
-                         "\nUp-to-date indicates if you have the latest version of a given package.\nUpdate possible indicates if your current requirement matches the latest version.\nRun `mix hex.outdated APP` to see requirements for a specific dependency.\n\nTo view the diffs in each available update, visit:\nhttps://diff.hex.pm/diffs?diffs[]=foo:0.1.0:0.1.1"
+                         "\nUp-to-date indicates if you have the latest version of a given package.\nUpdate possible indicates if your current requirement matches the latest version.\nRun `mix hex.outdated APP` to see requirements for a specific dependency.\n\nTo view the diffs in each available update, visit:\n" <>
+                           _
                        ]}
     end)
   end

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -159,7 +159,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
 
       assert_received {:mix_shell, :info,
                        [
-                         "\nUp-to-date indicates if you have the latest version of a given package.\nUpdate possible indicates if your current requirement matches the latest version.\nRun `mix hex.outdated APP` to see requirements for a specific dependency.\nTo view the diffs in each available update, visit:\nhttps://diff.hex.pm/diffs?diffs[]=foo:0.1.0:0.1.1"
+                         "\nUp-to-date indicates if you have the latest version of a given package.\nUpdate possible indicates if your current requirement matches the latest version.\nRun `mix hex.outdated APP` to see requirements for a specific dependency.\n\nTo view the diffs in each available update, visit:\nhttps://diff.hex.pm/diffs?diffs[]=foo:0.1.0:0.1.1"
                        ]}
     end)
   end

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -156,6 +156,11 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
       assert_received {:mix_shell, :info, [^bar]}
       assert_received {:mix_shell, :info, [^foo]}
       assert_received {:mix_shell, :info, [^ex_doc]}
+
+      assert_received {:mix_shell, :info,
+                       [
+                         "\nUp-to-date indicates if you have the latest version of a given package.\nUpdate possible indicates if your current requirement matches the latest version.\nRun `mix hex.outdated APP` to see requirements for a specific dependency.\nTo view the diffs in each available update, visit:\nhttps://diff.hex.pm/diffs?diffs[]=foo:0.1.0:0.1.1"
+                       ]}
     end)
   end
 


### PR DESCRIPTION
Closes #778 

When there are outdated deps that can be upgraded, build a list of the current version and the latest version. Then use the hexpm API to create a short link.

![diff](https://user-images.githubusercontent.com/773380/80871154-547a2580-8c68-11ea-949f-f189042f4a12.gif)
