### PR TITLE
Added HEX_API_KEY enviroment variable to hex.publish docs

### DIFF
--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -13,6 +13,8 @@ defmodule Mix.Tasks.Hex.Publish do
   owners can publish the package, new owners can be added with the
   `mix hex.owner` task.
 
+  Authentication can also be done by setting the `HEX_API_KEY` environment variable, for more information: `Mix.Tasks.Hex.Config`.
+
   Packages and documentation sizes are limited to 8mb compressed, and 64mb uncompressed.
 
   ## Publishing documentation


### PR DESCRIPTION
I was trying to integrate hex.publish in my ci/cd flow and couldn't find this option in the publish docs. But this feature is supported (I found a test for it). So I thought to add this to the publish docs.
