### PR TITLE
doc about `repository` permission is misleading

### DIFF
--- a/lib/mix/tasks/hex.organization.ex
+++ b/lib/mix/tasks/hex.organization.ex
@@ -49,7 +49,7 @@ defmodule Mix.Tasks.Hex.Organization do
   command is owned by the organization directly, and not the user that generated it. This makes it
   ideal for shared environments such as CI where you don't want to give access to user-specific
   resources and the user's organization membership status won't affect key. By default this command
-  sets the `repository` permission which allows read-only access to the repository, it can be
+  sets the `repository:organization_name` permission which allows read-only access to the organization's repository, it can be
   overridden with the `--permission` flag.
 
       $ mix hex.organization key ORGANIZATION generate [--key-name KEY_NAME] [--permission PERMISSION]
@@ -88,7 +88,7 @@ defmodule Mix.Tasks.Hex.Organization do
       multiple times, possibly values are:
       * `api:read` - API read access.
       * `api:write` - API write access.
-      * `repository` - Access to the organization's repository (this is the default permission).
+      * `repository:organization_name` - Access to the organization's repository (this is the default permission).
   """
   @behaviour Hex.Mix.TaskDescription
 


### PR DESCRIPTION
I just don't know how to express it correctly in english.
according to the doc (https://hexdocs.pm/hex/Mix.Tasks.Hex.Organization.html#module-generate-organization-key and https://hexdocs.pm/hex/Mix.Tasks.Hex.Organization.html#module-command-line-options), the permission to grant access to organization's repository is `repository` but I learnt the hard way that it has to be `repository:organization_name`.
So, the docs were misleading. I don't know if how I corrected them is the way to go