### PR TITLE
Gracefully handle missing hex metadata in sponsor task

### DIFF
--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -68,11 +68,7 @@ defmodule Mix.Tasks.Hex.Sponsor do
   end
 
   defp read_metadata(package, deps_path) do
-    path = Path.join([deps_path, package, @metadata_file])
-
-    if File.exists?(path) do
-      :file.consult(path)
-    end
+    :file.consult(Path.join([deps_path, package, @metadata_file]))
   end
 
   defp sponsorship(metadata) do

--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -60,12 +60,19 @@ defmodule Mix.Tasks.Hex.Sponsor do
             _ ->
               []
           end
+
+        nil ->
+          []
       end
     end)
   end
 
   defp read_metadata(package, deps_path) do
-    :file.consult(Path.join([deps_path, package, @metadata_file]))
+    path = Path.join([deps_path, package, @metadata_file])
+
+    if File.exists?(path) do
+      :file.consult(path)
+    end
   end
 
   defp sponsorship(metadata) do

--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -61,7 +61,7 @@ defmodule Mix.Tasks.Hex.Sponsor do
               []
           end
 
-        nil ->
+        {:error, :enoent} ->
           []
       end
     end)


### PR DESCRIPTION
 It is possible for a lock file to have entries which no longer exist in a mix project, as such the sponsor task will choke if it finds such an entry and tries to read in a hex_metadata.config file that does not exist.

 - Adjust Mix.Task.Hex.Sponsor.read_metadata/2 (private) to check if the
 path exists before attempt to invoke :file.consult/1 on the file.
- Closes #854 