### PR TITLE
Adding a tip to run `mix hex.sponsor` when a package that has a sponsor link is added or upgraded

### DIFF
--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -238,12 +238,8 @@ defmodule Hex.RemoteConverger do
       end)
 
       if any_sponsored_new_or_updated?(dep_changes) do
-        """
-        You have added or upgraded one or more package that you could sponsor.
-        Run `mix hex.sponsor` to know how.
-        """
-        |> String.trim()
-        |> Hex.Shell.info()
+        Hex.Shell.info("You have added/upgraded packages you could sponsor, " <> 
+          "run `mix hex.sponsor` to learn more")
       end
     end
   end

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -238,17 +238,19 @@ defmodule Hex.RemoteConverger do
       end)
 
       if any_sponsored_new_or_updated?(dep_changes) do
-        Hex.Shell.info("""
-        You have added or upgraded one or more package that you could sponsor. 
+        """
+        You have added or upgraded one or more package that you could sponsor.
         Run `mix hex.sponsor` to know how.
-        """)
+        """
+        |> String.trim()
+        |> Hex.Shell.info()
       end
     end
   end
 
   defp any_sponsored_new_or_updated?(%{new: new, gt: upgraded}) do
-    Enum.any?(new ++ upgraded, fn {name, _, _, _, _} -> 
-      Hex.Sponsor.get_link(name, Mix.Project.deps_path()) != nil
+    Enum.any?(new ++ upgraded, fn {name, _, _, _, _} ->
+      Hex.Sponsor.get_link(name, Mix.Project.deps_path())
     end)
   end
 

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -236,7 +236,20 @@ defmodule Hex.RemoteConverger do
         unless length(deps) == 0, do: print_category(mod)
         print_dependency_group(deps, mod)
       end)
+
+      if any_sponsored_new_or_updated?(dep_changes) do
+        Hex.Shell.info("""
+        You have added or upgraded one or more package that you could sponsor. 
+        Run `mix hex.sponsor` to know how.
+        """)
+      end
     end
+  end
+
+  defp any_sponsored_new_or_updated?(%{new: new, gt: upgraded}) do
+    Enum.any?(new ++ upgraded, fn {name, _, _, _, _} -> 
+      Hex.Sponsor.get_link(name, Mix.Project.deps_path()) != nil
+    end)
   end
 
   defp resolve_dependencies(resolved, locked) do

--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -200,6 +200,10 @@ defmodule Hex.SCM do
 
     File.write!(Path.join(dest, ".hex"), manifest)
 
+    if Hex.Sponsor.get_link(dest) != nil do
+      Hex.State.put(:print_sponsored_tip, true)
+    end
+
     deps =
       lock.deps
       |> Enum.map(fn {dep, req, opts} ->

--- a/lib/hex/sponsor.ex
+++ b/lib/hex/sponsor.ex
@@ -2,8 +2,8 @@ defmodule Hex.Sponsor do
   @metadata_file "hex_metadata.config"
   @sponsor_link_name "sponsor"
 
-  def get_link(package_name, deps_path) do
-    with {:ok, metadata} <- read_metadata(package_name, deps_path),
+  def get_link(package_path) do
+    with {:ok, metadata} <- read_metadata(package_path),
          {_, value} <- sponsorship(metadata) do
       value
     else
@@ -11,8 +11,16 @@ defmodule Hex.Sponsor do
     end
   end
 
-  defp read_metadata(package, deps_path) do
-    :file.consult(Path.join([deps_path, package, @metadata_file]))
+  def get_link(package_name, deps_path) do
+    deps_path
+    |> Path.join(package_name)
+    |> get_link()
+  end
+
+  defp read_metadata(package_path) do
+    package_path
+    |> Path.join(@metadata_file)
+    |> :file.consult()
   end
 
   defp sponsorship(metadata) do

--- a/lib/hex/sponsor.ex
+++ b/lib/hex/sponsor.ex
@@ -1,4 +1,6 @@
 defmodule Hex.Sponsor do
+  @moduledoc false
+
   @metadata_file "hex_metadata.config"
   @sponsor_link_name "sponsor"
 

--- a/lib/hex/sponsor.ex
+++ b/lib/hex/sponsor.ex
@@ -1,0 +1,27 @@
+defmodule Hex.Sponsor do
+  @metadata_file "hex_metadata.config"
+  @sponsor_link_name "sponsor"
+
+  def get_link(package_name, deps_path) do
+    with {:ok, metadata} <- read_metadata(package_name, deps_path),
+         {_, value} <- sponsorship(metadata) do
+      value
+    else
+      _ -> nil
+    end
+  end
+
+  defp read_metadata(package, deps_path) do
+    :file.consult(Path.join([deps_path, package, @metadata_file]))
+  end
+
+  defp sponsorship(metadata) do
+    case Enum.find(metadata, fn {name, _} -> name == "links" end) do
+      {_links, links} ->
+        Enum.find(links, fn {link, _} -> String.downcase(link) == @sponsor_link_name end)
+
+      _ ->
+        nil
+    end
+  end
+end

--- a/lib/mix/tasks/hex.sponsor.ex
+++ b/lib/mix/tasks/hex.sponsor.ex
@@ -20,8 +20,6 @@ defmodule Mix.Tasks.Hex.Sponsor do
   """
 
   @behaviour Hex.Mix.TaskDescription
-  @metadata_file "hex_metadata.config"
-  @sponsor_link_name "sponsor"
 
   @impl true
   def run(_) do
@@ -51,34 +49,11 @@ defmodule Mix.Tasks.Hex.Sponsor do
 
   defp sponsor_links(packages, deps_path) do
     Enum.flat_map(packages, fn {_repo, package_name} ->
-      case read_metadata(package_name, deps_path) do
-        {:ok, metadata} ->
-          case sponsorship(metadata) do
-            {_, value} ->
-              [[package_name, value]]
-
-            _ ->
-              []
-          end
-
-        {:error, :enoent} ->
-          []
+      case Hex.Sponsor.get_link(package_name, deps_path) do
+        nil -> []
+        value -> [[package_name, value]]
       end
     end)
-  end
-
-  defp read_metadata(package, deps_path) do
-    :file.consult(Path.join([deps_path, package, @metadata_file]))
-  end
-
-  defp sponsorship(metadata) do
-    case Enum.find(metadata, fn {name, _} -> name == "links" end) do
-      {_links, links} ->
-        Enum.find(links, fn {link, _} -> String.downcase(link) == @sponsor_link_name end)
-
-      _ ->
-        nil
-    end
   end
 
   @impl true

--- a/test/hex/mix_task_test.exs
+++ b/test/hex/mix_task_test.exs
@@ -223,6 +223,18 @@ defmodule Hex.MixTaskTest do
     end
   end
 
+  defmodule DependsOnSponsored do
+    def project do
+      [
+        app: :depends_on_sponsored,
+        version: "0.1.0",
+        deps: [
+          {:sponsored, "0.1.0"}
+        ]
+      ]
+    end
+  end
+
   test "deps.get" do
     Mix.Project.push(Simple)
 
@@ -918,5 +930,24 @@ defmodule Hex.MixTaskTest do
       Ecto_3_3_1.Fixture.MixProject,
       Ecto_3_3_2.Fixture.MixProject
     ])
+  end
+
+  test "prints a sponsors tip when updating or adding a package with sponsor link" do
+    Mix.Project.push(DependsOnSponsored)
+
+    in_tmp("sponsor_tmp", fn ->
+      Hex.State.put(:cache_home, tmp_path())
+      Mix.Task.run("deps.get")
+
+      assert_received {:mix_shell, :info, ["* Getting sponsored (Hex package)"]}
+
+      msg =
+        String.trim("""
+        You have added or upgraded one or more package that you could sponsor.
+        Run `mix hex.sponsor` to know how.
+        """)
+
+      assert_received {:mix_shell, :info, [^msg]}
+    end)
   end
 end

--- a/test/hex/mix_task_test.exs
+++ b/test/hex/mix_task_test.exs
@@ -941,13 +941,8 @@ defmodule Hex.MixTaskTest do
 
       assert_received {:mix_shell, :info, ["* Getting sponsored (Hex package)"]}
 
-      msg =
-        String.trim("""
-        You have added or upgraded one or more package that you could sponsor.
-        Run `mix hex.sponsor` to know how.
-        """)
-
-      assert_received {:mix_shell, :info, [^msg]}
+      assert_received {:mix_shell, :info, ["You have added/upgraded packages you could " <> 
+        "sponsor, run `mix hex.sponsor` to learn more"]}
     end)
   end
 end

--- a/test/setup_hexpm.exs
+++ b/test/setup_hexpm.exs
@@ -97,3 +97,6 @@ Hexpm.new_package("hexpm", "ecto", "3.3.1", [], pkg_meta, auth, [
 Hexpm.new_package("hexpm", "ecto", "3.3.2", [], pkg_meta, auth, [
   {"mix.exs", File.read!(Case.fixture_path("ecto_3_3_2/mix.exs"))}
 ])
+
+sponsored_meta = put_in(pkg_meta, ["links", "Sponsor"], "https://my.sponsor.link")
+Hexpm.new_package("hexpm", "sponsored", "0.1.0", [], sponsored_meta, auth)


### PR DESCRIPTION
Closes #883

Was not sure where to add tests for it though, but I ran it locally and it printed like this:

<img width="850" alt="Screen Shot 2021-05-14 at 15 37 02" src="https://user-images.githubusercontent.com/2791965/118314254-46412500-b4ca-11eb-89eb-4f57f5a10891.png">
