### PR TITLE
Add tests for mix xdg

### DIFF
--- a/lib/hex/config.ex
+++ b/lib/hex/config.ex
@@ -51,12 +51,12 @@ defmodule Hex.Config do
     if state_pid && state_pid != self() do
       Hex.State.fetch!(:config_home)
     else
-      {:ok, config_home} = find_config_home()
+      {:ok, config_home} = find_config_home(:user_config)
       config_home
     end
   end
 
-  def find_config_home(setting \\ :user_cache) do
+  def find_config_home(setting) do
     cond do
       dir = System.get_env("HEX_HOME") ->
         {:ok, dir}

--- a/test/hex/config_test.exs
+++ b/test/hex/config_test.exs
@@ -5,7 +5,7 @@ defmodule Hex.ConfigTest do
   test "find_config_home/1 when no env var flags are set" do
     System.delete_env("HEX_HOME")
     {:ok, dir} = Config.find_config_home(:user_data)
-    assert String.match?(dir, ~r/\/.hex/)
+    assert dir =~ ".hex"
   end
 
   test "find_config_home/1 when HEX_HOME is set" do

--- a/test/hex/config_test.exs
+++ b/test/hex/config_test.exs
@@ -1,0 +1,15 @@
+defmodule Hex.ConfigTest do
+  use ExUnit.Case, async: false
+  alias Hex.Config
+
+  test "find_config_home/1 when no env var flags are set" do
+    {:ok, dir} = Config.find_config_home(:user_data)
+    assert String.match?(dir, ~r/\/.hex/)
+  end
+
+  test "find_config_home/1 when HEX_HOME is set" do
+    System.put_env("HEX_HOME", "/sys/tmp")
+    assert Config.find_config_home(:user_cache) == {:ok, "/sys/tmp"}
+    System.delete_env("HEX_HOME")
+  end
+end

--- a/test/hex/config_test.exs
+++ b/test/hex/config_test.exs
@@ -13,4 +13,21 @@ defmodule Hex.ConfigTest do
     assert Config.find_config_home(:user_cache) == {:ok, "/sys/tmp"}
     System.delete_env("HEX_HOME")
   end
+
+  @tag skip: System.otp_release() < "19"
+  test "find_config_home/1 when MIX_XDG is set and HEX_HOME is not" do
+    System.delete_env("HEX_HOME")
+    System.put_env("MIX_XDG", "true")
+    {:ok, dir} = Config.find_config_home(:user_cache)
+    assert dir =~ "/hex"
+    System.delete_env("MIX_XDG")
+  end
+
+  test "find_config_home/1 when MIX_XDG is set and HEX_HOME is set" do
+    System.put_env("MIX_XDG", "true")
+    System.put_env("HEX_HOME", "/sys/tmp")
+    assert Config.find_config_home(:user_cache) == {:ok, "/sys/tmp"}
+    System.delete_env("HEX_HOME")
+    System.delete_env("MIX_XDG")
+  end
 end

--- a/test/hex/config_test.exs
+++ b/test/hex/config_test.exs
@@ -14,12 +14,23 @@ defmodule Hex.ConfigTest do
     System.delete_env("HEX_HOME")
   end
 
-  @tag skip: System.version() < "1.3" and System.otp_release() < "19"
+  @tag skip: Version.match?(System.version(), "< 1.6.0")
   test "find_config_home/1 when MIX_XDG is set and HEX_HOME is not" do
     System.delete_env("HEX_HOME")
     System.put_env("MIX_XDG", "true")
-    {:ok, dir} = Config.find_config_home(:user_cache)
-    assert dir =~ "/hex"
+    {:ok, cache_dir} = Config.find_config_home(:user_cache)
+    {:ok, config_dir} = Config.find_config_home(:user_config)
+
+    case :os.type() do
+      {_, :linux} ->
+        assert config_dir =~ ".config/hex"
+        assert cache_dir =~ ".cache/hex"
+
+      {_, :darwin} ->
+        assert config_dir =~ "Application Support/hex"
+        assert cache_dir =~ "Caches/hex"
+    end
+
     System.delete_env("MIX_XDG")
   end
 

--- a/test/hex/config_test.exs
+++ b/test/hex/config_test.exs
@@ -3,6 +3,7 @@ defmodule Hex.ConfigTest do
   alias Hex.Config
 
   test "find_config_home/1 when no env var flags are set" do
+    System.delete_env("HEX_HOME")
     {:ok, dir} = Config.find_config_home(:user_data)
     assert String.match?(dir, ~r/\/.hex/)
   end

--- a/test/hex/config_test.exs
+++ b/test/hex/config_test.exs
@@ -14,7 +14,7 @@ defmodule Hex.ConfigTest do
     System.delete_env("HEX_HOME")
   end
 
-  @tag skip: System.otp_release() < "19"
+  @tag skip: System.version() < "1.3" and System.otp_release() < "19"
   test "find_config_home/1 when MIX_XDG is set and HEX_HOME is not" do
     System.delete_env("HEX_HOME")
     System.put_env("MIX_XDG", "true")


### PR DESCRIPTION
adds some unit testing to a function added for mix_xdg
I am not unit testing the when the mix_xdg flag is true because it will fail in < OTP19
I also found one other mistake in the last PR with the default arg