### PR TITLE
Add hex.sponsor mix task

### DIFF
--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -45,9 +45,6 @@ defmodule Mix.Tasks.Hex.Sponsor do
             _ ->
               []
           end
-
-        _ ->
-          []
       end
     end)
   end

--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -9,6 +9,14 @@ defmodule Mix.Tasks.Hex.Sponsor do
   Sponsorship plays an important role to maintain some open
   source projects. This task will display all packages that
   are accepting sponsorship from the current project.
+
+  You can add sponsorship links to your projects by adding the
+  following to your mix.exs:
+
+      links: %{
+        "GitHub" => "[your-repo-link]",
+        "Sponsor" => "[your-sponsorship-link]"
+      }
   """
 
   @behaviour Hex.Mix.TaskDescription
@@ -26,22 +34,7 @@ defmodule Mix.Tasks.Hex.Sponsor do
 
     case sponsor_links do
       [] ->
-        Hex.Shell.info([
-          "No dependencies with sponsorship link found.",
-          ?\n,
-          "You can add sponsorship links to your projects by ",
-          "adding the following to your mix.exs:",
-          ?\n,
-          ?\n,
-          "  links: %{",
-          ?\n,
-          ~s(    "GitHub" => "[your-repo-link]",),
-          ?\n,
-          ~s(    "Sponsor" => "[your-sponsorship-link]"),
-          ?\n,
-          "  }",
-          ?\n
-        ])
+        Hex.Shell.info("No dependencies with sponsorship link found.")
 
       deps_links ->
         header = ["Dependency", "Sponsorship"]

--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -1,0 +1,83 @@
+defmodule Mix.Tasks.Hex.Sponsor do
+  use Mix.Task
+
+  alias Hex.Registry.Server, as: Registry
+
+  @shortdoc "Shows Hex deps accepting sponsorship"
+
+  @moduledoc """
+  Shows Hex deps based on mix.lock accepting sponsorship.
+
+  Sponsorship plays an important role to maintain some open
+  source projects. This task will display all packages that
+  are accepting sponsorship from the current project.
+  """
+
+  @behaviour Hex.Mix.TaskDescription
+  @metadata_file "hex_metadata.config"
+  @sponsor_link_names ~w(sponsor sponsorship funding donation donate)
+
+  @impl true
+  def run(_) do
+    Hex.Mix.check_deps()
+    Hex.start()
+    Registry.open()
+
+    lock = Mix.Dep.Lock.read()
+    deps_path = Mix.Project.deps_path()
+
+    lock
+    |> Hex.Mix.packages_from_lock()
+    |> sponsor_links(deps_path)
+    |> case do
+      [] ->
+        Hex.Shell.info("No dependencies with sponsorship links found")
+
+      deps_links ->
+        header = ["Dependency", "Sponsorship"]
+        Mix.Tasks.Hex.print_table(header, deps_links)
+    end
+  end
+
+  defp sponsor_links(packages, deps_path) do
+    Enum.reduce(packages, [], fn {_repo, package_name}, acc ->
+      case read_metadata(package_name, deps_path) do
+        {:ok, metadata} ->
+          case sponsorship(metadata) do
+            {_, value} ->
+              [[package_name, value] | acc]
+
+            _ ->
+              acc
+          end
+
+        _ ->
+          acc
+      end
+    end)
+  end
+
+  defp read_metadata(package, deps_path) do
+    deps_path
+    |> Path.join(package)
+    |> Path.join(@metadata_file)
+    |> :file.consult()
+  end
+
+  defp sponsorship(metadata) do
+    case Enum.find(metadata, fn {name, _} -> name == "links" end) do
+      {_links, links} ->
+        Enum.find(links, fn {link, _} -> String.downcase(link) in @sponsor_link_names end)
+
+      _ ->
+        nil
+    end
+  end
+
+  @impl true
+  def tasks() do
+    [
+      {"", "Shows Hex deps accepting sponsorship from current project"}
+    ]
+  end
+end

--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -1,8 +1,6 @@
 defmodule Mix.Tasks.Hex.Sponsor do
   use Mix.Task
 
-  alias Hex.Registry.Server, as: Registry
-
   @shortdoc "Shows Hex deps accepting sponsorship"
 
   @moduledoc """

--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -69,7 +69,7 @@ defmodule Mix.Tasks.Hex.Sponsor do
   @impl true
   def tasks() do
     [
-      {"", "Shows Hex deps accepting sponsorship from current project"}
+      {"", @shortdoc}
     ]
   end
 end

--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -20,8 +20,6 @@ defmodule Mix.Tasks.Hex.Sponsor do
   @impl true
   def run(_) do
     Hex.Mix.check_deps()
-    Hex.start()
-    Registry.open()
 
     lock = Mix.Dep.Lock.read()
     deps_path = Mix.Project.deps_path()

