### PR TITLE
Add support for reading credentials from .netrc files

### DIFF
--- a/lib/hex/application.ex
+++ b/lib/hex/application.ex
@@ -74,6 +74,7 @@ defmodule Hex.Application do
   if Mix.env() == :test do
     defp children do
       [
+        worker(Hex.Netrc.Cache),
         worker(Hex.State),
         worker(Hex.Server),
         worker(Hex.Parallel, [:hex_fetcher])
@@ -82,6 +83,7 @@ defmodule Hex.Application do
   else
     defp children do
       [
+        worker(Hex.Netrc.Cache),
         worker(Hex.State),
         worker(Hex.Server),
         worker(Hex.Parallel, [:hex_fetcher]),

--- a/lib/hex/netrc.ex
+++ b/lib/hex/netrc.ex
@@ -1,0 +1,16 @@
+defmodule Hex.Netrc do
+  @moduledoc false
+
+  alias Hex.Netrc.Cache
+  alias Hex.Netrc.Parser
+
+  def lookup(host, path \\ Parser.netrc_path()) when is_binary(host) and is_binary(path) do
+    case Cache.fetch(path) do
+      {:ok, %{} = machines} ->
+        {:ok, Map.get(machines, host)}
+
+      other ->
+        other
+    end
+  end
+end

--- a/lib/hex/netrc/cache.ex
+++ b/lib/hex/netrc/cache.ex
@@ -1,0 +1,31 @@
+defmodule Hex.Netrc.Cache do
+  @moduledoc false
+
+  alias Hex.Netrc.Parser
+
+  @agent_name __MODULE__
+
+  def start_link(_arg) do
+    Agent.start_link(fn -> %{} end, name: @agent_name)
+  end
+
+  def child_spec(arg) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [arg]}
+    }
+  end
+
+  def fetch(path \\ Parser.netrc_path()) when is_binary(path) do
+    Agent.get_and_update(@agent_name, fn cache ->
+      case Map.fetch(cache, path) do
+        {:ok, cached_parse_result} ->
+          {cached_parse_result, cache}
+
+        :error ->
+          parse_result = Parser.parse(path)
+          {parse_result, Map.put(cache, path, parse_result)}
+      end
+    end)
+  end
+end

--- a/lib/hex/netrc/parser.ex
+++ b/lib/hex/netrc/parser.ex
@@ -1,0 +1,60 @@
+defmodule Hex.Netrc.Parser do
+  @moduledoc false
+
+  def parse(path \\ netrc_path()) when is_binary(path) do
+    case File.read(path) do
+      {:ok, contents} ->
+        parse_contents(contents)
+
+      error ->
+        error
+    end
+  end
+
+  defp parse_contents(contents) when is_binary(contents) do
+    parse_result =
+      contents
+      |> Hex.Stdlib.string_trim()
+      |> String.split("\n", trim: true)
+      |> Enum.map(&String.split/1)
+      |> Enum.reduce({%{}, nil}, &parse_line/2)
+
+    case parse_result do
+      {machines, %{username: _, password: _} = current} ->
+        {host, machine} = Map.pop(current, :host)
+        {:ok, Map.put(machines, host, machine)}
+
+      _ ->
+        {:error, :parse}
+    end
+  end
+
+  defp parse_line(_, :parse_error), do: :parse_error
+
+  defp parse_line(["machine", host], {machines, nil}) do
+    {machines, %{host: host}}
+  end
+
+  defp parse_line(["machine", next_host], {machines, %{username: _, password: _} = current}) do
+    {host, machine} = Map.pop(current, :host)
+    {Map.put(machines, host, machine), %{host: next_host}}
+  end
+
+  defp parse_line(["login", username], {machines, %{} = current}) do
+    {machines, Map.put(current, :username, username)}
+  end
+
+  defp parse_line(["password", password], {machines, %{} = current}) do
+    {machines, Map.put(current, :password, password)}
+  end
+
+  defp parse_line(_line, _parse_state), do: :parse_error
+
+  def netrc_path() do
+    System.get_env("NETRC") || default_path()
+  end
+
+  defp default_path() do
+    Path.join(System.user_home!(), ".netrc")
+  end
+end

