### PR TITLE
Support no_proxy environment variable

### DIFF
--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -67,6 +67,10 @@ defmodule Hex.State do
       env: ["https_proxy", "HTTPS_PROXY"],
       config: [:https_proxy]
     },
+    no_proxy: %{
+      env: ["no_proxy", "NO_PROXY"],
+      config: [:no_proxy]
+    },
     http_timeout: %{
       env: ["HEX_HTTP_TIMEOUT"],
       config: [:http_timeout],

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -41,6 +41,9 @@ defmodule Mix.Tasks.Hex.Config do
       environment variable `HTTP_PROXY` (Default: `nil`)
     * `https_proxy` - HTTPS proxy server. Can be overridden by setting the
       environment variable `HTTPS_PROXY` (Default: `nil`)
+    * `no_proxy` - A comma separated list of hostnames that will not be proxied,
+      asterisks can be used as wildcards. Can be overridden by setting the
+      environment variable `NO_PROXY` (Default: `nil`)
     * `http_concurrency` - Limits the number of concurrent HTTP requests in
       flight. Can be overridden by setting the environment variable
       `HEX_HTTP_CONCURRENCY` (Default: `8`)

--- a/test/mix/tasks/hex.config_test.exs
+++ b/test/mix/tasks/hex.config_test.exs
@@ -17,6 +17,7 @@ defmodule Mix.Tasks.Hex.ConfigTest do
       assert_received {:mix_shell, :info, ["unsafe_registry: false (default)"]}
       assert_received {:mix_shell, :info, ["http_proxy: nil (default)"]}
       assert_received {:mix_shell, :info, ["https_proxy: nil (default)"]}
+      assert_received {:mix_shell, :info, ["no_proxy: nil (default)"]}
       assert_received {:mix_shell, :info, ["http_concurrency: 8 (default)"]}
       assert_received {:mix_shell, :info, ["http_timeout: nil (default)"]}
       assert_received {:mix_shell, :info, ["mirror_url: nil (default)"]}


### PR DESCRIPTION
Add `no_proxy` variable to `set_options` instead of empty list