### PR TITLE
Add mix hex.repo get task

### DIFF
--- a/lib/mix/tasks/hex.repo.ex
+++ b/lib/mix/tasks/hex.repo.ex
@@ -47,12 +47,6 @@ defmodule Mix.Tasks.Hex.Repo do
       mix hex.repo set NAME --public-key PATH
       mix hex.repo set NAME --auth-key KEY
 
-  ## Get config for repo
-
-      mix hex.repo get NAME --url
-      mix hex.repo get NAME --public-key
-      mix hex.repo get NAME --auth-key
-
   ## Remove repo
 
       mix hex.repo remove NAME
@@ -60,6 +54,7 @@ defmodule Mix.Tasks.Hex.Repo do
   ## Show repo config
 
       mix hex.repo show NAME
+      mix hex.repo show NAME --url
 
   ## List all repos
 
@@ -106,7 +101,6 @@ defmodule Mix.Tasks.Hex.Repo do
 
     mix hex.repo add NAME URL
     mix hex.repo set NAME
-    mix hex.repo get NAME
     mix hex.repo remove NAME
     mix hex.repo show NAME
     mix hex.repo list
@@ -118,8 +112,8 @@ defmodule Mix.Tasks.Hex.Repo do
     [
       {"add NAME URL", "Add a repo"},
       {"set NAME", "Set config for repo"},
-      {"get NAME", "Get config for repo"},
       {"remove NAME", "Remove repo"},
+      {"show NAME", "Show repo config"},
       {"list", "List all repos"}
     ]
   end

--- a/test/mix/tasks/hex.repo_test.exs
+++ b/test/mix/tasks/hex.repo_test.exs
@@ -144,6 +144,29 @@ defmodule Mix.Tasks.Hex.RepoTest do
     end)
   end
 
+  test "get url" do
+    in_tmp(fn ->
+      Hex.State.put(:config_home, File.cwd!())
+
+      Mix.Tasks.Hex.Repo.run(["add", "reponame", "url"])
+      Mix.Tasks.Hex.Repo.run(["get", "reponame", "--url"])
+
+      assert_received {:mix_shell, :info, ["url"]}
+    end)
+  end
+
+  test "get url and key" do
+    in_tmp(fn ->
+      Hex.State.put(:config_home, File.cwd!())
+
+      Mix.Tasks.Hex.Repo.run(["add", "reponame", "url", "--auth-key", "key"])
+      Mix.Tasks.Hex.Repo.run(["get", "reponame", "--url", "--auth-key"])
+
+      assert_received {:mix_shell, :info, ["URL: url"]}
+      assert_received {:mix_shell, :info, ["Auth key: key"]}
+    end)
+  end
+
   test "show prints repo config" do
     in_tmp(fn ->
       Hex.State.put(:config_home, File.cwd!())

--- a/test/mix/tasks/hex.repo_test.exs
+++ b/test/mix/tasks/hex.repo_test.exs
@@ -144,26 +144,14 @@ defmodule Mix.Tasks.Hex.RepoTest do
     end)
   end
 
-  test "get url" do
+  test "show url" do
     in_tmp(fn ->
       Hex.State.put(:config_home, File.cwd!())
 
       Mix.Tasks.Hex.Repo.run(["add", "reponame", "url"])
-      Mix.Tasks.Hex.Repo.run(["get", "reponame", "--url"])
+      Mix.Tasks.Hex.Repo.run(["show", "reponame", "--url"])
 
       assert_received {:mix_shell, :info, ["url"]}
-    end)
-  end
-
-  test "get url and key" do
-    in_tmp(fn ->
-      Hex.State.put(:config_home, File.cwd!())
-
-      Mix.Tasks.Hex.Repo.run(["add", "reponame", "url", "--auth-key", "key"])
-      Mix.Tasks.Hex.Repo.run(["get", "reponame", "--url", "--auth-key"])
-
-      assert_received {:mix_shell, :info, ["URL: url"]}
-      assert_received {:mix_shell, :info, ["Auth key: key"]}
     end)
   end
 


### PR DESCRIPTION
This task can be useful if you CI or other tasks that require you to pass an explicit key, for example:

```
HEXPM_KEY=$(mix hex.repo get --auth-key) make build
```

This assumes you have previously authenticated with `mix hex.user auth`.