### PR TITLE
Add overridden_deps/1 and remove unnecessary resolver state

### DIFF
--- a/lib/hex/mix.ex
+++ b/lib/hex/mix.ex
@@ -112,22 +112,6 @@ defmodule Hex.Mix do
   end
 
   @doc """
-  Add a potentially new dependency and its children.
-  This function is used to add Hex packages to the dependency tree which
-  we use in overridden_parents to check overridden status.
-  """
-  def attach_dep_and_children(deps, app, children) do
-    {override, _} = Map.fetch!(deps, app)
-
-    children =
-      Enum.into(children, %{}, fn {_repo, _name, app, _req, _optional} ->
-        {app, {false, %{}}}
-      end)
-
-    Map.merge(children, Map.put(deps, app, {override, children}))
-  end
-
-  @doc """
   Converts a list of dependencies to a requests to the resolver. Skips
   dependencies overriding with another SCM (but include dependencies
   overriding with Hex) and dependencies that are not Hex packages.

--- a/lib/hex/mix.ex
+++ b/lib/hex/mix.ex
@@ -38,19 +38,25 @@ defmodule Hex.Mix do
   due to options like `:only`.
   """
   @spec flatten_deps([Mix.Dep.t()], [atom]) :: [Mix.Dep.t()]
-  def flatten_deps(deps, top_level) do
+  def flatten_deps(deps, overridden_map) do
     apps = Enum.map(deps, & &1.app)
-    top_level = Enum.map(top_level, &Atom.to_string/1)
-    prepared_deps = prepare_deps(deps)
 
     deps ++
       for(
         dep <- deps,
-        overridden_map = overridden_parents(top_level, prepared_deps, Atom.to_string(dep.app)),
         %{app: app} = child <- dep.deps,
         app in apps and !overridden_map[Atom.to_string(app)],
         do: child
       )
+  end
+
+  def overridden_deps(deps) do
+    for(
+      dep <- deps,
+      dep.opts[:override],
+      into: %{},
+      do: {Atom.to_string(dep.app), true}
+    )
   end
 
   @doc """

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -53,8 +53,6 @@ defmodule Hex.RemoteConverger do
     verify_input(requests, locked)
 
     repos = repo_overrides(deps)
-    deps = Hex.Mix.prepare_deps(deps)
-
     top_level = Enum.map(top_level, &Atom.to_string/1)
 
     Hex.Shell.info("Resolving Hex dependencies...")
@@ -69,7 +67,7 @@ defmodule Hex.RemoteConverger do
         end
       end)
 
-    result = Hex.Resolver.resolve(Registry, requests, deps, top_level, repos, locked, overridden_map)
+    result = Hex.Resolver.resolve(Registry, requests, top_level, repos, locked, overridden_map)
     send(pid, :done)
 
     case result do

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -33,7 +33,8 @@ defmodule Hex.RemoteConverger do
     old_lock = Mix.Dep.Lock.read()
 
     top_level = Hex.Mix.top_level(deps)
-    flat_deps = Hex.Mix.flatten_deps(deps, top_level)
+    overridden_map = Hex.Mix.overridden_deps(deps)
+    flat_deps = Hex.Mix.flatten_deps(deps, overridden_map)
     requests = Hex.Mix.deps_to_requests(flat_deps)
 
     [
@@ -68,7 +69,7 @@ defmodule Hex.RemoteConverger do
         end
       end)
 
-    result = Hex.Resolver.resolve(Registry, requests, deps, top_level, repos, locked)
+    result = Hex.Resolver.resolve(Registry, requests, deps, top_level, repos, locked, overridden_map)
     send(pid, :done)
 
     case result do

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -328,7 +328,7 @@ defmodule Mix.Tasks.Hex.Publish do
     end)
 
     Hex.Shell.info("")
-    owner_prompt_selection(Map.new(organizations))
+    owner_prompt_selection(Enum.into(organizations, %{}))
   end
 
   defp owner_prompt_selection(organizations) do

--- a/test/hex/mix_test.exs
+++ b/test/hex/mix_test.exs
@@ -48,7 +48,7 @@ defmodule Hex.MixTest do
 
     deps = [phoenix, ecto, postgrex]
 
-    flattened_deps = Hex.Mix.flatten_deps(deps, [:phoenix])
+    flattened_deps = Hex.Mix.flatten_deps(deps, %{})
     assert phoenix in flattened_deps
     assert ecto in flattened_deps
     assert postgrex in flattened_deps
@@ -63,7 +63,7 @@ defmodule Hex.MixTest do
 
     deps = [ecto, postgrex, phoenix]
 
-    flattened_deps = Hex.Mix.flatten_deps(deps, [:phoenix, :postgrex])
+    flattened_deps = Hex.Mix.flatten_deps(deps, %{"postgrex" => true})
     assert phoenix in flattened_deps
     assert ecto in flattened_deps
     assert postgrex in flattened_deps

--- a/test/support/resolver_helper.ex
+++ b/test/support/resolver_helper.ex
@@ -12,7 +12,7 @@ defmodule HexTest.ResolverHelper do
     |> Enum.map(&{elem(&1, 0), elem(&1, 1)})
     |> Registry.prefetch()
 
-    case Hex.Resolver.resolve(Registry, reqs, deps, top_level, repos, locked, %{}) do
+    case Hex.Resolver.resolve(Registry, reqs, top_level, repos, locked, %{}) do
       {:ok, dict} -> dict
       {:error, {_reason, messages}} -> messages <> "\n"
     end

--- a/test/support/resolver_helper.ex
+++ b/test/support/resolver_helper.ex
@@ -12,7 +12,7 @@ defmodule HexTest.ResolverHelper do
     |> Enum.map(&{elem(&1, 0), elem(&1, 1)})
     |> Registry.prefetch()
 
-    case Hex.Resolver.resolve(Registry, reqs, deps, top_level, repos, locked) do
+    case Hex.Resolver.resolve(Registry, reqs, deps, top_level, repos, locked, %{}) do
       {:ok, dict} -> dict
       {:error, {_reason, messages}} -> messages <> "\n"
     end


### PR DESCRIPTION
Simplifies the overridden check and moves it out of the resolver to improve performance.

In initial testing it's a performance improvement of about 2-4x.