### PR TITLE
Fix leaking of test config into global config

### DIFF
--- a/test/mix/tasks/hex.info_test.exs
+++ b/test/mix/tasks/hex.info_test.exs
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Hex.InfoTest do
     Mix.Project.push(Simple)
 
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
       Mix.Task.run("deps.get")
       Mix.Task.clear()
 

--- a/test/mix/tasks/hex.organization_test.exs
+++ b/test/mix/tasks/hex.organization_test.exs
@@ -3,7 +3,7 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
 
   test "auth" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
       auth = Hexpm.new_user("orgauth", "orgauth@mail.com", "password", "orgauth")
       Hexpm.new_repo("myorgauth", auth)
       Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
 
   test "auth with --keyname" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       auth =
         Hexpm.new_user("orgauthwithkeyname", "orgauthwithkeyname@mail.com", "password", "orgauth")
@@ -58,7 +58,7 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
 
   test "auth --key" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
       auth = Hexpm.new_user("orgauthkey", "orgauthkey@mail.com", "password", "orgauthkey")
       Hexpm.new_repo("myorgauthkey", auth)
 
@@ -85,7 +85,7 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
 
   test "auth --key with invalid key" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
       message = "Failed to authenticate against organization repository with given key"
 
       assert_raise Mix.Error, message, fn ->
@@ -96,7 +96,7 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
 
   test "deauth" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
       auth = Hexpm.new_user("orgdeauth", "orgdeauth@mail.com", "password", "orgdeauth")
       Hexpm.new_repo("myorgdeauth", auth)
       Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
 
   test "key --generate" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       auth =
         Hexpm.new_user("orgkeygenuser", "orgkeygenuser@mail.com", "password", "orgkeygenuser")
@@ -140,7 +140,7 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
 
   test "list keys" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       auth =
         Hexpm.new_user("orgkeylistuser", "orgkeylistuser@mail.com", "password", "orgkeylistuser")
