### PR TITLE
do not unpack tarball when flag is not passed

### DIFF
--- a/lib/mix/tasks/hex.package.ex
+++ b/lib/mix/tasks/hex.package.ex
@@ -150,11 +150,16 @@ defmodule Mix.Tasks.Hex.Package do
 
     File.write!(tar_path, tarball)
 
-    %{inner_checksum: inner_checksum, outer_checksum: outer_checksum} =
-      Hex.Tar.unpack!(tar_path, abs_path)
+    if unpack? do
+      %{inner_checksum: inner_checksum, outer_checksum: outer_checksum} =
+        Hex.Tar.unpack!(tar_path, abs_path)
 
-    verify_inner_checksum!(repo, package, version, inner_checksum)
-    verify_outer_checksum!(repo, package, version, outer_checksum)
+      verify_inner_checksum!(repo, package, version, inner_checksum)
+      verify_outer_checksum!(repo, package, version, outer_checksum)
+    else
+      {:ok, outer_checksum} = Hex.Tar.outer_checksum(tar_path)
+      verify_outer_checksum!(repo, package, version, outer_checksum)
+    end
 
     message =
       if unpack? do

--- a/test/mix/tasks/hex.package_test.exs
+++ b/test/mix/tasks/hex.package_test.exs
@@ -9,6 +9,7 @@ defmodule Mix.Tasks.Hex.PackageTest do
       msg = "ex_doc v0.0.1 downloaded to #{cwd}/ex_doc-0.0.1.tar"
       assert_received {:mix_shell, :info, [^msg]}
       assert File.exists?("#{cwd}/ex_doc-0.0.1.tar")
+      refute File.exists?("#{cwd}/ex_doc-0.0.1/")
     end)
   end
 


### PR DESCRIPTION
Closes #815

Seems like we were unpacking to verify the inner checksum. If we still want to do that, we could unpack, verify, then delete. I didnt feel like that would be the expected behaviour though