### PR TITLE
Update ssl opts for host validation on redirect

### DIFF
--- a/lib/hex/http.ex
+++ b/lib/hex/http.ex
@@ -18,10 +18,11 @@ defmodule Hex.HTTP do
     request = build_request(url, headers, body)
     profile = Hex.State.fetch!(:httpc_profile)
 
-    retry(method, request, @request_retries, fn request ->
-      redirect(request, @request_redirects, fn request ->
-        timeout(request, timeout, fn request ->
-          :httpc.request(method, request, http_opts, opts, profile)
+    retry(method, request, http_opts, @request_retries, fn request, http_opts ->
+      redirect(request, http_opts, @request_redirects, fn request, http_opts ->
+        timeout(request, http_opts, timeout, fn request, http_opts ->
+          method
+          |> :httpc.request(request, http_opts, opts, profile)
           |> handle_response()
         end)
       end)
@@ -56,9 +57,9 @@ defmodule Hex.HTTP do
     end
   end
 
-  defp retry(:get, request, times, fun) do
+  defp retry(:get, request, http_opts, times, fun) do
     result =
-      case fun.(request) do
+      case fun.(request, http_opts) do
         {:http_error, _, _} = error ->
           {:retry, error}
 
@@ -71,23 +72,26 @@ defmodule Hex.HTTP do
 
     case result do
       {:retry, _} when times > 0 ->
-        retry(:get, request, times - 1, fun)
+        retry(:get, request, http_opts, times - 1, fun)
 
       {_other, result} ->
         result
     end
   end
 
-  defp retry(_method, request, _times, fun), do: fun.(request)
+  defp retry(_method, request, http_opts, _times, fun), do: fun.(request, http_opts)
 
-  defp redirect(request, times, fun) do
-    case fun.(request) do
+  defp redirect(request, http_opts, times, fun) do
+    case fun.(request, http_opts) do
       {:ok, response} ->
         case handle_redirect(response) do
           {:ok, location} when times > 0 ->
+            ssl_opts = Hex.HTTP.SSL.ssl_opts(to_string(location))
+            http_opts = Keyword.put(http_opts, :ssl, ssl_opts)
+
             request
             |> update_request(location)
-            |> redirect(times - 0, fun)
+            |> redirect(http_opts, times - 0, fun)
 
           {:ok, _location} ->
             Mix.raise("Too many redirects")
@@ -124,10 +128,9 @@ defmodule Hex.HTTP do
     {new_url, headers}
   end
 
-  defp timeout(request, timeout, fun) do
-    Task.async(fn ->
-      fun.(request)
-    end)
+  defp timeout(request, http_opts, timeout, fun) do
+    fn -> fun.(request, http_opts) end
+    |> Task.async()
     |> task_await(:timeout, timeout)
   end
 

--- a/lib/hex/http.ex
+++ b/lib/hex/http.ex
@@ -21,8 +21,7 @@ defmodule Hex.HTTP do
     retry(method, request, http_opts, @request_retries, fn request, http_opts ->
       redirect(request, http_opts, @request_redirects, fn request, http_opts ->
         timeout(request, http_opts, timeout, fn request, http_opts ->
-          method
-          |> :httpc.request(request, http_opts, opts, profile)
+          :httpc.request(method, request, http_opts, opts, profile)
           |> handle_response()
         end)
       end)
@@ -129,8 +128,7 @@ defmodule Hex.HTTP do
   end
 
   defp timeout(request, http_opts, timeout, fun) do
-    fn -> fun.(request, http_opts) end
-    |> Task.async()
+    Task.async(fn -> fun.(request, http_opts) end)
     |> task_await(:timeout, timeout)
   end
 


### PR DESCRIPTION
The HTTP module didn't update SSL options when following a redirect.

That caused a handshake failure with do to `hostname_check_failed`. This passes the original `http_opts` through so that the SSL opts are recalculated for each redirect location.

For posterity, here was the original error I encountered when redirecting to a CloudFront URL:

```
 - {:bad_cert, :hostname_check_failed}
** (Mix) Downloading http://localhost:4000/repo/tarballs/oban_pro-0.7.0.tar failed:

Request failed ({:failed_connect, [{:to_address, {'d2g9d86gzekkkn.cloudfront.net', 443}}, {:inet, [:inet], {:tls_alert, {:handshake_failure, 'TLS client: In state certify at ssl_handshake.erl:1768 generated CLIENT ALERT: Fatal - Handshake Failure\n {bad_cert,hostname_check_failed}'}}}]})
```

Note: There aren't any test changes here because I couldn't find any obvious tests for the redirect behaviour. Locally, this works perfectly now.
