### PR TITLE
Match docs tarball error to package error

### DIFF
--- a/src/mix_hex_tarball.erl
+++ b/src/mix_hex_tarball.erl
@@ -103,11 +103,14 @@ create_docs(Files, #{tarball_max_size := TarballMaxSize, tarball_max_uncompresse
     Tarball = gzip(UncompressedTarball),
     Size = byte_size(Tarball),
 
-    case(Size > TarballMaxSize) or (UncompressedSize > TarballMaxUncompressedSize) of
-        true ->
-            {error, {tarball, too_big}};
+    case {(Size > TarballMaxSize), (UncompressedSize > TarballMaxUncompressedSize)} of
+        {_, true} -> 
+            {error, {tarball, {too_big_uncompressed, TarballMaxUncompressedSize}}};
 
-        false ->
+        {true, _} ->
+            {error, {tarball, {too_big_compressed, TarballMaxSize}}};
+
+        {false, false} ->
             {ok, Tarball}
     end.
 


### PR DESCRIPTION
This helps the cases where the package size may be fine, but the documentation is too large (usually because assets like pictures, gifs, etc have been included). Previously, it would report as `too_big`, but that excludes how big the size is and if it was too big compressed or uncompressed.

This changes the `create_docs/2` error to match the `create/2` error reporting the reason for error and the size that was calculated