### PR TITLE
Add :logger to :extra_applications

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -17,13 +17,10 @@ defmodule Hex.MixProject do
 
   def application do
     [
-      applications: applications(Mix.env()),
+      extra_applications: [:ssl, :inets, :logger],
       mod: {Hex.Application, []}
     ]
   end
-
-  defp applications(:prod), do: [:ssl, :inets]
-  defp applications(_), do: [:ssl, :inets, :logger]
 
   defp deps() do
     [


### PR DESCRIPTION
I noticed a bunch of warnings when running:

    $ mix archive.install github hexpm/hex branch main

which look like this:

    warning: Logger.error/1 defined in application :logger is used by the current application but the current application does not depend on :logger. To fix this, you must do one of:

      1. If :logger is part of Erlang/Elixir, you must include it under :extra_applications inside "def application" in your mix.exs

      2. If :logger is a dependency, make sure it is listed under "def deps" in your mix.exs

      3. In case you don't want to add a requirement to :logger, you may optionally skip this warning by adding [xref: [exclude: [Logger]]] to your "def project" in mix.exs

Here are all the locations we use Logger:

    lib/hex/parallel.ex:79: Hex.Parallel.handle_info/2
    lib/hex/parallel.ex:88: Hex.Parallel.handle_info/2
    lib/hex/remote_converger.ex:82: Hex.RemoteConverger.run_solver/5
    lib/hex/remote_converger.ex:83: Hex.RemoteConverger.run_solver/5
    lib/hex/remote_converger.ex:95: Hex.RemoteConverger.run_solver/5
    lib/hex/solver/solver.ex:147: Hex.Solver.Solver.choose_package_version/1
    lib/hex/solver/solver.ex:165: Hex.Solver.Solver.add_incompatibility/2
    lib/hex/solver/solver.ex:190: Hex.Solver.Solver.conflict_resolution/2
    lib/hex/solver/solver.ex:313: Hex.Solver.Solver.do_conflict_resolution/3
    lib/hex/solver/solver.ex:97: Hex.Solver.Solver.propagate_incompatibility/4

Since we depend on Elixir 1.5, it is safe to use :extra_applications.
