### PR TITLE
Add `hex.registry add` Command

### DIFF
--- a/lib/mix/tasks/hex.registry.ex
+++ b/lib/mix/tasks/hex.registry.ex
@@ -61,13 +61,13 @@ defmodule Mix.Tasks.Hex.Registry do
 
   ## Add a package
 
-      $ mix hex.registry add PUBLIC_DIR PACKAGE1 PACKAGE2 ...
+      $ mix hex.registry add PUBLIC_DIR PACKAGE
 
-  To add one or more packages to an existing registry, supply the public directory of the registry
-  and paths to the new packages. This action also requires the private key used to generate the
-  original registry:
+  To add a package to an existing registry, supply the public directory of the registry and path to
+  the new packages. This action also requires the name of the registry and the private key
+  originally used to generate it:
 
-      $ mix hex.registry add public --private-key=private_key.pem foo-1.0.0.tar
+      $ mix hex.registry add public --name=acme --private-key=private_key.pem foo-1.0.0.tar
       * reading public/name
       * reading public/versions
       * moving foo-1.0.0.tar -> public/tarballs/foo-1.0.0.tar
@@ -76,8 +76,6 @@ defmodule Mix.Tasks.Hex.Registry do
       * updating public/names
       * updating public/versions
 
-  Supplying a `--name` is optional. If given, an error will be raised if the existing registry's
-  name is different than the supplied value.
   """
   @impl true
   def run(args) do

--- a/src/mix_hex_registry.erl
+++ b/src/mix_hex_registry.erl
@@ -8,6 +8,7 @@
     decode_names/2,
     build_names/2,
     unpack_names/3,
+    get_repository_name/2,
     encode_versions/1,
     decode_versions/2,
     build_versions/2,
@@ -61,6 +62,19 @@ decode_names(Payload, Repository) ->
         _ ->
             {error, unverified}
     end.
+
+%% @doc
+%% Get the encoded repository name.
+get_repository_name(Payload, PublicKey) ->
+  case decode_and_verify_signed(zlib:gunzip(Payload), PublicKey) of
+    {ok, Names} -> decode_repository_name(Names);
+    Other -> Other
+  end.
+
+%% @private
+decode_repository_name(Payload) ->
+  #{repository := Repository} = mix_hex_pb_names:decode_msg(Payload, 'Names'),
+  {ok, Repository}.
 
 %% @doc
 %% Builds versions resource.

--- a/src/mix_hex_registry.erl
+++ b/src/mix_hex_registry.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.8.2, do not edit manually
+%% Vendored from hex_core v0.8.0, do not edit manually
 
 %% @doc
 %% Functions for encoding and decoding Hex registries.
@@ -8,7 +8,6 @@
     decode_names/2,
     build_names/2,
     unpack_names/3,
-    get_repository_name/2,
     encode_versions/1,
     decode_versions/2,
     build_versions/2,
@@ -62,19 +61,6 @@ decode_names(Payload, Repository) ->
         _ ->
             {error, unverified}
     end.
-
-%% @doc
-%% Get the encoded repository name.
-get_repository_name(Payload, PublicKey) ->
-  case decode_and_verify_signed(zlib:gunzip(Payload), PublicKey) of
-    {ok, Names} -> decode_repository_name(Names);
-    Other -> Other
-  end.
-
-%% @private
-decode_repository_name(Payload) ->
-  #{repository := Repository} = mix_hex_pb_names:decode_msg(Payload, 'Names'),
-  {ok, Repository}.
 
 %% @doc
 %% Builds versions resource.

--- a/test/mix/tasks/hex.registry_test.exs
+++ b/test/mix/tasks/hex.registry_test.exs
@@ -1,201 +1,417 @@
 defmodule Mix.Tasks.Hex.RegistryTest do
   use HexTest.Case
 
-  test "build" do
-    in_tmp(fn ->
-      bypass = setup_bypass()
+  describe "add" do
+    test "adds a single package to an empty registry" do
+      in_tmp(fn ->
+        bypass = setup_bypass()
 
-      0 = Mix.shell().cmd("openssl genrsa -out private_key.pem")
-      flush()
+        0 = Mix.shell().cmd("openssl genrsa -out private_key.pem")
 
-      Mix.Task.run(
-        "hex.registry",
-        ~w(build public --name acme --private-key private_key.pem)
-      )
+        Mix.Task.run(
+          "hex.registry",
+          ~w(build public --name acme --private-key private_key.pem)
+        )
 
-      assert_received {:mix_shell, :info, ["* creating public/public_key"]}
-      assert_received {:mix_shell, :info, ["* creating public/tarballs"]}
-      assert_received {:mix_shell, :info, ["* creating public/names"]}
-      assert_received {:mix_shell, :info, ["* creating public/versions"]}
-      refute_received _
+        flush()
 
-      config = %{
-        :mix_hex_core.default_config()
-        | repo_url: "http://localhost:#{bypass.port}",
-          repo_verify: false,
-          repo_verify_origin: false
-      }
+        {:ok, %{tarball: tarball}} =
+          :mix_hex_tarball.create(%{name: "foo", version: "0.10.0"}, [])
 
-      assert {:ok, {200, _, []}} = :mix_hex_repo.get_names(config)
-      assert {:ok, {200, _, []}} = :mix_hex_repo.get_versions(config)
+        File.mkdir!("subdir")
+        File.write!("subdir/foo-0.10.0.tar", tarball)
+        Mix.Task.reenable("hex.registry")
 
-      {:ok, %{tarball: tarball}} = :mix_hex_tarball.create(%{name: "foo", version: "0.10.0"}, [])
-      File.write!("public/tarballs/foo-0.10.0.tar", tarball)
+        Mix.Task.run(
+          "hex.registry",
+          ~w(add public --name acme --private-key private_key.pem subdir/foo-0.10.0.tar)
+        )
 
-      Mix.Task.reenable("hex.registry")
+        assert_received {:mix_shell, :info, ["* reading public/names"]}
+        assert_received {:mix_shell, :info, ["* reading public/versions"]}
 
-      Mix.Task.run(
-        "hex.registry",
-        ~w(build public --name acme --private-key private_key.pem)
-      )
+        assert_received {:mix_shell, :info,
+                         ["* moving subdir/foo-0.10.0.tar -> public/tarballs/foo-0.10.0.tar"]}
 
-      assert_received {:mix_shell, :info, ["* creating public/packages/foo"]}
-      assert_received {:mix_shell, :info, ["* updating public/names"]}
-      assert_received {:mix_shell, :info, ["* updating public/versions"]}
-      refute_received _
+        assert_received {:mix_shell, :info, ["* skipping public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* creating public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* updating public/names"]}
+        assert_received {:mix_shell, :info, ["* updating public/versions"]}
+        refute_received _
 
-      assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
-      assert [%{name: "foo", updated_at: %{seconds: updated_at}}] = names
+        config = %{
+          :mix_hex_core.default_config()
+          | repo_url: "http://localhost:#{bypass.port}",
+            repo_verify: false,
+            repo_verify_origin: false
+        }
 
-      assert updated_at ==
-               "public/tarballs/foo-0.10.0.tar"
-               |> File.stat!()
-               |> Map.fetch!(:mtime)
-               |> Mix.Tasks.Hex.Registry.to_unix()
+        assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
+        assert [%{name: "foo", updated_at: %{seconds: updated_at}}] = names
 
-      assert {:ok, {200, _, versions}} = :mix_hex_repo.get_versions(config)
-      assert versions == [%{name: "foo", retired: [], versions: ["0.10.0"]}]
+        assert updated_at ==
+                 "public/tarballs/foo-0.10.0.tar"
+                 |> File.stat!()
+                 |> Map.fetch!(:mtime)
+                 |> Mix.Tasks.Hex.Registry.to_unix()
 
-      {:ok, %{tarball: tarball}} = :mix_hex_tarball.create(%{name: "foo", version: "0.9.0"}, [])
-      File.write!("public/tarballs/foo-0.9.0.tar", tarball)
+        assert {:ok, {200, _, versions}} = :mix_hex_repo.get_versions(config)
+        assert versions == [%{name: "foo", retired: [], versions: ["0.10.0"]}]
+      end)
+    end
 
-      Mix.Task.reenable("hex.registry")
+    test "adds a single package to a populated registry" do
+      in_tmp(fn ->
+        bypass = setup_bypass()
 
-      Mix.Task.run(
-        "hex.registry",
-        ~w(build public --name acme --private-key private_key.pem)
-      )
+        {:ok, %{tarball: tarball}} =
+          :mix_hex_tarball.create(%{name: "foo", version: "0.10.0"}, [])
 
-      assert_received {:mix_shell, :info, ["* updating public/packages/foo"]}
-      assert_received {:mix_shell, :info, ["* updating public/names"]}
-      assert_received {:mix_shell, :info, ["* updating public/versions"]}
-      refute_received _
+        File.mkdir_p!("public/tarballs")
+        File.write!("public/tarballs/foo-0.10.0.tar", tarball)
+        0 = Mix.shell().cmd("openssl genrsa -out private_key.pem")
 
-      assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
-      assert [%{name: "foo", updated_at: %{seconds: updated_at}}] = names
+        Mix.Task.run(
+          "hex.registry",
+          ~w(build public --name acme --private-key private_key.pem)
+        )
 
-      assert updated_at ==
-               "public/tarballs/foo-0.9.0.tar"
-               |> File.stat!()
-               |> Map.fetch!(:mtime)
-               |> Mix.Tasks.Hex.Registry.to_unix()
+        flush()
 
-      assert {:ok, {200, _, versions}} = :mix_hex_repo.get_versions(config)
-      assert versions == [%{name: "foo", retired: [], versions: ["0.9.0", "0.10.0"]}]
+        {:ok, %{tarball: tarball}} = :mix_hex_tarball.create(%{name: "foo", version: "0.9.0"}, [])
+        File.mkdir!("subdir")
+        File.write!("subdir/foo-0.9.0.tar", tarball)
 
-      # Versions with hyphen
-      {:ok, %{tarball: tarball}} =
-        :mix_hex_tarball.create(%{name: "foo", version: "1.0.0-rc"}, [])
+        Mix.Task.reenable("hex.registry")
 
-      File.write!("public/tarballs/foo-1.0.0-rc.tar", tarball)
+        Mix.Task.run(
+          "hex.registry",
+          ~w(add public --name acme --private-key private_key.pem subdir/foo-0.9.0.tar)
+        )
 
-      Mix.Task.reenable("hex.registry")
+        assert_received {:mix_shell, :info, ["* reading public/names"]}
+        assert_received {:mix_shell, :info, ["* reading public/versions"]}
 
-      Mix.Task.run(
-        "hex.registry",
-        ~w(build public --name acme --private-key private_key.pem)
-      )
+        assert_received {:mix_shell, :info,
+                         ["* moving subdir/foo-0.9.0.tar -> public/tarballs/foo-0.9.0.tar"]}
 
-      assert_received {:mix_shell, :info, ["* updating public/packages/foo"]}
-      assert_received {:mix_shell, :info, ["* updating public/names"]}
-      assert_received {:mix_shell, :info, ["* updating public/versions"]}
-      refute_received _
+        assert_received {:mix_shell, :info, ["* reading public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* updating public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* updating public/names"]}
+        assert_received {:mix_shell, :info, ["* updating public/versions"]}
+        refute_received _
 
-      assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
-      assert [%{name: "foo", updated_at: _}] = names
-      assert {:ok, {200, _, versions}} = :mix_hex_repo.get_versions(config)
-      assert versions == [%{name: "foo", retired: [], versions: ["0.9.0", "0.10.0", "1.0.0-rc"]}]
+        config = %{
+          :mix_hex_core.default_config()
+          | repo_url: "http://localhost:#{bypass.port}",
+            repo_verify: false,
+            repo_verify_origin: false
+        }
 
-      # Re-generating private key
-      0 = Mix.shell().cmd("openssl genrsa -out private_key.pem")
-      flush()
-      Mix.Task.reenable("hex.registry")
+        assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
+        assert [%{name: "foo", updated_at: %{seconds: updated_at}}] = names
 
-      Mix.Task.run(
-        "hex.registry",
-        ~w(build public --name acme --private-key private_key.pem)
-      )
+        assert updated_at ==
+                 "public/tarballs/foo-0.9.0.tar"
+                 |> File.stat!()
+                 |> Map.fetch!(:mtime)
+                 |> Mix.Tasks.Hex.Registry.to_unix()
 
-      assert_received {:mix_shell, :info, ["* public key at public/public_key does not" <> _]}
-      assert_received {:mix_shell, :info, ["* updating public/public_key"]}
-      assert_received {:mix_shell, :info, ["* updating public/packages/foo"]}
-      assert_received {:mix_shell, :info, ["* updating public/names"]}
-      assert_received {:mix_shell, :info, ["* updating public/versions"]}
-      refute_received _
+        assert {:ok, {200, _, versions}} = :mix_hex_repo.get_versions(config)
+        assert versions == [%{name: "foo", retired: [], versions: ["0.9.0", "0.10.0"]}]
+      end)
+    end
 
-      # Package with deps
-      metadata = %{
-        name: "bar",
-        version: "0.1.0",
-        requirements: %{
-          "foo" => %{
-            "app" => "foo",
-            "optional" => false,
-            "repository" => "acme",
-            "requirement" => "~> 0.1.0"
-          },
-          "baz" => %{
-            "app" => "baz",
-            "optional" => false,
-            "repository" => "external",
-            "requirement" => "~> 0.1.0"
+    test "adds multiple packages" do
+      in_tmp(fn ->
+        bypass = setup_bypass()
+
+        {:ok, %{tarball: tarball}} =
+          :mix_hex_tarball.create(%{name: "foo", version: "0.10.0"}, [])
+
+        File.mkdir_p!("public/tarballs")
+        File.write!("public/tarballs/foo-0.10.0.tar", tarball)
+        0 = Mix.shell().cmd("openssl genrsa -out private_key.pem")
+
+        Mix.Task.run(
+          "hex.registry",
+          ~w(build public --name acme --private-key private_key.pem)
+        )
+
+        flush()
+
+        {:ok, %{tarball: bar_tarball}} =
+          :mix_hex_tarball.create(%{name: "bar", version: "0.1.0"}, [])
+
+        {:ok, %{tarball: foo_tarball}} =
+          :mix_hex_tarball.create(%{name: "foo", version: "0.9.0"}, [])
+
+        File.mkdir!("subdir")
+        File.write!("subdir/bar-0.1.0.tar", bar_tarball)
+        File.write!("subdir/foo-0.9.0.tar", foo_tarball)
+
+        Mix.Task.reenable("hex.registry")
+
+        Mix.Task.run(
+          "hex.registry",
+          ~w(add public --name acme --private-key private_key.pem subdir/foo-0.9.0.tar subdir/bar-0.1.0.tar)
+        )
+
+        assert_received {:mix_shell, :info, ["* reading public/names"]}
+        assert_received {:mix_shell, :info, ["* reading public/versions"]}
+
+        assert_received {:mix_shell, :info,
+                         ["* moving subdir/foo-0.9.0.tar -> public/tarballs/foo-0.9.0.tar"]}
+
+        assert_received {:mix_shell, :info,
+                         ["* moving subdir/bar-0.1.0.tar -> public/tarballs/bar-0.1.0.tar"]}
+
+        assert_received {:mix_shell, :info, ["* reading public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* updating public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* skipping public/packages/bar"]}
+        assert_received {:mix_shell, :info, ["* creating public/packages/bar"]}
+        assert_received {:mix_shell, :info, ["* updating public/names"]}
+        assert_received {:mix_shell, :info, ["* updating public/versions"]}
+        refute_received _
+
+        config = %{
+          :mix_hex_core.default_config()
+          | repo_url: "http://localhost:#{bypass.port}",
+            repo_verify: false,
+            repo_verify_origin: false
+        }
+
+        assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
+
+        assert [
+                 %{name: "bar", updated_at: %{seconds: bar_updated_at}},
+                 %{name: "foo", updated_at: %{seconds: foo_updated_at}}
+               ] = names
+
+        assert bar_updated_at ==
+                 "public/tarballs/bar-0.1.0.tar"
+                 |> File.stat!()
+                 |> Map.fetch!(:mtime)
+                 |> Mix.Tasks.Hex.Registry.to_unix()
+
+        assert foo_updated_at ==
+                 "public/tarballs/foo-0.9.0.tar"
+                 |> File.stat!()
+                 |> Map.fetch!(:mtime)
+                 |> Mix.Tasks.Hex.Registry.to_unix()
+
+        assert {:ok, {200, _, versions}} = :mix_hex_repo.get_versions(config)
+
+        assert versions == [
+                 %{name: "bar", retired: [], versions: ["0.1.0"]},
+                 %{name: "foo", retired: [], versions: ["0.9.0", "0.10.0"]}
+               ]
+      end)
+    end
+  end
+
+  describe "build" do
+    test "builds a registry" do
+      in_tmp(fn ->
+        bypass = setup_bypass()
+
+        0 = Mix.shell().cmd("openssl genrsa -out private_key.pem")
+        flush()
+
+        Mix.Task.run(
+          "hex.registry",
+          ~w(build public --name acme --private-key private_key.pem)
+        )
+
+        assert_received {:mix_shell, :info, ["* creating public/public_key"]}
+        assert_received {:mix_shell, :info, ["* creating public/tarballs"]}
+        assert_received {:mix_shell, :info, ["* creating public/names"]}
+        assert_received {:mix_shell, :info, ["* creating public/versions"]}
+        refute_received _
+
+        config = %{
+          :mix_hex_core.default_config()
+          | repo_url: "http://localhost:#{bypass.port}",
+            repo_verify: false,
+            repo_verify_origin: false
+        }
+
+        assert {:ok, {200, _, []}} = :mix_hex_repo.get_names(config)
+        assert {:ok, {200, _, []}} = :mix_hex_repo.get_versions(config)
+
+        {:ok, %{tarball: tarball}} =
+          :mix_hex_tarball.create(%{name: "foo", version: "0.10.0"}, [])
+
+        File.write!("public/tarballs/foo-0.10.0.tar", tarball)
+
+        Mix.Task.reenable("hex.registry")
+
+        Mix.Task.run(
+          "hex.registry",
+          ~w(build public --name acme --private-key private_key.pem)
+        )
+
+        assert_received {:mix_shell, :info, ["* creating public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* updating public/names"]}
+        assert_received {:mix_shell, :info, ["* updating public/versions"]}
+        refute_received _
+
+        assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
+        assert [%{name: "foo", updated_at: %{seconds: updated_at}}] = names
+
+        assert updated_at ==
+                 "public/tarballs/foo-0.10.0.tar"
+                 |> File.stat!()
+                 |> Map.fetch!(:mtime)
+                 |> Mix.Tasks.Hex.Registry.to_unix()
+
+        assert {:ok, {200, _, versions}} = :mix_hex_repo.get_versions(config)
+        assert versions == [%{name: "foo", retired: [], versions: ["0.10.0"]}]
+
+        {:ok, %{tarball: tarball}} = :mix_hex_tarball.create(%{name: "foo", version: "0.9.0"}, [])
+        File.write!("public/tarballs/foo-0.9.0.tar", tarball)
+
+        Mix.Task.reenable("hex.registry")
+
+        Mix.Task.run(
+          "hex.registry",
+          ~w(build public --name acme --private-key private_key.pem)
+        )
+
+        assert_received {:mix_shell, :info, ["* updating public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* updating public/names"]}
+        assert_received {:mix_shell, :info, ["* updating public/versions"]}
+        refute_received _
+
+        assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
+        assert [%{name: "foo", updated_at: %{seconds: updated_at}}] = names
+
+        assert updated_at ==
+                 "public/tarballs/foo-0.9.0.tar"
+                 |> File.stat!()
+                 |> Map.fetch!(:mtime)
+                 |> Mix.Tasks.Hex.Registry.to_unix()
+
+        assert {:ok, {200, _, versions}} = :mix_hex_repo.get_versions(config)
+        assert versions == [%{name: "foo", retired: [], versions: ["0.9.0", "0.10.0"]}]
+
+        # Versions with hyphen
+        {:ok, %{tarball: tarball}} =
+          :mix_hex_tarball.create(%{name: "foo", version: "1.0.0-rc"}, [])
+
+        File.write!("public/tarballs/foo-1.0.0-rc.tar", tarball)
+
+        Mix.Task.reenable("hex.registry")
+
+        Mix.Task.run(
+          "hex.registry",
+          ~w(build public --name acme --private-key private_key.pem)
+        )
+
+        assert_received {:mix_shell, :info, ["* updating public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* updating public/names"]}
+        assert_received {:mix_shell, :info, ["* updating public/versions"]}
+        refute_received _
+
+        assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
+        assert [%{name: "foo", updated_at: _}] = names
+        assert {:ok, {200, _, versions}} = :mix_hex_repo.get_versions(config)
+
+        assert versions == [
+                 %{name: "foo", retired: [], versions: ["0.9.0", "0.10.0", "1.0.0-rc"]}
+               ]
+
+        # Re-generating private key
+        0 = Mix.shell().cmd("openssl genrsa -out private_key.pem")
+        flush()
+        Mix.Task.reenable("hex.registry")
+
+        Mix.Task.run(
+          "hex.registry",
+          ~w(build public --name acme --private-key private_key.pem)
+        )
+
+        assert_received {:mix_shell, :info, ["* public key at public/public_key does not" <> _]}
+        assert_received {:mix_shell, :info, ["* updating public/public_key"]}
+        assert_received {:mix_shell, :info, ["* updating public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* updating public/names"]}
+        assert_received {:mix_shell, :info, ["* updating public/versions"]}
+        refute_received _
+
+        # Package with deps
+        metadata = %{
+          name: "bar",
+          version: "0.1.0",
+          requirements: %{
+            "foo" => %{
+              "app" => "foo",
+              "optional" => false,
+              "repository" => "acme",
+              "requirement" => "~> 0.1.0"
+            },
+            "baz" => %{
+              "app" => "baz",
+              "optional" => false,
+              "repository" => "external",
+              "requirement" => "~> 0.1.0"
+            }
           }
         }
-      }
 
-      {:ok, %{tarball: tarball}} = :mix_hex_tarball.create(metadata, [])
-      File.write!("public/tarballs/bar-0.1.0.tar", tarball)
+        {:ok, %{tarball: tarball}} = :mix_hex_tarball.create(metadata, [])
+        File.write!("public/tarballs/bar-0.1.0.tar", tarball)
 
-      Mix.Task.reenable("hex.registry")
+        Mix.Task.reenable("hex.registry")
 
-      Mix.Task.run(
-        "hex.registry",
-        ~w(build public --name acme --private-key private_key.pem)
-      )
+        Mix.Task.run(
+          "hex.registry",
+          ~w(build public --name acme --private-key private_key.pem)
+        )
 
-      assert_received {:mix_shell, :info, ["* creating public/packages/bar"]}
-      assert_received {:mix_shell, :info, ["* updating public/packages/foo"]}
-      assert_received {:mix_shell, :info, ["* updating public/names"]}
-      assert_received {:mix_shell, :info, ["* updating public/versions"]}
-      refute_received _
+        assert_received {:mix_shell, :info, ["* creating public/packages/bar"]}
+        assert_received {:mix_shell, :info, ["* updating public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* updating public/names"]}
+        assert_received {:mix_shell, :info, ["* updating public/versions"]}
+        refute_received _
 
-      assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
-      assert [%{name: "bar", updated_at: _}, %{name: "foo", updated_at: _}] = names
-      assert {:ok, {200, _, [package]}} = :mix_hex_repo.get_package(config, "bar")
+        assert {:ok, {200, _, names}} = :mix_hex_repo.get_names(config)
+        assert [%{name: "bar", updated_at: _}, %{name: "foo", updated_at: _}] = names
+        assert {:ok, {200, _, [package]}} = :mix_hex_repo.get_package(config, "bar")
 
-      assert package.dependencies == [
-               %{
-                 app: "baz",
-                 optional: false,
-                 package: "baz",
-                 requirement: "~> 0.1.0",
-                 repository: "external"
-               },
-               %{
-                 app: "foo",
-                 optional: false,
-                 package: "foo",
-                 requirement: "~> 0.1.0"
-               }
-             ]
+        assert package.dependencies == [
+                 %{
+                   app: "baz",
+                   optional: false,
+                   package: "baz",
+                   requirement: "~> 0.1.0",
+                   repository: "external"
+                 },
+                 %{
+                   app: "foo",
+                   optional: false,
+                   package: "foo",
+                   requirement: "~> 0.1.0"
+                 }
+               ]
 
-      # Removing all package releases
-      File.rm!("public/tarballs/foo-0.9.0.tar")
-      File.rm!("public/tarballs/foo-0.10.0.tar")
-      File.rm!("public/tarballs/foo-1.0.0-rc.tar")
-      Mix.Task.reenable("hex.registry")
+        # Removing all package releases
+        File.rm!("public/tarballs/foo-0.9.0.tar")
+        File.rm!("public/tarballs/foo-0.10.0.tar")
+        File.rm!("public/tarballs/foo-1.0.0-rc.tar")
+        Mix.Task.reenable("hex.registry")
 
-      Mix.Task.run(
-        "hex.registry",
-        ~w(build public --name acme --private-key private_key.pem)
-      )
+        Mix.Task.run(
+          "hex.registry",
+          ~w(build public --name acme --private-key private_key.pem)
+        )
 
-      assert_received {:mix_shell, :info, ["* updating public/packages/bar"]}
-      assert_received {:mix_shell, :info, ["* removing public/packages/foo"]}
-      assert_received {:mix_shell, :info, ["* updating public/names"]}
-      assert_received {:mix_shell, :info, ["* updating public/versions"]}
-      refute_received _
-    end)
+        assert_received {:mix_shell, :info, ["* updating public/packages/bar"]}
+        assert_received {:mix_shell, :info, ["* removing public/packages/foo"]}
+        assert_received {:mix_shell, :info, ["* updating public/names"]}
+        assert_received {:mix_shell, :info, ["* updating public/versions"]}
+        refute_received _
+      end)
+    end
   end
 
   defp setup_bypass() do


### PR DESCRIPTION
This PR supersedes #920. See that PR for previous discussion.

In this PR, we add a `mix hex.registry add` command to the existing mix task. The purpose of this command is to allow private registry maintainers to add one or more packages to an existing registry without necessarily having all of the package tarballs present.

At the time or writing, this PR is a minimal effort for the purpose of discussion. We have an opportunity to make larger changes to the `hex.registry` task to support future growth, if desired.

Some topics to consider:

* Do you have any recommendations for error messages when, for example, someone attempts to add a non-existent tarball?
* Should we support adding a package that matches one already in the registry?
* Should we create separate (and more granular) functions for reading and writing local registries, for the purpose of reuse as we add additional commands in the future (e.g. `remove`, `retire`)?
* Should we provide test setup helpers, such as `create_local_registry` or even an `in_local_registry` macro?

With your guidance, I'm happy to contribute towards the right solution for the long term.