--- a/test/hex/netrc/cache_test.exs
+++ b/test/hex/netrc/cache_test.exs
@@ -1,0 +1,68 @@
+defmodule Hex.Netrc.CacheTest do
+  use HexTest.Case, async: false
+
+  alias Hex.Netrc.Cache
+
+  setup do
+    # Restart Hex between tests to get a fresh cache.
+    Application.stop(:hex)
+    :ok = Application.start(:hex)
+  end
+
+  test "fetch/1 fails on non-existent file" do
+    in_tmp(fn ->
+      assert {:error, :enoent} = Cache.fetch(".netrc")
+    end)
+  end
+
+  test "fetch/1 remembers parse errors" do
+    in_tmp(fn ->
+      File.write!(".netrc", "")
+      assert {:error, :parse} = Cache.fetch(".netrc")
+      File.rm!(".netrc")
+      assert {:error, :parse} = Cache.fetch(".netrc")
+    end)
+  end
+
+  test "fetch/1 succeeds on simple file" do
+    in_tmp(fn ->
+      data = """
+      machine foo.example.com
+        login john
+        password bar
+      """
+
+      parsed = %{
+        "foo.example.com" => %{
+          username: "john",
+          password: "bar"
+        }
+      }
+
+      File.write!(".netrc", data)
+      assert {:ok, ^parsed} = Cache.fetch(".netrc")
+    end)
+  end
+
+  test "fetch/1 remembers successful parses" do
+    in_tmp(fn ->
+      data = """
+      machine foo.example.com
+        login john
+        password bar
+      """
+
+      parsed = %{
+        "foo.example.com" => %{
+          username: "john",
+          password: "bar"
+        }
+      }
+
+      File.write!(".netrc", data)
+      assert {:ok, ^parsed} = Cache.fetch(".netrc")
+      File.rm!(".netrc")
+      assert {:ok, ^parsed} = Cache.fetch(".netrc")
+    end)
+  end
+end

