### PR TITLE
Fix flaky divergereq test

### DIFF
--- a/test/hex/mix_task_test.exs
+++ b/test/hex/mix_task_test.exs
@@ -892,7 +892,7 @@ defmodule Hex.MixTaskTest do
     ])
   end
 
-  if Version.match?(System.version(), "< 1.11.0-dev") do
+  if Version.match?(System.version(), "< 1.12.0-dev") do
     @tag :skip
   end
 
@@ -909,9 +909,6 @@ defmodule Hex.MixTaskTest do
 
       Mix.Task.run("deps.get")
       Mix.Task.run("compile")
-      # due to bug in Mix, dep that was just compiled and about to be updated is not actually
-      # updated because we have the same mtime on .fetch and .mix/compile.fetch lock files
-      wait_until_next_second()
       Mix.Task.run("deps.update", ["ecto_sql"])
     end)
   after
@@ -922,10 +919,5 @@ defmodule Hex.MixTaskTest do
       Ecto_3_3_1.Fixture.MixProject,
       Ecto_3_3_2.Fixture.MixProject
     ])
-  end
-
-  defp wait_until_next_second() do
-    {microseconds, 6} = Time.utc_now().microsecond
-    Process.sleep(div(1_000_000 - microseconds, 1_000) + 1)
   end
 end

--- a/test/hex/mix_task_test.exs
+++ b/test/hex/mix_task_test.exs
@@ -909,6 +909,9 @@ defmodule Hex.MixTaskTest do
 
       Mix.Task.run("deps.get")
       Mix.Task.run("compile")
+      # due to bug in Mix, dep that was just compiled and about to be updated is not actually
+      # updated because we have the same mtime on .fetch and .mix/compile.fetch lock files
+      wait_until_next_second()
       Mix.Task.run("deps.update", ["ecto_sql"])
     end)
   after
@@ -919,5 +922,10 @@ defmodule Hex.MixTaskTest do
       Ecto_3_3_1.Fixture.MixProject,
       Ecto_3_3_2.Fixture.MixProject
     ])
+  end
+
+  defp wait_until_next_second() do
+    {microseconds, 6} = Time.utc_now().microsecond
+    Process.sleep(div(1_000_000 - microseconds, 1_000) + 1)
   end
 end


### PR DESCRIPTION
Instead of sleep, we could do the following:

    File.rm!("_build/test/lib/ecto/.mix/compile.fetch")

which is what we're most likely going to do in Elixir, but i'm worried we're leaking Mix too much.

cc @josevalim