### PR TITLE
Use tarball outer checksum to check cache freshness

### DIFF
--- a/lib/hex/dev.ex
+++ b/lib/hex/dev.ex
@@ -41,7 +41,6 @@ if Mix.env() == :dev do
               copy(original_ets, new_ets, {:inner_checksum, @repo, package, version})
               copy(original_ets, new_ets, {:outer_checksum, @repo, package, version})
               copy(original_ets, new_ets, {:retired, @repo, package, version})
-              copy(original_ets, new_ets, {:tarball_etag, @repo, package, version})
               copy(original_ets, new_ets, {:timestamp, @repo, package, version})
 
               [{_, dep_tuples}] = :ets.lookup(original_ets, {:deps, @repo, package, version})

--- a/lib/hex/registry/server.ex
+++ b/lib/hex/registry/server.ex
@@ -50,14 +50,6 @@ defmodule Hex.Registry.Server do
     GenServer.call(@name, {:retired, repo, package, version}, @timeout)
   end
 
-  def tarball_etag(repo, package, version) do
-    GenServer.call(@name, {:tarball_etag, repo, package, version}, @timeout)
-  end
-
-  def tarball_etag(repo, package, version, etag) do
-    GenServer.call(@name, {:tarball_etag, repo, package, version, etag}, @timeout)
-  end
-
   def last_update() do
     GenServer.call(@name, :last_update, @timeout)
   end
@@ -173,16 +165,6 @@ defmodule Hex.Registry.Server do
     end)
   end
 
-  def handle_call({:tarball_etag, repo, package, version}, _from, state) do
-    etag = lookup(state.ets, {:tarball_etag, repo, package, version})
-    {:reply, etag, state}
-  end
-
-  def handle_call({:tarball_etag, repo, package, version, etag}, _from, state) do
-    :ets.insert(state.ets, {{:tarball_etag, repo, package, version}, etag})
-    {:reply, :ok, state}
-  end
-
   def handle_call(:last_update, _from, state) do
     time = lookup(state.ets, :last_update)
     {:reply, time, state}
@@ -272,7 +254,6 @@ defmodule Hex.Registry.Server do
   #   {{:inner_checksum, ^repo, _package, _version}, _} -> true
   #   {{:outer_checksum, ^repo, _package, _version}, _} -> true
   #   {{:retired, ^repo, _package, _version}, _} -> true
-  #   {{:tarball_etag, ^repo, _package, _version}, _} -> true
   #   {{:registry_etag, ^repo, _package}, _} -> true
   #   {{:timestamp, ^repo, _package}, _} -> true
   #   {{:timestamp, ^repo, _package, _version}, _} -> true
@@ -286,7 +267,6 @@ defmodule Hex.Registry.Server do
       {{{:inner_checksum, :"$1", :"$2", :"$3"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
       {{{:outer_checksum, :"$1", :"$2", :"$3"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
       {{{:retired, :"$1", :"$2", :"$3"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
-      {{{:tarball_etag, :"$1", :"$2", :"$3"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
       {{{:registry_etag, :"$1", :"$2"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
       {{{:timetamp, :"$1", :"$2"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
       {{{:timetamp, :"$1", :"$2", :"$3"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},

--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -166,8 +166,8 @@ defmodule Hex.Repo do
     HTTP.request(:get, docs_url(repo, package, version), headers, nil)
   end
 
-  def get_tarball(repo, package, version, etag) do
-    headers = Map.merge(etag_headers(etag), auth_headers(repo))
+  def get_tarball(repo, package, version) do
+    headers = auth_headers(repo)
     HTTP.request(:get, tarball_url(repo, package, version), headers, nil)
   end
 

--- a/lib/hex/tar.ex
+++ b/lib/hex/tar.ex
@@ -41,4 +41,12 @@ defmodule Hex.Tar do
         Mix.raise("Unpacking tarball failed: #{:mix_hex_tarball.format_error(reason)}")
     end
   end
+
+  # TODO: Add this function to
+  def outer_checksum(path) do
+    case File.read(path) do
+      {:ok, tarball} -> {:ok, :crypto.hash(:sha256, tarball)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
 end

--- a/lib/mix/tasks/hex.package.ex
+++ b/lib/mix/tasks/hex.package.ex
@@ -169,17 +169,21 @@ defmodule Mix.Tasks.Hex.Package do
   end
 
   defp fetch_tarball!(repo, package, version) do
-    etag = nil
+    path = Hex.SCM.cache_path(repo, package, version)
 
-    case Hex.SCM.fetch(repo, package, version, :memory, etag) do
-      {:ok, :new, tarball, _etag} ->
-        tarball
+    case Hex.SCM.fetch(repo, package, version) do
+      {:ok, _} ->
+        File.read!(path)
 
       {:error, reason} ->
-        Mix.raise(
-          "Downloading " <>
-            Hex.Repo.tarball_url(repo, package, version) <> " failed:\n\n" <> reason
-        )
+        if File.exists?(path) do
+          File.read!(path)
+        else
+          Mix.raise(
+            "Downloading " <>
+              Hex.Repo.tarball_url(repo, package, version) <> " failed:\n\n" <> reason
+          )
+        end
     end
   end
 


### PR DESCRIPTION
Use tarball outer checksum to check if cache is fresh instead of using
etag to make conditional HTTP requests.