### PR TITLE
Check hex timeout

### DIFF
--- a/lib/hex/update_checker.ex
+++ b/lib/hex/update_checker.ex
@@ -9,11 +9,11 @@ defmodule Hex.UpdateChecker do
 
   def start_link(opts \\ []) do
     opts = Keyword.put_new(opts, :name, @name)
-    GenServer.start_link(__MODULE__, [], opts)
+    GenServer.start_link(__MODULE__, opts, opts)
   end
 
-  def init([]) do
-    {:ok, state()}
+  def init(opts) do
+    {:ok, state(opts)}
   end
 
   def start_check() do
@@ -117,12 +117,16 @@ defmodule Hex.UpdateChecker do
     end
   end
 
-  defp state() do
-    %{
+  defp state(opts) do
+    init_state = Keyword.get(opts, :init_state, %{})
+
+    state = %{
       from: nil,
       reply: nil,
       done: false,
       started: false
     }
+
+    Map.merge(state, init_state)
   end
 end

--- a/lib/hex/update_checker.ex
+++ b/lib/hex/update_checker.ex
@@ -8,12 +8,14 @@ defmodule Hex.UpdateChecker do
   @update_interval 24 * 60 * 60
 
   def start_link(opts \\ []) do
+    {init_state, opts} = Keyword.pop(opts, :init_state, %{})
     opts = Keyword.put_new(opts, :name, @name)
-    GenServer.start_link(__MODULE__, opts, opts)
+
+    GenServer.start_link(__MODULE__, init_state, opts)
   end
 
-  def init(opts) do
-    {:ok, state(opts)}
+  def init(init_state) do
+    {:ok, state(init_state)}
   end
 
   def start_check() do
@@ -127,9 +129,7 @@ defmodule Hex.UpdateChecker do
     end
   end
 
-  defp state(opts) do
-    init_state = Keyword.get(opts, :init_state, %{})
-
+  defp state(init_state) do
     state = %{
       from: nil,
       reply: nil,

--- a/test/hex/update_checker_test.exs
+++ b/test/hex/update_checker_test.exs
@@ -65,4 +65,14 @@ defmodule Hex.UpdateCheckerTest do
     GenServer.cast(pid, :start_check)
     assert :already_checked = GenServer.call(pid, :check)
   end
+
+  test "handle check timeout" do
+    flush()
+
+    init_state = %{started: true, check_timeout: 1}
+
+    {:ok, pid} = UpdateChecker.start_link(name: nil, init_state: init_state)
+
+    assert :timeout = GenServer.call(pid, :check)
+  end
 end


### PR DESCRIPTION
Related with this issue https://github.com/hexpm/hex/issues/780

For context, if I'm not wrong, the problem is when there is a `check` operation, it has started, but it doesn't receive any `reply`. If this happens, the GenServer will timeout with the timeout defined in the API part of the GenServer.

In the solution I did:

1. Allow to initialize the state when you start the GenServer. I don't really like this, but is the only way that I found to be able to test and reproduce this bug. This is because I need a started=true and a reply=nil state.
2. Move the timeout from the API to the server.
3. Handle the timeout with `handle_info`.