### PR TITLE
Do not pass --canonical to docs task

### DIFF
--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -104,7 +104,6 @@ defmodule Mix.Tasks.Hex.Publish do
   @switches [
     revert: :string,
     progress: :boolean,
-    canonical: :string,
     organization: :string,
     organisation: :string,
     yes: :boolean,
@@ -221,10 +220,9 @@ defmodule Mix.Tasks.Hex.Publish do
 
   defp docs_task(build, opts) do
     name = build.meta.name
-    canonical = opts[:canonical] || Hex.Utils.hexdocs_url(opts[:organization], name)
 
     try do
-      Mix.Task.run("docs", ["--canonical", canonical])
+      Mix.Task.run("docs", [])
     rescue
       ex in [Mix.NoTaskError] ->
         require Hex

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -148,7 +148,7 @@ defmodule Mix.Tasks.Hex.Publish do
         end
 
       ["docs"] ->
-        docs_task(build, opts)
+        docs_task()
         auth = Mix.Tasks.Hex.auth_info(:write)
         create_docs(build, organization, auth, opts)
 
@@ -182,7 +182,7 @@ defmodule Mix.Tasks.Hex.Publish do
     case proceed_with_owner(build, organization, opts) do
       {:ok, owner} ->
         Hex.Shell.info("Building docs...")
-        docs_task(build, opts)
+        docs_task()
         auth = Mix.Tasks.Hex.auth_info(:write)
         Hex.Shell.info("Publishing package...")
 
@@ -218,9 +218,7 @@ defmodule Mix.Tasks.Hex.Publish do
     end
   end
 
-  defp docs_task(build, opts) do
-    name = build.meta.name
-
+  defp docs_task() do
     try do
       Mix.Task.run("docs", [])
     rescue

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -1,17 +1,4 @@
 defmodule Mix.Tasks.Docs do
-  def run(["--canonical", "https://hexdocs.pm/invalid_filename"]) do
-    File.mkdir_p!("doc")
-    File.write!("doc/index.html", "the index")
-    File.write!("doc/1.5.5", "semver file")
-  end
-
-  def run(["--canonical", "https://hexdocs.pm/invalid_dirname"]) do
-    File.mkdir_p!("doc")
-    File.write!("doc/index.html", "the index")
-    File.mkdir_p!("doc/1.5.5")
-    File.write!("doc/1.5.5/index.html", "sub index")
-  end
-
   def run(_) do
     File.mkdir_p!("doc")
     File.write!("doc/index.html", "the index")
@@ -24,25 +11,47 @@ defmodule Mix.Tasks.Hex.PublishTest do
 
   defmodule DocsSimple.MixProject do
     def project do
-      [app: :ex_doc, version: "0.1.0"]
+      [app: :ex_doc, version: "0.1.0", aliases: [docs: [&docs/1]]]
+    end
+
+    defp docs(_) do
+      File.mkdir_p!("doc")
+      File.write!("doc/index.html", "the index")
     end
   end
 
   defmodule DocsError.MixProject do
     def project do
-      [app: :ex_doc, version: "0.1.1"]
+      [app: :ex_doc, version: "0.1.1", aliases: [docs: [&docs/1]]]
+    end
+
+    defp docs(_) do
+      File.mkdir_p!("doc")
+      File.write!("doc/index.html", "the index")
     end
   end
 
   defmodule DocsFilenameError.MixProject do
     def project do
-      [app: :invalid_filename, version: "0.1.0"]
+      [app: :invalid_filename, version: "0.1.0", aliases: [docs: [&docs/1]]]
+    end
+
+    defp docs(_) do
+      File.mkdir_p!("doc")
+      File.write!("doc/index.html", "the index")
+      File.write!("doc/1.5.5", "")
     end
   end
 
   defmodule DocsDirnameError.MixProject do
     def project do
-      [app: :invalid_dirname, version: "0.1.0"]
+      [app: :invalid_dirname, version: "0.1.0", aliases: [docs: [&docs/1]]]
+    end
+
+    defp docs(_) do
+      File.mkdir_p!("doc/1.5.5")
+      File.write!("doc/index.html", "the index")
+      File.write!("doc/1.5.5/index.html", "")
     end
   end
 


### PR DESCRIPTION
It is no longer needed because we set the link header on the CDN.