### PR TITLE
changes concurrency default to 2x schedulers or 8, whichever is lower

### DIFF
--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -56,7 +56,7 @@ defmodule Hex.State do
     http_concurrency: %{
       env: ["HEX_HTTP_CONCURRENCY"],
       config: [:http_concurrency],
-      default: 8,
+      default: min(2 * System.schedulers_online(), 8),
       fun: {__MODULE__, :to_integer}
     },
     http_proxy: %{

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -43,7 +43,8 @@ defmodule Mix.Tasks.Hex.Config do
       environment variable `HTTPS_PROXY` (Default: `nil`)
     * `http_concurrency` - Limits the number of concurrent HTTP requests in
       flight. Can be overridden by setting the environment variable
-      `HEX_HTTP_CONCURRENCY` (Default: `8`)
+      `HEX_HTTP_CONCURRENCY` (Default: 2 x the number of available schedulers
+      or `8`, whichever is less)
     * `http_timeout` - Sets the timeout for HTTP requests in seconds. Can be
       overridden by setting the environment variable `HEX_HTTP_TIMEOUT`
       (Default: `nil`)


### PR DESCRIPTION
![Screenshot from 2020-08-14 10-27-23](https://user-images.githubusercontent.com/773380/90271313-d3aaf800-de18-11ea-80d4-802daa067dcc.png)