--- a/test/hex/netrc/parser_test.exs
+++ b/test/hex/netrc/parser_test.exs
@@ -1,0 +1,146 @@
+defmodule Hex.Netrc.ParserTest do
+  use HexTest.Case, async: false
+
+  alias Hex.Netrc.Parser
+
+  test "parse/1 fails on non-existent file" do
+    in_tmp(fn ->
+      assert {:error, :enoent} = Parser.parse(".netrc")
+    end)
+  end
+
+  test "parse/1 fails on unreadable file" do
+    in_tmp(fn ->
+      File.write!(".netrc", "")
+      File.chmod!(".netrc", 0o000)
+      assert {:error, :eacces} = Parser.parse(".netrc")
+    end)
+  end
+
+  test "parse/1 fails on empty file" do
+    in_tmp(fn ->
+      File.write!(".netrc", "")
+      assert {:error, :parse} = Parser.parse(".netrc")
+    end)
+  end
+
+  test "parse/1 succeeds on simple file" do
+    in_tmp(fn ->
+      data = """
+      machine foo.example.com
+        login john
+        password bar
+      """
+
+      parsed = %{
+        "foo.example.com" => %{
+          username: "john",
+          password: "bar"
+        }
+      }
+
+      File.write!(".netrc", data)
+      assert {:ok, ^parsed} = Parser.parse(".netrc")
+    end)
+  end
+
+  test "parse/1 succeeds on file with multiple records" do
+    in_tmp(fn ->
+      data = """
+      machine foo.example.com
+        login john
+        password bar
+      machine bar.example.com
+        login yoyo
+        password dyne
+      """
+
+      parsed = %{
+        "foo.example.com" => %{
+          username: "john",
+          password: "bar"
+        },
+        "bar.example.com" => %{
+          username: "yoyo",
+          password: "dyne"
+        }
+      }
+
+      File.write!(".netrc", data)
+      assert {:ok, ^parsed} = Parser.parse(".netrc")
+    end)
+  end
+
+  test "parse/1 ignores excessive whitespace" do
+    in_tmp(fn ->
+      data = "\n\n\t\nmachine foo.example.com\n\n     login\t\tjohn\npassword\t\tbar\n\n"
+
+      parsed = %{
+        "foo.example.com" => %{
+          username: "john",
+          password: "bar"
+        }
+      }
+
+      File.write!(".netrc", data)
+      assert {:ok, ^parsed} = Parser.parse(".netrc")
+    end)
+  end
+
+  test "parse/1 missing machine line is a parse error" do
+    in_tmp(fn ->
+      data = """
+      login foo
+      password bar
+      """
+
+      File.write!(".netrc", data)
+      assert {:error, :parse} = Parser.parse(".netrc")
+    end)
+  end
+
+  test "parse/1 missing login line is a parse error" do
+    in_tmp(fn ->
+      data = """
+      machine foo.example.com
+      password bar
+      """
+
+      File.write!(".netrc", data)
+      assert {:error, :parse} = Parser.parse(".netrc")
+    end)
+  end
+
+  test "parse/1 missing password line is a parse error" do
+    in_tmp(fn ->
+      data = """
+      machine foo.example.com
+      login foo
+      """
+
+      File.write!(".netrc", data)
+      assert {:error, :parse} = Parser.parse(".netrc")
+    end)
+  end
+
+  test "parse/1 username can be overridden" do
+    in_tmp(fn ->
+      data = """
+      machine foo.example.com
+      login foo
+      login foo2
+      password bar
+      """
+
+      parsed = %{
+        "foo.example.com" => %{
+          username: "foo2",
+          password: "bar"
+        }
+      }
+
+      File.write!(".netrc", data)
+      assert {:ok, ^parsed} = Parser.parse(".netrc")
+    end)
+  end
+end

--- a/test/hex/netrc_test.exs
+++ b/test/hex/netrc_test.exs
@@ -1,0 +1,40 @@
+defmodule Hex.NetrcTest do
+  use HexTest.Case, async: false
+
+  alias Hex.Netrc
+
+  setup do
+    # Restart Hex between tests to get a fresh cache.
+    Application.stop(:hex)
+    :ok = Application.start(:hex)
+  end
+
+  test "lookup/2 returns nil for unknown host" do
+    in_tmp(fn ->
+      data = """
+      machine foo.example.com
+        login foo
+        password bar
+      """
+
+      File.write!(".netrc", data)
+
+      assert {:ok, nil} = Netrc.lookup("bar.example.com", ".netrc")
+    end)
+  end
+
+  test "lookup/2 returns expected result for known host" do
+    in_tmp(fn ->
+      data = """
+      machine foo.example.com
+        login foo
+        password bar
+      """
+
+      File.write!(".netrc", data)
+
+      assert {:ok, %{username: "foo", password: "bar"}} =
+               Netrc.lookup("foo.example.com", ".netrc")
+    end)
+  end
+end


### PR DESCRIPTION
This makes Hex check an optional `.netrc` file for login credentials whenever making HTTP requests.

In case no `authorization` header is present in the request (e.g. as a result of configuring an `auth_key` for the repository), Hex will try to locate a `.netrc` file by checking the `NETRC` environment variable and by checking the user's home directory. In case a file is found, Hex parses it and tries to read login credentials for the host to which the HTTP request is made.

The file format understood by Hex largely follows the [.netrc File Format of cURL](https://everything.curl.dev/usingcurl/netrc): it is a plain-text file with multiple records, each consisting of three lines:

* `machine` defines the host name to which the login credentials should apply
* `login` gives the username
* `password` gives the password

White space is not relevant, i.e. sections can be separated by empty lines and individual lines can be indented, e.g.:

```
machine api.example.com
  login foo
  password yoyodyne

machine another_machine.example.com
login bar
password 12345
```

Closes #924 .