### PR TITLE
Customize hostname check to allow also wildcard certificates

### DIFF
--- a/lib/hex/http/ssl.ex
+++ b/lib/hex/http/ssl.ex
@@ -178,7 +178,11 @@ defmodule Hex.HTTP.SSL do
   defp domain_without_host([_ | more]), do: domain_without_host(more)
 
   defp ssl_major_version do
-    Application.spec(:ssl, :vsn)
+    # Elixir 1.0.5 - 1.1.1 have no Application.spec/2
+    case :application.get_key(:ssl, :vsna) do
+      {:ok, value} -> value
+      :undefined -> nil
+    end
     |> :string.to_integer()
     |> elem(0)
   end

--- a/lib/hex/http/ssl.ex
+++ b/lib/hex/http/ssl.ex
@@ -76,6 +76,7 @@ defmodule Hex.HTTP.SSL do
         cacerts: get_ca_certs(),
         verify_fun: verify_fun,
         server_name_indication: hostname,
+        customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)],
         secure_renegotiate: true,
         reuse_sessions: true,
         versions: @default_versions,

--- a/lib/hex/http/ssl.ex
+++ b/lib/hex/http/ssl.ex
@@ -76,7 +76,7 @@ defmodule Hex.HTTP.SSL do
         cacerts: get_ca_certs(),
         verify_fun: verify_fun,
         server_name_indication: hostname,
-        customize_hostname_check: [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)],
+        customize_hostname_check: customize_hostname_check_fun(),
         secure_renegotiate: true,
         reuse_sessions: true,
         versions: @default_versions,
@@ -124,5 +124,13 @@ defmodule Hex.HTTP.SSL do
   defp filter_ciphers(allowed) do
     available = Hex.Set.new(:ssl.cipher_suites(:openssl))
     Enum.filter(allowed, &(&1 in available))
+  end
+
+  def customize_hostname_check_fun do
+    if function_exported?(:public_key, :pkix_verify_hostname_match_fun, 1) do
+      [match_fun: :public_key.pkix_verify_hostname_match_fun(:https)]
+    else
+      []
+    end
   end
 end

--- a/lib/hex/http/ssl.ex
+++ b/lib/hex/http/ssl.ex
@@ -129,8 +129,7 @@ defmodule Hex.HTTP.SSL do
       # From OTP 20.0 use built-in support for custom hostname checks
       add_customize_hostname_check(opts)
     else
-      # Before OTP 20.0 use mint_shims for hostname check, from a custom
-      # verify_fun
+      # Before OTP 20.0 use mint_shims for hostname check, from a custom verify_fun
       add_verify_fun(opts, hostname)
     end
   end
@@ -179,7 +178,7 @@ defmodule Hex.HTTP.SSL do
 
   defp ssl_major_version do
     # Elixir 1.0.5 - 1.1.1 have no Application.spec/2
-    case :application.get_key(:ssl, :vsna) do
+    case :application.get_key(:ssl, :vsn) do
       {:ok, value} -> value
       :undefined -> nil
     end

--- a/lib/hex/http/ssl.ex
+++ b/lib/hex/http/ssl.ex
@@ -127,54 +127,12 @@ defmodule Hex.HTTP.SSL do
   defp customize_hostname_check(opts, hostname) do
     if ssl_major_version() >= 9 do
       # From OTP 20.0 use built-in support for custom hostname checks
-      add_customize_hostname_check(opts)
+      Keyword.put(opts, :customize_hostname_check, match_fun: &VerifyHostname.match_fun/2)
     else
       # Before OTP 20.0 use mint_shims for hostname check, from a custom verify_fun
-      add_verify_fun(opts, hostname)
-    end
-  end
-
-  defp add_customize_hostname_check(opts) do
-    customize_hostname_check_present? = Keyword.has_key?(opts, :customize_hostname_check)
-
-    if not customize_hostname_check_present? do
-      Keyword.put(opts, :customize_hostname_check, match_fun: &match_fun/2)
-    else
-      opts
-    end
-  end
-
-  defp add_verify_fun(opts, hostname) do
-    verify_fun_present? = Keyword.has_key?(opts, :verify_fun)
-
-    if not verify_fun_present? do
       Keyword.put(opts, :verify_fun, {&VerifyHostname.verify_fun/3, check_hostname: hostname})
-    else
-      opts
     end
   end
-
-  # Wildcard domain handling for DNS ID entries in the subjectAltName X.509
-  # extension. Note that this is a subset of the wildcard patterns implemented
-  # by OTP when matching against the subject CN attribute, but this is the only
-  # wildcard usage defined by the CA/Browser Forum's Baseline Requirements, and
-  # therefore the only pattern used in commercially issued certificates.
-  defp match_fun({:dns_id, reference}, {:dNSName, [?*, ?. | presented]}) do
-    case domain_without_host(reference) do
-      '' ->
-        :default
-
-      domain ->
-        # TODO: replace with `:string.casefold/1` eventually
-        :string.to_lower(domain) == :string.to_lower(presented)
-    end
-  end
-
-  defp match_fun(_reference, _presented), do: :default
-
-  defp domain_without_host([]), do: []
-  defp domain_without_host([?. | domain]), do: domain
-  defp domain_without_host([_ | more]), do: domain_without_host(more)
 
   defp ssl_major_version do
     # Elixir 1.0.5 - 1.1.1 have no Application.spec/2

--- a/lib/hex/http/verify_hostname.ex
+++ b/lib/hex/http/verify_hostname.ex
@@ -63,6 +63,12 @@ defmodule Hex.HTTP.VerifyHostname do
     end
   end
 
+  def match_fun({:dns_id, reference_id}, {:dNSName, presented_id}) do
+    try_match_hostname(presented_id, reference_id)
+  end
+
+  def match_fun(_reference, _presented), do: :default
+
   def validate_and_parse_wildcard_identifier(identifier, hostname) do
     wildcard_pos = :string.chr(identifier, ?*)
 


### PR DESCRIPTION
Hello everyone,

I already wrote one solution that I took over from the `mint` library to activate validation of wildcard certificates with the now stricter Erlang TLS handling in the issue here: https://github.com/hexpm/hex/issues/797

But I actually was able to find a better solution of using the wildcard hostname verification directly from the
[public_key Erlang module](https://github.com/erlang/otp/blob/9bca07b045b5fe6fe958f38b25585a0f50b326bb/lib/public_key/src/public_key.erl#L1113) that does to knowledge exactly the same.

Disclaimer: I did manual testing of this but wasn't really able to come up with how to actually test this.  Speaking of having a proper test setup that provides a server with wildcard certificate for its domain. If you know a way let me know. For now I can only deliver this 😄  

Have a nice day!