### PR TITLE
Add `--fetch-public-key FINGERPRINT` to `mix hex.repo add`

### DIFF
--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -323,4 +323,17 @@ defmodule Hex.Repo do
   defp repo_name(name) do
     name |> split_repo_name() |> List.last()
   end
+
+  def get_public_key(repo_url, auth_key) do
+    auth_headers =
+      if auth_key do
+        %{'authorization' => Hex.Stdlib.string_to_charlist(auth_key)}
+      else
+        %{}
+      end
+
+    HTTP.request(:get, public_key_url(repo_url), auth_headers, nil)
+  end
+
+  defp public_key_url(repo_url), do: repo_url <> "/public_key"
 end

--- a/lib/mix/tasks/hex.repo.ex
+++ b/lib/mix/tasks/hex.repo.ex
@@ -204,15 +204,16 @@ defmodule Mix.Tasks.Hex.Repo do
   defp fetch_public_key(nil, _, _), do: nil
 
   defp fetch_public_key(fingerprint, repo_url, auth_key) do
-    with {:ok, {200, key, _}} <- Hex.Repo.get_public_key(repo_url, auth_key),
-         {:verify, true} <- {:verify, show_public_key(key) == "SHA256:" <> fingerprint} do
-      key
-    else
+    case Hex.Repo.get_public_key(repo_url, auth_key) do
+      {:ok, {200, key, _}} ->
+        if show_public_key(key) == fingerprint do
+          key
+        else
+          Mix.raise("public key fingerprint does not match with provided")
+        end
+
       {:error, _} ->
         Mix.raise("could not download public key. check your auth key and the server")
-
-      {:verify, false} ->
-        Mix.raise("public key fingerprint does not match with provided")
     end
   end
 

--- a/lib/mix/tasks/hex.repo.ex
+++ b/lib/mix/tasks/hex.repo.ex
@@ -223,11 +223,8 @@ defmodule Mix.Tasks.Hex.Repo do
   end
 
   defp sshfp_string(key) do
-    # The padding: false on Base.encode64 requires Elixir v1.3+,
-    # so we do a String.replace/3 instead.
-    :crypto.hash(:sha256, :public_key.ssh_encode(key, :ssh2_pubkey))
-    |> Base.encode64()
-    |> String.replace("=", "")
+    :crypto.hash(:sha256, Hex.Stdlib.ssh2_pubkey_encode(key))
+    |> Hex.Stdlib.base_encode64_nopadding()
   end
 
   defp show(name) do

--- a/lib/mix/tasks/hex.repo.ex
+++ b/lib/mix/tasks/hex.repo.ex
@@ -212,6 +212,10 @@ defmodule Mix.Tasks.Hex.Repo do
           Mix.raise("Public key fingerprint mismatch")
         end
 
+      {:ok, {code, _, _}} ->
+        Hex.Shell.error("Downloading public key failed with code \"#{inspect(code)}\"")
+        Mix.Tasks.Hex.set_exit_code(1)
+
       other ->
         Hex.Shell.error("Downloading public key failed")
         Hex.Utils.print_error_result(other)

--- a/lib/mix/tasks/hex.repo.ex
+++ b/lib/mix/tasks/hex.repo.ex
@@ -37,7 +37,7 @@ defmodule Mix.Tasks.Hex.Repo do
 
     * `--public-key PATH` - Path to public key used to verify the registry (optional).
     * `--auth-key KEY` - Key used to authenticate HTTP requests to repository (optional).
-    * `--fetch-public-key FINGERPRINT` - It will automatically download the public key (optional).
+    * `--fetch-public-key FINGERPRINT` - Download public key from the repository and verify against the fingerprint (optional).
 
   ## Set config for repo
 

--- a/lib/mix/tasks/hex.repo.ex
+++ b/lib/mix/tasks/hex.repo.ex
@@ -209,11 +209,13 @@ defmodule Mix.Tasks.Hex.Repo do
         if show_public_key(key) == fingerprint do
           key
         else
