### PR TITLE
mix hex.outdated includes dependency mix env scoping

### DIFF
--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -14,6 +14,19 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     end
   end
 
+  defmodule OutdatedDepsWithOnly.MixProject do
+    def project do
+      [
+        app: :outdated_app,
+        version: "0.0.2",
+        deps: [
+          {:test_package, "0.1.0", only: :test},
+          {:ex_doc, "~> 0.0.1"}
+        ]
+      ]
+    end
+  end
+
   defmodule OutdatedBetaDeps.MixProject do
     def project do
       [
@@ -93,12 +106,42 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["         ", "0.1.0", :reset],
           ["    ", :green, "0.1.0", :reset],
           ["   ", :green, "Up-to-date", :reset],
-          "           "
+          ["           ", "default", :reset],
+          "  "
         ]
         |> IO.ANSI.format()
         |> List.to_string()
 
       assert_received {:mix_shell, :info, [^bar]}
+      refute_received {:mix_shell, :info, ["foo" <> _]}
+    end)
+  end
+
+  test "outdated (with only)" do
+    Mix.Project.push(OutdatedDepsWithOnly.MixProject)
+
+    in_tmp(fn ->
+      set_home_tmp()
+      Mix.Dep.Lock.write(%{bar: {:hex, :bar, "0.1.0"}, foo: {:hex, :foo, "0.1.0"}})
+
+      Mix.Task.run("deps.get")
+      flush()
+
+      assert catch_throw(Mix.Task.run("hex.outdated")) == {:exit_code, 1}
+
+      test_package =
+        [
+          [:bright, "test_package", :reset],
+          ["  ", "0.1.0", :reset],
+          ["    ", :green, "0.1.0", :reset],
+          ["   ", :green, "Up-to-date", :reset],
+          ["           ", "test", :reset],
+          "     "
+        ]
+        |> IO.ANSI.format()
+        |> List.to_string()
+
+      assert_received {:mix_shell, :info, [^test_package]}
       refute_received {:mix_shell, :info, ["foo" <> _]}
     end)
   end
@@ -121,7 +164,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["         ", "0.1.0", :reset],
           ["    ", :green, "0.1.0", :reset],
           ["   ", :green, "Up-to-date", :reset],
-          "           "
+          ["           ", "default", :reset],
+          "  "
         ]
         |> IO.ANSI.format()
         |> List.to_string()
@@ -132,7 +176,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["         ", "0.1.0", :reset],
           ["    ", :red, "0.1.1", :reset],
           ["   ", :yellow, "Update possible", :reset],
-          "      "
+          ["", "      ", :reset],
+          "         "
         ]
         |> IO.ANSI.format()
         |> List.to_string()
@@ -143,6 +188,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["      ", "0.0.1", :reset],
           ["    ", :red, "0.1.0", :reset],
           ["   ", :red, "Update not possible", :reset],
+          ["  ", "default", :reset],
           "  "
         ]
         |> IO.ANSI.format()
@@ -177,7 +223,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["         ", "0.1.0", :reset],
           ["    ", :red, "0.1.1", :reset],
           ["   ", :red, "Update not possible", :reset],
-          "  "
+          ["", "  ", :reset],
+          "         "
         ]
         |> IO.ANSI.format()
         |> List.to_string()
@@ -205,7 +252,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["         ", "0.1.0", :reset],
           ["    ", :green, "0.1.0", :reset],
           ["   ", :green, "Up-to-date", :reset],
-          "           "
+          ["           ", "default", :reset],
+          "  "
         ]
         |> IO.ANSI.format()
         |> List.to_string()
@@ -216,7 +264,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["         ", "0.1.0", :reset],
           ["    ", :red, "0.1.1", :reset],
           ["   ", :yellow, "Update possible", :reset],
-          "      "
+          ["", "      ", :reset],
+          "         "
         ]
         |> IO.ANSI.format()
         |> List.to_string()
@@ -227,6 +276,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["      ", "0.0.1", :reset],
           ["    ", :red, "0.1.0", :reset],
           ["   ", :red, "Update not possible", :reset],
+          ["  ", "default", :reset],
           "  "
         ]
         |> IO.ANSI.format()
@@ -277,7 +327,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["        ", "1.0.0", :reset],
           ["    ", :green, "1.0.0", :reset],
           ["   ", :green, "Up-to-date", :reset],
-          ["  "]
+          ["  ", "default", :reset],
+          "  "
         ]
         |> IO.ANSI.format()
         |> List.to_string()
@@ -293,6 +344,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
           ["        ", "1.0.0", :reset],
           ["    ", :red, "1.1.0-beta", :reset],
           ["  ", :red, "Update not possible", :reset],
