### PR TITLE
Fix registry build crash on versions with hyphens

### DIFF
--- a/lib/mix/tasks/hex.registry.ex
+++ b/lib/mix/tasks/hex.registry.ex
@@ -107,7 +107,7 @@ defmodule Mix.Tasks.Hex.Registry do
 
     paths_per_name =
       Enum.group_by(Path.wildcard("#{public_dir}/tarballs/*.tar"), fn path ->
-        [name, _version] = String.split(Path.basename(path), ["-", ".tar"], trim: true)
+        [name | _rest] = String.split(Path.basename(path), ["-", ".tar"], trim: true)
         name
       end)
 


### PR DESCRIPTION
Closes https://github.com/hexpm/hex/issues/864

When trying to build a hex registry with a tarball which filename's version contains a hyphen, the command raises a `MatchError`. For example, given the following filename `jason-1.0.0-rc.1.tar`:

```elixir
$ mix hex.registry build public --name=acme --private-key=private_key.pem
** (MatchError) no match of right hand side value: ["jason", "1.0.0", "rc.1"]
    lib/mix/tasks/hex.registry.ex:101: anonymous fn/1 in Mix.Tasks.Hex.Registry.build/3
    (elixir 1.12.0-dev) lib/enum.ex:1318: anonymous fn/4 in Enum.group_by/3
    (elixir 1.12.0-dev) lib/enum.ex:2331: Enum."-group_by/3-lists^foldl/2-0-"/3
    lib/mix/tasks/hex.registry.ex:100: Mix.Tasks.Hex.Registry.build/3
    (mix 1.12.0-dev) lib/mix/task.ex:394: anonymous fn/3 in Mix.Task.run_task/3
    (mix 1.12.0-dev) lib/mix/cli.ex:84: Mix.CLI.run_task/2
```

This Pull Request fixes that issue.