@@ -162,7 +162,7 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
 
   test "revoke key" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       auth =
         Hexpm.new_user(
@@ -189,8 +189,8 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
 
   test "revoke all keys" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
+      set_home_cwd()
 
       auth =
         Hexpm.new_user(

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -79,7 +79,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     Mix.Project.push(OutdatedDeps.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       Mix.Dep.Lock.write(%{bar: {:hex, :bar, "0.1.0"}, foo: {:hex, :foo, "0.1.0"}})
 
       Mix.Task.run("deps.get")
@@ -107,7 +107,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     Mix.Project.push(OutdatedDeps.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       Mix.Dep.Lock.write(%{bar: {:hex, :bar, "0.1.0"}, foo: {:hex, :foo, "0.1.0"}})
 
       Mix.Task.run("deps.get")
@@ -158,7 +158,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     Mix.Project.push(OutdatedMultiDeps.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
 
       Mix.Dep.Lock.write(%{
         foo: {:hex, :foo, "0.1.0"},
@@ -190,7 +190,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     Mix.Project.push(OutdatedDeps.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       Mix.Dep.Lock.write(%{bar: {:hex, :bar, "0.1.0"}, foo: {:hex, :foo, "0.1.0"}})
 
       Mix.Task.run("deps.get")
@@ -242,7 +242,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     Mix.Project.push(NotOutdatedApp.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       Mix.Dep.Lock.write(%{ex_doc: {:hex, :ex_doc, "0.1.0"}})
 
       Mix.Task.run("deps.get")
@@ -263,7 +263,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     Mix.Project.push(OutdatedBetaDeps.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       Mix.Dep.Lock.write(%{beta: {:hex, :beta, "1.0.0"}})
 
       Mix.Task.run("deps.get")
@@ -306,7 +306,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     Mix.Project.push(OutdatedApp.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       Mix.Dep.Lock.write(%{ex_doc: {:hex, :ex_doc, "0.0.1"}})
 
       Mix.Task.run("deps.get")
@@ -390,7 +390,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     Mix.Project.push(NotOutdatedApp.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       Mix.Dep.Lock.write(%{ex_doc: {:hex, :ex_doc, "0.1.0"}})
 
       Mix.Task.run("deps.get")
@@ -411,7 +411,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     Mix.Project.push(WithoutHexDeps.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       Mix.Dep.Lock.write(%{})
 
       Mix.Task.run("deps.get")

--- a/test/mix/tasks/hex.owner_test.exs
+++ b/test/mix/tasks/hex.owner_test.exs
@@ -6,7 +6,7 @@ defmodule Mix.Tasks.Hex.OwnerTest do
     Hexpm.new_user("owner_user2", "owner_user2@mail.com", "passpass", "key")
     Hexpm.new_package("hexpm", "owner_package1", "0.0.1", [], %{}, auth)
 
-    Hex.State.put(:home, tmp_path())
+    set_home_tmp()
     Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
 
     send(self(), {:mix_shell_input, :prompt, "passpass"})
@@ -26,7 +26,7 @@ defmodule Mix.Tasks.Hex.OwnerTest do
     Hexpm.new_user("owner_user2a", "owner_user2a@mail.com", "passpass", "key")
     Hexpm.new_package("hexpm", "owner_package1a", "0.0.1", [], %{}, auth)
 
-    Hex.State.put(:home, tmp_path())
+    set_home_tmp()
     Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
 
     send(self(), {:mix_shell_input, :prompt, "passpass"})
@@ -53,7 +53,7 @@ defmodule Mix.Tasks.Hex.OwnerTest do
     Hexpm.new_user("owner_user2b", "owner_user2b@mail.com", "passpass", "key")
     Hexpm.new_package("hexpm", "owner_package1b", "0.0.1", [], %{}, auth)
 
-    Hex.State.put(:home, tmp_path())
+    set_home_tmp()
     Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
 
     send(self(), {:mix_shell_input, :prompt, "passpass"})
@@ -74,7 +74,7 @@ defmodule Mix.Tasks.Hex.OwnerTest do
     Hexpm.new_user("owner_user2c", "owner_user2c@mail.com", "passpass", "key")
     Hexpm.new_package("hexpm", "owner_package1c", "0.0.1", [], %{}, auth)
 
-    Hex.State.put(:home, tmp_path())
+    set_home_tmp()
     Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
 
     send(self(), {:mix_shell_input, :prompt, "passpass"})
@@ -94,7 +94,7 @@ defmodule Mix.Tasks.Hex.OwnerTest do
     Hexpm.new_user("owner_user4", "owner_user4@mail.com", "passpass", "key")
     Hexpm.new_package("hexpm", "owner_package2", "0.0.1", [], %{}, auth)
 
-    Hex.State.put(:home, tmp_path())
+    set_home_tmp()
     Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
 
     send(self(), {:mix_shell_input, :prompt, "passpass"})
@@ -113,7 +113,7 @@ defmodule Mix.Tasks.Hex.OwnerTest do
     auth = Hexpm.new_user("owner_user5", "owner_user5@mail.com", "passpass", "key")
     Hexpm.new_package("hexpm", "owner_package3", "0.0.1", [], %{}, auth)
 
-    Hex.State.put(:home, tmp_path())
+    set_home_tmp()
     Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
 
     Mix.Tasks.Hex.Owner.run(["list", "owner_package3"])
@@ -137,7 +137,7 @@ defmodule Mix.Tasks.Hex.OwnerTest do
     Hexpm.new_package("hexpm", package1, "0.0.1", [], %{}, auth)
     Hexpm.new_package("hexpm", package2, "0.0.1", [], %{}, auth)
 
-    Hex.State.put(:home, tmp_path())
+    set_home_tmp()
     Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
 
     Mix.Tasks.Hex.Owner.run(["packages"])
@@ -152,7 +152,7 @@ defmodule Mix.Tasks.Hex.OwnerTest do
     Hexpm.new_user("owner_user7b", "owner_user7b@mail.com", "passpass", "key")
     Hexpm.new_package("hexpm", "owner_package6", "0.0.1", [], %{}, auth)
 
-    Hex.State.put(:home, tmp_path())
+    set_home_tmp()
     Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
 
     send(self(), {:mix_shell_input, :prompt, "passpass"})

--- a/test/mix/tasks/hex.package_test.exs
+++ b/test/mix/tasks/hex.package_test.exs
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Hex.PackageTest do
     in_fixture("diff", fn ->
       Mix.Project.push(ReleaseDeps.MixProject)
       Mix.Dep.Lock.write(%{ex_doc: {:hex, :ex_doc, "0.0.1"}})
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
       Mix.Task.run("deps.get")
       fun.()
     end)

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -56,7 +56,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
 
   test "ensure user exists" do
     Mix.Project.push(ReleaseSimple.MixProject)
-    Hex.State.put(:home, tmp_path("does_not_exist"))
+    set_home_path(tmp_path("does_not_exist"))
 
     in_tmp(fn ->
       File.write!("myfile.txt", "hello")
@@ -74,7 +74,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseNewSimple.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       File.write!("mix.exs", "mix.exs")
       File.write!("myfile.txt", "hello")
       File.write_stat!("mix.exs", %{File.stat!("mix.exs") | mode: 0o100644})
@@ -111,7 +111,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseSimple.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       File.write!("mix.exs", "mix.exs")
       File.write!("myfile.txt", "hello")
       setup_auth("user2", "hunter42")
@@ -128,7 +128,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(DocsSimple.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       setup_auth("user", "hunter42")
 
       send(self(), {:mix_shell_input, :prompt, "hunter42"})
@@ -147,7 +147,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(DocsFilenameError.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       setup_auth("user", "hunter42")
 
       error_msg = "Invalid filename: top-level filenames cannot match a semantic version pattern"
@@ -166,7 +166,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(DocsDirnameError.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       setup_auth("user", "hunter42")
 
       error_msg = "Invalid filename: top-level filenames cannot match a semantic version pattern"
@@ -185,7 +185,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(DocsError.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       setup_auth("user", "hunter42")
 
       send(self(), {:mix_shell_input, :prompt, "hunter42"})
@@ -204,7 +204,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseName.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       File.write!("mix.exs", "mix.exs")
       File.write!("myfile.txt", "hello")
       setup_auth("user2", "hunter42")
@@ -235,7 +235,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseName.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       File.write!("mix.exs", "mix.exs")
       File.write!("myfile.txt", "hello")
 
@@ -257,7 +257,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseName.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       File.write!("mix.exs", "mix.exs")
       File.write!("myfile.txt", "hello")
       setup_auth("user", "hunter42")
@@ -277,7 +277,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseSimple.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       File.write!("mix.exs", "mix.exs")
       File.write!("myfile.txt", "hello")
       setup_auth("user2", "hunter42")
@@ -295,7 +295,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseSimple.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       File.write!("mix.exs", "mix.exs")
       File.write!("myfile.txt", "hello")
 
@@ -320,7 +320,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseDeps.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       File.write!("mix.exs", "mix.exs")
       setup_auth("user", "hunter42")
 
@@ -345,7 +345,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseMeta.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       setup_auth("user", "hunter42")
 
       error_msg =
@@ -372,7 +372,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseMeta.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       setup_auth("user2", "hunter42")
 
       File.mkdir!("missing")
@@ -401,7 +401,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseRepo.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       File.write!("mix.exs", "mix.exs")
       bypass_repo("myorg")
       setup_auth("user", "hunter42")
@@ -423,7 +423,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseRepo.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       File.write!("mix.exs", "mix.exs")
       setup_auth("user", "hunter42")
 
@@ -439,7 +439,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseRepo.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       File.write!("mix.exs", "mix.exs")
       bypass_repo("myorg2")
       setup_auth("user", "hunter42")
@@ -461,7 +461,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
     Mix.Project.push(ReleaseMetaNoFiles.MixProject)
 
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       setup_auth("user2", "hunter42")
 
       error_msg =

--- a/test/mix/tasks/hex.retire_test.exs
+++ b/test/mix/tasks/hex.retire_test.exs
@@ -5,7 +5,7 @@ defmodule Mix.Tasks.Hex.RetireTest do
     auth = Hexpm.new_user("retire_user", "retire_user@mail.com", "passpass", "key")
     Hexpm.new_package("hexpm", "retire_package", "0.0.1", [], %{}, auth)
 
-    Hex.State.put(:home, tmp_path())
+    set_home_tmp()
     Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
 
     send(self(), {:mix_shell_input, :prompt, "passpass"})
@@ -27,7 +27,7 @@ defmodule Mix.Tasks.Hex.RetireTest do
 
     Hexpm.new_package("hexpm", "retire_package_message", "0.0.1", [], %{}, auth)
 
-    Hex.State.put(:home, tmp_path())
+    set_home_tmp()
     Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
     send(self(), {:mix_shell_input, :prompt, "passpass"})
 

--- a/test/mix/tasks/hex.search_test.exs
+++ b/test/mix/tasks/hex.search_test.exs
@@ -16,7 +16,7 @@ defmodule Mix.Tasks.Hex.SearchTest do
 
   test "search all private packages" do
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       auth = Hexpm.new_user("searchuser1", "searchuser1@mail.com", "password", "searchuser1")
       Hexpm.new_repo("searchrepo1", auth)
       Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
@@ -32,7 +32,7 @@ defmodule Mix.Tasks.Hex.SearchTest do
 
   test "search private package" do
     in_tmp(fn ->
-      Hex.State.put(:home, tmp_path())
+      set_home_tmp()
       auth = Hexpm.new_user("searchuser2", "searchuser2@mail.com", "password", "searchuser2")
       Hexpm.new_repo("searchrepo2", auth)
       Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])

--- a/test/mix/tasks/hex.user_test.exs
+++ b/test/mix/tasks/hex.user_test.exs
@@ -28,7 +28,7 @@ defmodule Mix.Tasks.Hex.UserTest do
 
   test "auth" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       send(self(), {:mix_shell_input, :prompt, "user"})
       send(self(), {:mix_shell_input, :prompt, "hunter42"})
@@ -48,7 +48,7 @@ defmodule Mix.Tasks.Hex.UserTest do
 
   test "auth with --key-name" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       send(self(), {:mix_shell_input, :prompt, "user"})
       send(self(), {:mix_shell_input, :prompt, "hunter42"})
@@ -65,7 +65,7 @@ defmodule Mix.Tasks.Hex.UserTest do
 
   test "auth organizations" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       auth = Hexpm.new_user("userauthorg", "userauthorg@mail.com", "password", "userauthorg")
       Hexpm.new_repo("myuserauthorg", auth)
@@ -85,7 +85,7 @@ defmodule Mix.Tasks.Hex.UserTest do
 
   test "deauth user and organizations" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       auth = Hexpm.new_user("userdeauth1", "userdeauth1@mail.com", "password", "userdeauth1")
       Hexpm.new_repo("myorguserdeauth1", auth)
@@ -103,7 +103,7 @@ defmodule Mix.Tasks.Hex.UserTest do
 
   test "whoami" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
       auth = Hexpm.new_user("whoami", "whoami@mail.com", "password", "whoami")
       Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
 
@@ -114,7 +114,7 @@ defmodule Mix.Tasks.Hex.UserTest do
 
   test "list keys" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       auth = Hexpm.new_user("list_keys", "list_keys@mail.com", "password", "list_keys")
       Mix.Tasks.Hex.update_keys(auth[:"$write_key"], auth[:"$read_key"])
@@ -128,7 +128,7 @@ defmodule Mix.Tasks.Hex.UserTest do
 
   test "revoke key" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       auth_a = Hexpm.new_user("revoke_key", "revoke_key@mail.com", "password", "revoke_key_a")
       auth_b = Hexpm.new_key("revoke_key", "password", "revoke_key_b")
@@ -161,7 +161,7 @@ defmodule Mix.Tasks.Hex.UserTest do
 
   test "revoke all keys" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       auth_a =
         Hexpm.new_user(
@@ -195,7 +195,7 @@ defmodule Mix.Tasks.Hex.UserTest do
 
   test "key generate" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
       Hexpm.new_user("userkeygenerate", "userkeygenerate@mail.com", "password", "password")
       send(self(), {:mix_shell_input, :prompt, "userkeygenerate"})
       send(self(), {:mix_shell_input, :prompt, "password"})
@@ -217,7 +217,7 @@ defmodule Mix.Tasks.Hex.UserTest do
 
   test "reset local password" do
     in_tmp(fn ->
-      Hex.State.put(:home, File.cwd!())
+      set_home_cwd()
 
       Mix.Tasks.Hex.update_keys(Mix.Tasks.Hex.encrypt_key("hunter42", "qwerty"))
       first_key = Hex.Config.read()[:"$write_key"]

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -255,8 +255,9 @@ defmodule HexTest.Case do
   def init_reset_state() do
     public_key = File.read!(Path.join(__DIR__, "../fixtures/test_pub.pem"))
 
-    Hex.State.put(:home, Path.expand("../../tmp/hex_home", __DIR__))
-    Hex.State.put(:hexpm_pk, public_key)
+    Hex.State.put(:config_home, Path.expand("../../tmp/hex_config_home", __DIR__))
+    Hex.State.put(:cache_home, Path.expand("../../tmp/hex_cache_home", __DIR__))
+    Hex.State.put(:data_home, Path.expand("../../tmp/hex_data_home", __DIR__))
     Hex.State.put(:api_url, "http://localhost:4043/api")
     Hex.State.put(:api_key_write, nil)
     Hex.State.put(:api_key_read, nil)
@@ -272,6 +273,20 @@ defmodule HexTest.Case do
 
   def reset_state do
     Hex.State.put_all(Application.get_env(:hex, :reset_state))
+  end
+
+  def set_home_cwd() do
+    set_home_path(File.cwd!())
+  end
+
+  def set_home_tmp() do
+    set_home_path(tmp_path())
+  end
+
+  def set_home_path(path) do
+    Hex.State.put(:config_home, path)
+    Hex.State.put(:cache_home, path)
+    Hex.State.put(:data_home, path)
   end
 
   def wait_on_exit({:ok, pid}) do


### PR DESCRIPTION
Fixes corruption of `~/.hex/hex.config` when running tests.