### PR TITLE
Remove rebar3 that is included in the base image

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,8 +98,6 @@ jobs:
           mkdir -p ${HEXPM_MIX_HOME}
           PATH=$(pwd)/${HEXPM_ELIXIR_PATH}/bin:$(pwd)/${HEXPM_OTP_PATH}/bin:${PATH} MIX_HOME=$(pwd)/${HEXPM_MIX_HOME} MIX_ARCHIVES=$(pwd)/${HEXPM_MIX_HOME} mix local.hex --force
           PATH=$(pwd)/${HEXPM_ELIXIR_PATH}/bin:$(pwd)/${HEXPM_OTP_PATH}/bin:${PATH} MIX_HOME=$(pwd)/${HEXPM_MIX_HOME} MIX_ARCHIVES=$(pwd)/${HEXPM_MIX_HOME} mix local.rebar --force
-          mix local.hex --force
-          mix local.rebar --force
 
       - name: Set up hexpm
         run: |
@@ -109,6 +107,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo rm -rf /usr/local/bin/rebar3
           mix deps.get
           mix deps.compile
 


### PR DESCRIPTION
For some reason its BEAM files are loaded when running mix test and they
are incompatible with some OTP versions we test on.