### PR TITLE
Add support for whitespaces and `.hostname` wildcards in no_proxy env var

### DIFF
--- a/lib/hex/http.ex
+++ b/lib/hex/http.ex
@@ -224,7 +224,17 @@ defmodule Hex.HTTP do
   defp no_proxy() do
     (Hex.State.fetch!(:no_proxy) || "")
     |> String.split(",", trim: true)
+    |> Enum.map(&String.trim/1)
+    |> Enum.map(&normalize_no_proxy_domain_desc/1)
     |> Enum.map(&String.to_charlist/1)
+  end
+
+  defp normalize_no_proxy_domain_desc(<<".", rest::binary>>) do
+    "*." <> rest
+  end
+
+  defp normalize_no_proxy_domain_desc(host) do
+    host
   end
 
   defp user_agent do


### PR DESCRIPTION
In our infrastructure we define no_proxy as `127.0.0.1, localhost, .acme.com, .acme.io` which works perfectly with every piece of software we use (curl and wget as an example).
During my experiments, I've found that wget does not support wildcards with asterisks and httpc does not support the alternative. 