--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -26,7 +26,22 @@ defmodule Mix.Tasks.Hex.Sponsor do
 
     case sponsor_links do
       [] ->
-        Hex.Shell.info("No dependencies with sponsorship link found")
+        Hex.Shell.info([
+          "No dependencies with sponsorship link found.",
+          ?\n,
+          "You can add sponsorship links to your projects by ",
+          "adding the following to your mix.exs:",
+          ?\n,
+          ?\n,
+          "  links: %{",
+          ?\n,
+          ~s(    "GitHub" => "[your-repo-link]",),
+          ?\n,
+          ~s(    "Sponsor" => "[your-sponsorship-link]"),
+          ?\n,
+          "  }",
+          ?\n
+        ])
 
       deps_links ->
         header = ["Dependency", "Sponsorship"]

--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -13,21 +13,20 @@ defmodule Mix.Tasks.Hex.Sponsor do
 
   @behaviour Hex.Mix.TaskDescription
   @metadata_file "hex_metadata.config"
-  @sponsor_link_names ~w(sponsor sponsorship funding donation donate)
+  @sponsor_link_name "sponsor"
 
   @impl true
   def run(_) do
     Hex.Mix.check_deps()
 
-    lock = Mix.Dep.Lock.read()
-    deps_path = Mix.Project.deps_path()
+    sponsor_links =
+      Mix.Dep.Lock.read()
+      |> Hex.Mix.packages_from_lock()
+      |> sponsor_links(Mix.Project.deps_path())
 
-    lock
-    |> Hex.Mix.packages_from_lock()
-    |> sponsor_links(deps_path)
-    |> case do
+    case sponsor_links do
       [] ->
-        Hex.Shell.info("No dependencies with sponsorship links found")
+        Hex.Shell.info("No dependencies with sponsorship link found")
 
       deps_links ->
         header = ["Dependency", "Sponsorship"]
@@ -36,19 +35,19 @@ defmodule Mix.Tasks.Hex.Sponsor do
   end
 
   defp sponsor_links(packages, deps_path) do
