### PR TITLE
Extract common docs to Hex.Package

### DIFF
--- a/lib/hex/package.ex
+++ b/lib/hex/package.ex
@@ -1,0 +1,56 @@
+defmodule Hex.Package do
+  @moduledoc false
+
+  def default_files() do
+    ~w(lib priv .formatter.exs mix.exs README* readme* LICENSE* license*
+      CHANGELOG* changelog* src c_src Makefile*)
+  end
+
+  def configuration_doc() do
+    """
+    ## Configuration
+
+    * `:app` - Package name (required).
+    * `:version` - Package version (required).
+    * `:deps` - List of package dependencies (see [Dependencies](#module-dependencies) below).
+    * `:description` - Short description of the project.
+    * `:package` - Hex specific configuration (see [Package configuration](#module-package-configuration) below).
+
+    ## Dependencies
+
+    Dependencies are defined in mix's dependency format. But instead of using
+    `:git` or `:path` as the SCM `:package` is used.
+
+        defp deps() do
+          [
+            {:ecto, "~> 0.1.0"},
+            {:postgrex, "~> 0.3.0"},
+            {:cowboy, github: "extend/cowboy"}
+          ]
+        end
+
+    As can be seen Hex package dependencies works alongside git dependencies.
+    Important to note is that non-Hex dependencies will not be used during
+    dependency resolution and neither will they be listed as dependencies of the
+    package.
+
+    ## Package configuration
+
+    Additional metadata of the package can optionally be defined, but it is very recommended to do so.
+
+      * `:name` - Set this if the package name is not the same as the application
+         name.
+      * `:files` - List of files and directories to include in the package,
+        can include wildcards. Defaults to `#{inspect(default_files())}`.
+      * `:exclude_patterns` - List of patterns matching files and directories to
+        exclude from the package.
+      * `:licenses` - List of licenses used by the package.
+      * `:links` - Map of links relevant to the package.
+      * `:build_tools` - List of build tools that can build the package. Hex will
+        try to automatically detect the build tools based on the files in the
+        package. If a `rebar` or `rebar.config` file is present Hex will mark it
+        as able to build with rebar. This detection can be overridden by setting
+        this field.
+    """
+  end
+end

--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -12,51 +12,7 @@ defmodule Mix.Tasks.Hex.Build do
 
       $ mix hex.build
 
-  ## Configuration
-
-    * `:app` - Package name (required).
-    * `:version` - Package version (required).
-    * `:deps` - List of package dependencies (see Dependencies below).
-    * `:description` - Short description of the project.
-    * `:package` - Hex specific configuration (see Package configuration below).
-
-  ## Dependencies
-
-  Dependencies are defined in mix's dependency format. But instead of using
-  `:git` or `:path` as the SCM `:package` is used.
-
-      defp deps() do
-        [
-          {:ecto, "~> 0.1.0"},
-          {:postgrex, "~> 0.3.0"},
-          {:cowboy, github: "extend/cowboy"}
-        ]
-      end
-
-  As can be seen Hex package dependencies works alongside git dependencies.
-  Important to note is that non-Hex dependencies will not be used during
-  dependency resolution and neither will they be listed as dependencies of the
-  package.
-
-  ## Package configuration
-
-  Additional package metadata is optional, but highly recommended.
-
-    * `:name` - Set this if the package name is not the same as the application
-       name.
-    * `:files` - List of files and directories to include in the package,
-      can include wildcards. Defaults to `["lib", "priv", ".formatter.exs",
-      "mix.exs", "README*", "readme*", "LICENSE*", "license*", "CHANGELOG*",
-      "changelog*", "src"]`.
-    * `:exclude_patterns` - List of patterns matching files and directories to
-      exclude from the package.
-    * `:licenses` - List of licenses used by the package.
-    * `:links` - Map of links relevant to the package.
-    * `:build_tools` - List of build tools that can build the package. Hex will
-      try to automatically detect the build tools based on the files in the
-      package. If a "rebar" or "rebar.config" file is present Hex will mark it
-      as able to build with rebar. This detection can be overridden by setting
-      this field.
+  #{Hex.Package.configuration_doc()}
 
   ### Command line options
 
@@ -71,8 +27,6 @@ defmodule Mix.Tasks.Hex.Build do
   """
   @behaviour Hex.Mix.TaskDescription
 
-  @default_files ~w(lib priv .formatter.exs mix.exs README* readme* LICENSE*
-                    license* CHANGELOG* changelog* src c_src Makefile*)
   @error_fields ~w(app name files version build_tools)a
   @warn_fields ~w(description licenses links)a
   @meta_fields @error_fields ++ @warn_fields ++ ~w(elixir extra)a
@@ -293,7 +247,7 @@ defmodule Mix.Tasks.Hex.Build do
 
   @doc false
   def package(package, config) do
-    files = package[:files] || @default_files
+    files = package[:files] || Hex.Package.default_files()
     exclude_patterns = (package[:exclude_patterns] || []) ++ [~r/\W\.DS_Store$/]
 
     files =

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -55,51 +55,7 @@ defmodule Mix.Tasks.Hex.Publish do
     * `--revert VERSION` - Revert given version. If the last version is reverted,
       the package is removed.
 
-  ## Configuration
-
-    * `:app` - Package name (required).
-    * `:version` - Package version (required).
-    * `:deps` - List of package dependencies (see Dependencies below).
-    * `:description` - Short description of the project.
-    * `:package` - Hex specific configuration (see Package configuration below).
-
-  ## Dependencies
-
-  Dependencies are defined in mix's dependency format. But instead of using
-  `:git` or `:path` as the SCM `:package` is used.
-
-      defp deps() do
-        [
-          {:ecto, "~> 0.1.0"},
-          {:postgrex, "~> 0.3.0"},
-          {:cowboy, github: "extend/cowboy"}
-        ]
-      end
-
-  As can be seen Hex package dependencies works alongside git dependencies.
-  Important to note is that non-Hex dependencies will not be used during
-  dependency resolution and neither will they be listed as dependencies of the
-  package.
-
-  ## Package configuration
-
-  Additional metadata of the package can optionally be defined, but it is very
-  recommended to do so.
-
-    * `:name` - Set this if the package name is not the same as the application
-      name.
-    * `:organization` - Set this if you are publishing to an organization instead
-      of the default public hex.pm.
-    * `:files` - List of files and directories to include in the package,
-      can include wildcards. Defaults to `["lib", "priv", "mix.exs", "README*",
-      "readme*", "LICENSE*", "license*", "CHANGELOG*", "changelog*", "src"]`.
-    * `:licenses` - List of licenses used by the package.
-    * `:links` - Map of links relevant to the package.
-    * `:build_tools` - List of build tools that can build the package. Hex will
-      try to automatically detect the build tools, it will do this based on the
-      files in the package. If a "rebar" or "rebar.config" file is present Hex
-      will mark it as able to build with rebar. This detection can be overridden
-      by setting this field.
+  #{Hex.Package.configuration_doc()}
   """
   @behaviour Hex.Mix.TaskDescription
 


### PR DESCRIPTION
This PR extracts the common docs part of `hex.publish` and `hex.build` tasks to a `Hex.Package` module.

It also adds a small change to the docs - 'see X below' now include links to the paragraphs

Fixes #941 