### PR TITLE
Make `mix hex.package diff` more CLI-friendly

### DIFF
--- a/lib/mix/tasks/hex.package.ex
+++ b/lib/mix/tasks/hex.package.ex
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.Hex.Package do
 
   ## Fetch and diff package contents between versions
 
+      mix hex.package diff PACKAGE VERSION1 VERSION2
       mix hex.package diff PACKAGE VERSION1..VERSION2
 
   This command fetches package tarballs for both versions,
@@ -91,6 +92,9 @@ defmodule Mix.Tasks.Hex.Package do
       ["fetch", package, version] ->
         fetch(repo(opts), package, version, unpack, output)
 
+      ["diff", package, version1, version2] ->
+        diff(repo(opts), package, "#{version1}..#{version2}")
+
       ["diff", package, version_range] ->
         diff(repo(opts), package, version_range)
 
@@ -99,6 +103,7 @@ defmodule Mix.Tasks.Hex.Package do
           Invalid arguments, expected one of:
 
           mix hex.package fetch PACKAGE VERSION [--unpack]
+          mix hex.package diff PACKAGE VERSION1 VERSION2
           mix hex.package diff PACKAGE VERSION1..VERSION2
         """)
     end
@@ -108,6 +113,7 @@ defmodule Mix.Tasks.Hex.Package do
   def tasks() do
     [
       {"fetch PACKAGE VERSION [--unpack]", "Fetch the package"},
+      {"diff PACKAGE VERSION1 VERSION2", "Fetch and diff package contents between versions"},
       {"diff PACKAGE VERSION1..VERSION2", "Fetch and diff package contents between versions"}
     ]
   end

--- a/test/mix/tasks/hex.package_test.exs
+++ b/test/mix/tasks/hex.package_test.exs
@@ -97,6 +97,19 @@ defmodule Mix.Tasks.Hex.PackageTest do
     end)
   end
 
+  test "diff: success (variant args)" do
+    in_tmp(fn ->
+      Hex.State.put(:diff_command, "git diff --no-index --no-color __PATH1__ __PATH2__")
+
+      assert catch_throw(Mix.Tasks.Hex.Package.run(["diff", "ex_doc", "0.0.1", "0.1.0"])) ==
+               {:exit_code, 1}
+
+      assert_received {:mix_shell, :run, [out]}
+      assert out =~ ~s(-{<<"version">>,<<"0.0.1">>}.)
+      assert out =~ ~s(+{<<"version">>,<<"0.1.0">>}.)
+    end)
+  end
+
   test "diff: custom diff command" do
     in_tmp(fn ->
       Hex.State.put(:diff_command, "ls __PATH1__ __PATH2__")


### PR DESCRIPTION
This makes `mix hex.package diff` more Unix shell friendly. With this, one can do `mix hex.package diff ex_doc 0.22.{0,1}`, which is expanded to `mix hex.package diff ex_doc 0.22.0 0.22.1` and is internally converted to `0.22.0..0.22.1`.

It would be nice to have #705 merged as well, although this PR would require minor updates to be fully compatible with that.