-    Enum.reduce(packages, [], fn {_repo, package_name}, acc ->
+    Enum.flat_map(packages, fn {_repo, package_name} ->
       case read_metadata(package_name, deps_path) do
         {:ok, metadata} ->
           case sponsorship(metadata) do
             {_, value} ->
-              [[package_name, value] | acc]
+              [[package_name, value]]
 
             _ ->
-              acc
+              []
           end
 
         _ ->
-          acc
+          []
       end
     end)
   end
@@ -60,7 +59,7 @@ defmodule Mix.Tasks.Hex.Sponsor do
   defp sponsorship(metadata) do
     case Enum.find(metadata, fn {name, _} -> name == "links" end) do
       {_links, links} ->
-        Enum.find(links, fn {link, _} -> String.downcase(link) in @sponsor_link_names end)
+        Enum.find(links, fn {link, _} -> String.downcase(link) == @sponsor_link_name end)
 
       _ ->
         nil

--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -1,10 +1,10 @@
 defmodule Mix.Tasks.Hex.Sponsor do
   use Mix.Task
 
-  @shortdoc "Shows Hex deps accepting sponsorship"
+  @shortdoc "Show Hex packages accepting sponsorships"
 
   @moduledoc """
-  Shows Hex deps based on mix.lock accepting sponsorship.
+  Show Hex packages in your dependencies that accept sponsorships.
 
   Sponsorship plays an important role to maintain some open
   source projects. This task will display all packages that
@@ -54,10 +54,7 @@ defmodule Mix.Tasks.Hex.Sponsor do
   end
 
   defp read_metadata(package, deps_path) do
-    deps_path
-    |> Path.join(package)
-    |> Path.join(@metadata_file)
-    |> :file.consult()
+    :file.consult(Path.join([deps_path, package, @metadata_file]))
   end
 
   defp sponsorship(metadata) do

--- a/test/mix/tasks/hex.sponsor_test.exs
+++ b/test/mix/tasks/hex.sponsor_test.exs
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Hex.SponsorTest do
     assert_received {:mix_shell, :info, [header_output]}
     refute_received {:mix_shell, :info, [_package_line]}
 
-    assert header_output =~ "No dependencies with sponsorship links found"
+    assert header_output =~ "No dependencies with sponsorship link found"
   end
 
   defp with_test_package(version, metadata, %{auth: auth}, fun) do

--- a/test/mix/tasks/hex.sponsor_test.exs
+++ b/test/mix/tasks/hex.sponsor_test.exs
@@ -1,0 +1,70 @@
+defmodule Mix.Tasks.Hex.SponsorTest do
+  use HexTest.Case
+  @moduletag :integration
+
+  @package :test_sponsored_package
+  @package_name Atom.to_string(@package)
+
+  defmodule SponsoredDeps.MixProject do
+    def project do
+      [app: :test_app, version: "0.0.1", deps: [{:test_sponsored_package, ">= 0.1.0"}]]
+    end
+  end
+
+  setup_all do
+    auth = Hexpm.new_user("sponsor_user", "sponsor@mail.com", "passpass", "key")
+    {:ok, [auth: auth]}
+  end
+
+  test "sponsor with sponsor link", context do
+    url = "https://sponsor.foo.bar"
+
+    with_test_package("0.1.0", %{links: %{sponsor: url}}, context, fn ->
+      Mix.Task.run("hex.sponsor")
+    end)
+
+    assert_received {:mix_shell, :info, [header_output]}
+    assert_received {:mix_shell, :info, [package_line]}
+
+    assert String.match?(header_output, ~r/Dependency/)
+    assert String.match?(header_output, ~r/Sponsorship/)
+
+    assert String.match?(package_line, ~r/#{@package_name}/)
+    assert String.match?(package_line, ~r/#{url}/)
+  end
+
+  test "without sponsor link", context do
+    with_test_package("1.2.0", %{links: %{github: "https://github.com/foo/bar"}}, context, fn ->
+      Mix.Task.run("hex.sponsor")
+    end)
+
+    assert_received {:mix_shell, :info, [header_output]}
+    refute_received {:mix_shell, :info, [_package_line]}
+
+    assert String.match?(header_output, ~r/No dependencies with sponsorship links found/)
+  end
+
+  defp with_test_package(version, metadata, %{auth: auth}, fun) do
+    Mix.Project.push(SponsoredDeps.MixProject)
+
+    Hexpm.new_package(
+      "hexpm",
+      @package_name,
+      version,
+      [],
+      metadata,
+      auth
+    )
+
+    in_tmp(fn ->
+      Hex.State.put(:cache_home, tmp_path())
+      Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
+      Mix.Dep.Lock.write(%{@package => {:hex, @package, version}})
+
+      Mix.Task.run("deps.get")
+      flush()
+
+      fun.()
+    end)
+  end
+end

--- a/test/mix/tasks/hex.sponsor_test.exs
+++ b/test/mix/tasks/hex.sponsor_test.exs
@@ -42,11 +42,6 @@ defmodule Mix.Tasks.Hex.SponsorTest do
     refute_received {:mix_shell, :info, [_package_line]}
 
     assert header_output =~ "No dependencies with sponsorship link found"
-
-    assert header_output =~
-             "You can add sponsorship links to your projects by adding the following to your mix.exs:"
-
-    assert header_output =~ ~s("Sponsor" => "[your-sponsorship-link]")
   end
 
   defp with_test_package(version, metadata, %{auth: auth}, fun) do

--- a/test/mix/tasks/hex.sponsor_test.exs
+++ b/test/mix/tasks/hex.sponsor_test.exs
@@ -42,6 +42,11 @@ defmodule Mix.Tasks.Hex.SponsorTest do
     refute_received {:mix_shell, :info, [_package_line]}
 
     assert header_output =~ "No dependencies with sponsorship link found"
+
+    assert header_output =~
+             "You can add sponsorship links to your projects by adding the following to your mix.exs:"
+
+    assert header_output =~ ~s("Sponsor" => "[your-sponsorship-link]")
   end
 
   defp with_test_package(version, metadata, %{auth: auth}, fun) do

--- a/test/mix/tasks/hex.sponsor_test.exs
+++ b/test/mix/tasks/hex.sponsor_test.exs
@@ -26,11 +26,11 @@ defmodule Mix.Tasks.Hex.SponsorTest do
     assert_received {:mix_shell, :info, [header_output]}
     assert_received {:mix_shell, :info, [package_line]}
 
-    assert String.match?(header_output, ~r/Dependency/)
-    assert String.match?(header_output, ~r/Sponsorship/)
+    assert header_output =~ "Dependency"
+    assert header_output =~ "Sponsorship"
 
-    assert String.match?(package_line, ~r/#{@package_name}/)
-    assert String.match?(package_line, ~r/#{url}/)
+    assert package_line =~ @package_name
+    assert package_line =~ url
   end
 
   test "without sponsor link", context do
@@ -41,7 +41,7 @@ defmodule Mix.Tasks.Hex.SponsorTest do
     assert_received {:mix_shell, :info, [header_output]}
     refute_received {:mix_shell, :info, [_package_line]}
 
-    assert String.match?(header_output, ~r/No dependencies with sponsorship links found/)
+    assert header_output =~ "No dependencies with sponsorship links found"
   end
 
   defp with_test_package(version, metadata, %{auth: auth}, fun) do


### PR DESCRIPTION
This task can help people to find projects that are accepting
sponsorship. The task looks for a link in the package metadata
whose name is one of the following: sponsor, sponsorship,
funding, donate, donation.