-          Mix.raise("public key fingerprint does not match with provided")
+          Mix.raise("Public key fingerprint mismatch")
         end
 
-      {:error, _} ->
-        Mix.raise("could not download public key. check your auth key and the server")
+      other ->
+        Hex.Shell.error("Downloading public key failed")
+        Hex.Utils.print_error_result(other)
+        Mix.Tasks.Hex.set_exit_code(1)
     end
   end
 

--- a/lib/mix/tasks/hex.repo.ex
+++ b/lib/mix/tasks/hex.repo.ex
@@ -223,8 +223,11 @@ defmodule Mix.Tasks.Hex.Repo do
   end
 
   defp sshfp_string(key) do
+    # The padding: false on Base.encode64 requires Elixir v1.3+,
+    # so we do a String.replace/3 instead.
     :crypto.hash(:sha256, :public_key.ssh_encode(key, :ssh2_pubkey))
-    |> Base.encode64(padding: false)
+    |> Base.encode64()
+    |> String.replace("=", "")
   end
 
   defp show(name) do

--- a/test/hex/repo_test.exs
+++ b/test/hex/repo_test.exs
@@ -3,6 +3,7 @@ defmodule Hex.RepoTest do
   @moduletag :integration
 
   @private_key File.read!(Path.join(__DIR__, "../fixtures/test_priv.pem"))
+  @hexpm_repo_url "https://repo.hex.pm"
 
   test "get_package" do
     assert {:ok, {200, _, _}} = Hex.Repo.get_package("hexpm", "postgrex", "")
@@ -49,7 +50,7 @@ defmodule Hex.RepoTest do
   test "get public key" do
     hexpm = Hex.Repo.default_hexpm_repo()
 
-    assert {:ok, {200, public_key, _}} = Hex.Repo.get_public_key(hexpm.url, hexpm.auth_key)
+    assert {:ok, {200, public_key, _}} = Hex.Repo.get_public_key(@hexpm_repo_url, nil)
     assert public_key == hexpm.public_key
 
     assert {:error, _} = Hex.Repo.get_public_key("http://localhost:4000/acme", nil)

--- a/test/hex/repo_test.exs
+++ b/test/hex/repo_test.exs
@@ -45,4 +45,13 @@ defmodule Hex.RepoTest do
     assert Hex.Repo.decode_package(message, "other repo", "ecto") == []
     assert Hex.Repo.decode_package(message, "hexpm", "other package") == []
   end
+
+  test "get public key" do
+    hexpm = Hex.Repo.default_hexpm_repo()
+
+    assert {:ok, {200, public_key, _}} = Hex.Repo.get_public_key(hexpm.url, hexpm.auth_key)
+    assert public_key == hexpm.public_key
+
+    assert {:error, _} = Hex.Repo.get_public_key("http://localhost:4000/acme", nil)
+  end
 end

--- a/test/mix/tasks/hex.repo_test.exs
+++ b/test/mix/tasks/hex.repo_test.exs
@@ -13,7 +13,7 @@ defmodule Mix.Tasks.Hex.RepoTest do
   -----END PUBLIC KEY-----
   """
 
-  @public_key_fingerprint "O1LOYhHFW4kcrblKAxROaDEzLD8bn1seWbe5tq8TRsk"
+  @public_key_fingerprint "SHA256:O1LOYhHFW4kcrblKAxROaDEzLD8bn1seWbe5tq8TRsk"
 
   defp bypass_public_key() do
     bypass = Bypass.open()


### PR DESCRIPTION
This allows Hex users to rely on the "/public_key" endpoint implemented by the [repositories](https://github.com/hexpm/specifications/blob/959f67a065959bc047baa2ccc4f0b4c5215dd53f/endpoints.md) to fetch the public key instead of doing it manually.

The option requires the user to know the fingerprint of the key in order to ensure more security. This prevents the key to be modified in transit.

It closes #801

Thanks!