### PR TITLE
Add `--incremental` option to `hex.registry build`

### DIFF
--- a/test/mix/tasks/hex.registry_test.exs
+++ b/test/mix/tasks/hex.registry_test.exs
@@ -198,6 +198,167 @@ defmodule Mix.Tasks.Hex.RegistryTest do
     end)
   end
 
+  test "build --incremental" do
+    in_tmp(fn ->
+      bypass = setup_bypass()
+
+      0 = Mix.shell().cmd("openssl genrsa -out private_key.pem")
+      flush()
+
+      # Initial run (--incremental cannot be used to create a new registry)
+
+      Mix.Task.run(
+        "hex.registry",
+        ~w(build public --name acme --private-key private_key.pem)
+      )
+
+      assert_received {:mix_shell, :info, ["* creating public/public_key"]}
+      assert_received {:mix_shell, :info, ["* creating public/tarballs"]}
+      assert_received {:mix_shell, :info, ["* creating public/names"]}
+      assert_received {:mix_shell, :info, ["* creating public/versions"]}
+      refute_received _
+
+      config = %{
+        :mix_hex_core.default_config()
+        | repo_url: "http://localhost:#{bypass.port}",
+          repo_verify: false,
+          repo_verify_origin: false
+      }
+
+      assert {:ok, {200, _, []}} = :mix_hex_repo.get_names(config)
+      assert {:ok, {200, _, []}} = :mix_hex_repo.get_versions(config)
+
+      # Add package to empty registry
+
+      {:ok, %{tarball: tarball}} = :mix_hex_tarball.create(%{name: "foo", version: "0.10.0"}, [])
+      File.write!("public/tarballs/foo-0.10.0.tar", tarball)
+
+      Mix.Task.reenable("hex.registry")
+
+      Mix.Task.run(
+        "hex.registry",
+        ~w(build public --name acme --private-key private_key.pem --incremental)
+      )
+
+      assert_received {:mix_shell, :info, ["* reading public/public_key"]}
+      assert_received {:mix_shell, :info, ["* reading public/names"]}
+      assert_received {:mix_shell, :info, ["* reading public/versions"]}
+      assert_received {:mix_shell, :info, ["* skipping public/packages/foo"]}
+      assert_received {:mix_shell, :info, ["* creating public/packages/foo"]}
+      assert_received {:mix_shell, :info, ["* updating public/names"]}
+      assert_received {:mix_shell, :info, ["* updating public/versions"]}
+      refute_received _
+
+      assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
+      assert [%{name: "foo", updated_at: %{seconds: updated_at}}] = names
+
+      assert updated_at ==
+               "public/tarballs/foo-0.10.0.tar"
+               |> File.stat!()
+               |> Map.fetch!(:mtime)
+               |> Mix.Tasks.Hex.Registry.to_unix()
+
+      assert {:ok, {200, _, versions}} = :mix_hex_repo.get_versions(config)
+      assert versions == [%{name: "foo", retired: [], versions: ["0.10.0"]}]
+
+      # Add new package version without tarballs for other versions
+
+      File.rm!("public/tarballs/foo-0.10.0.tar")
+      {:ok, %{tarball: tarball}} = :mix_hex_tarball.create(%{name: "foo", version: "0.9.0"}, [])
+      File.write!("public/tarballs/foo-0.9.0.tar", tarball)
+
+      Mix.Task.reenable("hex.registry")
+
+      Mix.Task.run(
+        "hex.registry",
+        ~w(build public --name acme --private-key private_key.pem --incremental)
+      )
+
+      assert_received {:mix_shell, :info, ["* reading public/public_key"]}
+      assert_received {:mix_shell, :info, ["* reading public/names"]}
+      assert_received {:mix_shell, :info, ["* reading public/versions"]}
+      assert_received {:mix_shell, :info, ["* reading public/packages/foo"]}
+      assert_received {:mix_shell, :info, ["* updating public/packages/foo"]}
+      assert_received {:mix_shell, :info, ["* updating public/names"]}
+      assert_received {:mix_shell, :info, ["* updating public/versions"]}
+      refute_received _
+
+      assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
+      assert [%{name: "foo", updated_at: %{seconds: updated_at}}] = names
+
+      assert updated_at ==
+               "public/tarballs/foo-0.9.0.tar"
+               |> File.stat!()
+               |> Map.fetch!(:mtime)
+               |> Mix.Tasks.Hex.Registry.to_unix()
+
+      assert {:ok, {200, _, versions}} = :mix_hex_repo.get_versions(config)
+      assert versions == [%{name: "foo", retired: [], versions: ["0.9.0", "0.10.0"]}]
+
+      # Add new package without tarballs for other packages
+
+      File.rm!("public/tarballs/foo-0.9.0.tar")
+
+      metadata = %{
+        name: "bar",
+        version: "0.1.0",
+        requirements: %{
+          "foo" => %{
+            "app" => "foo",
+            "optional" => false,
+            "repository" => "acme",
+            "requirement" => "~> 0.1.0"
+          },
+          "baz" => %{
+            "app" => "baz",
+            "optional" => false,
+            "repository" => "external",
+            "requirement" => "~> 0.1.0"
+          }
+        }
+      }
+
+      {:ok, %{tarball: tarball}} = :mix_hex_tarball.create(metadata, [])
+      File.write!("public/tarballs/bar-0.1.0.tar", tarball)
+
+      Mix.Task.reenable("hex.registry")
+
+      Mix.Task.run(
+        "hex.registry",
+        ~w(build public --name acme --private-key private_key.pem --incremental)
+      )
+
+      assert_received {:mix_shell, :info, ["* reading public/public_key"]}
+      assert_received {:mix_shell, :info, ["* reading public/names"]}
+      assert_received {:mix_shell, :info, ["* reading public/versions"]}
+      assert_received {:mix_shell, :info, ["* skipping public/packages/bar"]}
+      assert_received {:mix_shell, :info, ["* creating public/packages/bar"]}
+      assert_received {:mix_shell, :info, ["* updating public/names"]}
+      assert_received {:mix_shell, :info, ["* updating public/versions"]}
+      refute_received _
+
+      assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
+      assert [%{name: "bar", updated_at: _}, %{name: "foo", updated_at: _}] = names
+      assert {:ok, {200, _, [package]}} = :mix_hex_repo.get_package(config, "bar")
+
+      assert package.dependencies == [
+               %{
+                 app: "baz",
+                 optional: false,
+                 package: "baz",
+                 requirement: "~> 0.1.0",
+                 repository: "external"
+               },
+               %{
+                 app: "foo",
+                 optional: false,
+                 package: "foo",
+                 requirement: "~> 0.1.0"
+               }
+             ]
+    end)
+  end
+
   defp setup_bypass() do
     bypass = Bypass.open()
 