+          ["  ", "default", :reset],
           "  "
         ]
         |> IO.ANSI.format()
@@ -470,6 +522,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
             ["      ", "0.0.1", :reset],
             ["    ", :red, "0.1.0", :reset],
             ["   ", :red, "Update not possible", :reset],
+            ["  ", "default", :reset],
             "  "
           ]
           |> IO.ANSI.format()
@@ -481,7 +534,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
             ["         ", "0.1.0", :reset],
             ["    ", :green, "0.1.0", :reset],
             ["   ", :green, "Up-to-date", :reset],
-            "           "
+            ["           ", "default", :reset],
+            "  "
           ]
           |> IO.ANSI.format()
           |> List.to_string()
@@ -492,7 +546,8 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
             ["         ", "0.1.1", :reset],
             ["    ", :green, "0.1.1", :reset],
             ["   ", :green, "Up-to-date", :reset],
-            "           "
+            ["           ", "", :reset],
+            "         "
           ]
           |> IO.ANSI.format()
           |> List.to_string()

--- a/test/setup_hexpm.exs
+++ b/test/setup_hexpm.exs
@@ -41,6 +41,7 @@ Hexpm.new_package(
 )
 
 Hexpm.new_package("hexpm", "package_name", "0.1.0", [], package_name_meta, auth)
+Hexpm.new_package("hexpm", "test_package", "0.1.0", [], pkg_meta, auth)
 Hexpm.new_package("hexpm", "foo", "0.1.0", [], pkg_meta, auth)
 Hexpm.new_package("hexpm", "foo", "0.1.1", [], pkg_meta, auth)
 Hexpm.new_package("hexpm", "bar", "0.1.0", [foo: "~> 0.1.0"], pkg_meta, auth)


### PR DESCRIPTION
Co-authored-by: @mcass19

Hi, thanks for all your work!

We thought when one listing outdated deps with `mix hex.outdated` can be useful to have additional output about the mix env these dependencies are supposed to be active on, prod vs. test or dev dependencies, so one can prioritize those possible upgrades without needing to check the `mix.exs` manually.

This is **unfinished** and needs polishing but wanted to check with you this is something would be considered for merge if polished and refactored properly.

Pending:

- [ ] Minimize calls to `Mix.Project.config`
- [ ] Find a better name for the `Only` table header
- [ ] Reconsider the `default` value - maybe `all` better?
- [ ] Better test coverage

An example of the output with the new header:
```
› mix hex.outdated --all
Dependency           Current  Latest  Status               Only
bamboo               2.2.0    2.2.0   Up-to-date           default
bunt                 0.2.0    0.2.0   Up-to-date
bypass               2.1.0    2.1.0   Up-to-date           test
certifi              2.6.1    2.8.0   Update not possible
cowboy               2.9.0    2.9.0   Up-to-date
cowboy_telemetry     0.3.1    0.4.0   Update possible
cowlib               2.11.0   2.11.0  Up-to-date
credo                1.5.6    1.5.6   Up-to-date           dev
dialyxir             1.1.0    1.1.0   Up-to-date           dev
earmark_parser       1.4.13   1.4.16  Update possible
erlex                0.2.6    0.2.6   Up-to-date
ex_doc               0.25.1   0.25.3  Update possible      dev
file_system          0.2.10   0.2.10  Up-to-date
hackney              1.17.4   1.18.0  Update possible
httpoison            1.8.0    1.8.0   Up-to-date           default
idna                 6.1.1    6.1.1   Up-to-date
jason                1.2.2    1.2.2   Up-to-date           default
makeup               1.0.5    1.0.5   Up-to-date
makeup_elixir        0.15.1   0.15.1  Up-to-date
makeup_erlang        0.1.1    0.1.1   Up-to-date
metrics              1.0.1    2.5.0   Update not possible
mime                 1.6.0    2.0.1   Update not possible
mimerl               1.2.0    1.2.0   Up-to-date
nimble_parsec        1.1.0    1.1.0   Up-to-date
parse_trans          3.3.1    3.4.1   Update not possible
phoenix              1.5.10   1.6.0   Update possible      test
phoenix_pubsub       2.0.0    2.0.0   Up-to-date
plug                 1.12.1   1.12.1  Up-to-date
plug_cowboy          2.5.1    2.5.2   Update possible      default
plug_crypto          1.2.2    1.2.2   Up-to-date
ranch                1.8.0    2.1.0   Update not possible
ssl_verify_fun       1.1.6    1.1.6   Up-to-date
telemetry            0.4.3    1.0.0   Update not possible
unicode_util_compat  0.7.0    0.7.0   Up-to-date
```