### PR TITLE
Adds new config: no_short_urls

### DIFF
--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -106,7 +106,13 @@ defmodule Hex.State do
       env: ["HEX_CACERTS_PATH"],
       default: nil,
       config: [:cacerts_path]
-    }
+    },
+    no_short_urls: %{
+      env: ["HEX_NO_SHORT_URLS"],
+      config: [:no_short_urls],
+      default: false,
+      fun: {__MODULE__, :to_boolean}
+    },
   }
 
   def start_link([]) do

--- a/lib/hex/state.ex
+++ b/lib/hex/state.ex
@@ -112,7 +112,7 @@ defmodule Hex.State do
       config: [:no_short_urls],
       default: false,
       fun: {__MODULE__, :to_boolean}
-    },
+    }
   }
 
   def start_link([]) do

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -55,7 +55,7 @@ defmodule Mix.Tasks.Hex.Config do
     * `cacerts_path` - Path to the CA certificate store PEM file. If not set,
       a CA bundle that ships with Hex is used. Can be overridden by setting the
       environment variable `HEX_CACERTS_PATH`. (Default: `nil`)
-    * `no_short_urls` - If set to true Hex will not verify attempt to
+    * `no_short_urls` - If set to true Hex will not
       shorten any links. Can be overridden by setting the environment variable
       `HEX_NO_SHORT_URLS` (Default: `false`)
 

--- a/lib/mix/tasks/hex.config.ex
+++ b/lib/mix/tasks/hex.config.ex
@@ -55,6 +55,9 @@ defmodule Mix.Tasks.Hex.Config do
     * `cacerts_path` - Path to the CA certificate store PEM file. If not set,
       a CA bundle that ships with Hex is used. Can be overridden by setting the
       environment variable `HEX_CACERTS_PATH`. (Default: `nil`)
+    * `no_short_urls` - If set to true Hex will not verify attempt to
+      shorten any links. Can be overridden by setting the environment variable
+      `HEX_NO_SHORT_URLS` (Default: `false`)
 
   Hex responds to these additional environment variables:
 

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -298,6 +298,14 @@ defmodule Mix.Tasks.Hex.Outdated do
   defp diff_link(diff_links) do
     long_url = "https://diff.hex.pm/diffs?" <> Enum.join(diff_links, "&")
 
+    if Hex.State.fetch!(:no_short_urls) do
+      long_url
+    else
+      maybe_get_short_link(long_url)
+    end
+  end
+
+  defp maybe_get_short_link(long_url) do
     case Hex.API.ShortURL.create(long_url) do
       :error -> long_url
       {:ok, short_url} -> short_url

--- a/test/mix/tasks/hex.config_test.exs
+++ b/test/mix/tasks/hex.config_test.exs
@@ -22,6 +22,7 @@ defmodule Mix.Tasks.Hex.ConfigTest do
       assert_received {:mix_shell, :info, ["http_timeout: nil (default)"]}
       assert_received {:mix_shell, :info, ["mirror_url: nil (default)"]}
       assert_received {:mix_shell, :info, ["config_home:" <> _]}
+      assert_received {:mix_shell, :info, ["no_short_urls: false (default)"]}
     end)
   after
     purge([ReleaseCustomApiUrl.MixProject])


### PR DESCRIPTION
- config will prevent hex from presenting shortened URLs (security measure?)
- adheres to ENV_VAR called HEX_NO_SHORT_URLS (boolean)
- config test updated
Closes: #880 