--- a/test/mix/tasks/hex.registry_test.exs
+++ b/test/mix/tasks/hex.registry_test.exs
@@ -240,7 +240,6 @@ defmodule Mix.Tasks.Hex.RegistryTest do
         ~w(build public --name acme --private-key private_key.pem --incremental)
       )
 
-      assert_received {:mix_shell, :info, ["* reading public/public_key"]}
       assert_received {:mix_shell, :info, ["* reading public/names"]}
       assert_received {:mix_shell, :info, ["* reading public/versions"]}
       assert_received {:mix_shell, :info, ["* skipping public/packages/foo"]}
@@ -274,7 +273,6 @@ defmodule Mix.Tasks.Hex.RegistryTest do
         ~w(build public --name acme --private-key private_key.pem --incremental)
       )
 
-      assert_received {:mix_shell, :info, ["* reading public/public_key"]}
       assert_received {:mix_shell, :info, ["* reading public/names"]}
       assert_received {:mix_shell, :info, ["* reading public/versions"]}
       assert_received {:mix_shell, :info, ["* reading public/packages/foo"]}
@@ -328,7 +326,6 @@ defmodule Mix.Tasks.Hex.RegistryTest do
         ~w(build public --name acme --private-key private_key.pem --incremental)
       )
 
-      assert_received {:mix_shell, :info, ["* reading public/public_key"]}
       assert_received {:mix_shell, :info, ["* reading public/names"]}
       assert_received {:mix_shell, :info, ["* reading public/versions"]}
       assert_received {:mix_shell, :info, ["* skipping public/packages/bar"]}


### PR DESCRIPTION
Hello folks 👋🏼 

This PR is primarily for discussion purposes. The code is for demonstration, but I welcome all feedback.

The `mix hex.registry build` command is great for managing local package registries. Thank you for implementing it. Occasionally we want to add a package (or package version) to a registry without regenerating the entire registry. For example, if we build a package `.tar` in a CI job and want to publish it to a local registry, it might be difficult to download all of the existing tarballs prior to building the registry.

Perhaps there is a way around this. If so, great! No need for this PR. If there isn't, maybe this could help.

This PR implements an `--incremental` option for `mix hex.registry build`. When this option is enabled, it adds new packages to a registry without removing any existing packages. Thus, if you have a single tarball in `PUBLIC_DIR/tarballs`, then a single package will be added (or updated). All existing packages remain. The CI job could then re-upload the `names`, `versions`, and `packages/X` files along with the new tarball.

At the time of writing there are two commits with two variations of an implementation. The first keeps the incremental logic separate in a separate function. The second attempts to integrate it with the existing function. I welcome feedback on everything. 🙂 

Thank you for everything you do in the community!