### PR TITLE
Solve with path and git deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,6 @@ jobs:
       matrix:
         pair:
           - erlang: master
-            elixir: 1.14.0
-          - erlang: 25.0
             elixir: main
           - erlang: 25.0
             elixir: 1.14.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,8 +41,8 @@ jobs:
       fail-fast: false
       matrix:
         pair:
-          - erlang: master
-            elixir: main
+          # - erlang: master
+          #   elixir: main
           - erlang: 25.0
             elixir: 1.14.0
           - erlang: 25.0

--- a/lib/hex/mix.ex
+++ b/lib/hex/mix.ex
@@ -9,9 +9,9 @@ defmodule Hex.Mix do
     for(
       dep <- deps,
       dep.opts[:override],
-      uniq: true,
       do: dep.app
     )
+    |> Enum.uniq()
   end
 
   @doc """

--- a/lib/hex/mix.ex
+++ b/lib/hex/mix.ex
@@ -5,9 +5,19 @@ defmodule Hex.Mix do
 
   @type deps :: %{String.t() => {boolean, deps}}
 
+  def overridden_deps(deps) do
+    for(
+      dep <- deps,
+      dep.opts[:override],
+      uniq: true,
+      do: dep.app
+    )
+  end
+
   @doc """
-  Given a tree of dependencies return a flat list of all dependencies in
-  the tree.
+  Converts a list of dependencies to a requests to the resolver. Skips
+  dependencies overriding with another SCM (but include dependencies
+  overriding with Hex) and dependencies that are not Hex packages.
 
   The returned flattened list is going to contain duplicated dependencies
   because we want to accumulate all of the different requirements.
@@ -16,38 +26,46 @@ defmodule Hex.Mix do
   in the original list of dependencies as they were likely filtered out
   due to options like `:only`.
   """
-  @spec flatten_deps([Mix.Dep.t()], [atom]) :: [Mix.Dep.t()]
-  def flatten_deps(deps, overridden_map) do
+  def deps_to_requests(deps, overridden) do
     apps = Enum.map(deps, & &1.app)
 
-    deps ++
-      for(
-        dep <- deps,
-        %{app: app} = child <- dep.deps,
-        app in apps and !overridden_map[Atom.to_string(app)],
-        do: child
-      )
+    hex_deps_to_requests(deps, apps, overridden, _top_level? = true) ++
+      Enum.flat_map(deps, fn dep ->
+        if dep.scm != Hex.SCM and dep.deps != [] do
+          [
+            %{
+              repo: nil,
+              name: Atom.to_string(dep.app),
+              requirement: nil,
+              app: Atom.to_string(dep.app),
+              from: Path.relative_to_cwd(dep.from),
+              dependencies: hex_deps_to_requests(dep.deps, apps, overridden, _top_level? = false)
+            }
+          ]
+        else
+          []
+        end
+      end)
   end
 
-  def overridden_deps(deps) do
-    for(
-      dep <- deps,
-      dep.opts[:override],
-      into: %{},
-      do: {Atom.to_string(dep.app), true}
-    )
-  end
-
-  @doc """
-  Converts a list of dependencies to a requests to the resolver. Skips
-  dependencies overriding with another SCM (but include dependencies
-  overriding with Hex) and dependencies that are not Hex packages.
-  """
-  def deps_to_requests(deps) do
-    for %Mix.Dep{app: app, requirement: req, scm: Hex.SCM, opts: opts, from: from} <- deps do
-      from = Path.relative_to_cwd(from)
-      {opts[:repo], opts[:hex], Atom.to_string(app), req, from}
-    end
+  defp hex_deps_to_requests(deps, apps, overridden, top_level?) do
+    Enum.flat_map(deps, fn dep ->
+      if dep.scm == Hex.SCM and dep.app in apps and (dep.top_level or dep.app not in overridden) and
+           dep.top_level == top_level? do
+        [
+          %{
+            repo: dep.opts[:repo],
+            name: dep.opts[:hex],
+            requirement: dep.requirement,
+            app: Atom.to_string(dep.app),
+            from: Path.relative_to_cwd(dep.from),
+            dependencies: []
+          }
+        ]
+      else
+        []
+      end
+    end)
   end
 
   @doc """
@@ -77,7 +95,7 @@ defmodule Hex.Mix do
     Enum.flat_map(lock, fn {app, info} ->
       case Hex.Utils.lock(info) do
         %{name: name, version: version, repo: repo} ->
-          [{repo, name, Atom.to_string(app), version}]
+          [%{repo: repo, name: name, app: Atom.to_string(app), version: version}]
 
         nil ->
           []

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -71,7 +71,7 @@ defmodule Hex.RemoteConverger do
           dependencies,
           locked,
           overridden,
-          ansi: IO.ANSI.enabled?()
+          ansi: Hex.Shell.ansi_enabled?()
         )
       after
         Logger.configure(level: level)
@@ -87,7 +87,7 @@ defmodule Hex.RemoteConverger do
         solver_success(resolved, requests, lock, old_lock)
 
       {:error, message} ->
-        Hex.Shell.warn([IO.ANSI.reset(), message])
+        Hex.Shell.info(message)
         Mix.raise("Hex dependency resolution failed")
     end
   end

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -33,8 +33,7 @@ defmodule Hex.RemoteConverger do
     old_lock = Mix.Dep.Lock.read()
 
     overridden = Hex.Mix.overridden_deps(deps)
-    flat_deps = Hex.Mix.flatten_deps(deps, overridden)
-    requests = Hex.Mix.deps_to_requests(flat_deps)
+    requests = Hex.Mix.deps_to_requests(deps, overridden)
 
     [
       Hex.Mix.packages_from_lock(lock),
@@ -57,54 +56,10 @@ defmodule Hex.RemoteConverger do
 
   defp run_solver(lock, old_lock, requests, locked, overridden) do
     start_time = System.monotonic_time(:millisecond)
-
-    dependencies =
-      Enum.reduce(requests, %{}, fn {repo, name, app, requirement, from}, map ->
-        repo = if(repo != "hexpm", do: repo)
-        constraint = Hex.Solver.parse_constraint!(requirement || ">= 0.0.0-0")
-
-        dependency = %{
-          repo: repo,
-          name: name,
-          constraint: constraint,
-          optional: false,
-          label: app,
-          from: from
-        }
-
-        Map.update(map, {repo, name}, dependency, fn existing_dependency ->
-          if existing_dependency.label != dependency.label do
-            name = Hex.Utils.package_name(repo, name)
-
-            Mix.raise("""
-            Conflicting OTP application names in dependency definition of #{inspect(name)}, in the following locations:
-
-              * #{existing_dependency.from} defined application :#{existing_dependency.label}
-              * #{dependency.from} defined application :#{dependency.label}
-            """)
-          end
-
-          constraint =
-            Hex.Solver.Constraint.intersect(
-              existing_dependency.constraint,
-              dependency.constraint
-            )
-
-          optional = existing_dependency.optional and dependency.optional
-          %{existing_dependency | constraint: constraint, optional: optional}
-        end)
-      end)
-      |> Map.values()
-
-    locked =
-      Enum.map(locked, fn {repo, name, app, version} ->
-        %{
-          repo: if(repo != "hexpm", do: repo),
-          name: name,
-          version: Hex.Solver.parse_constraint!(version),
-          label: app
-        }
-      end)
+    dependencies = Enum.map(requests, &request_to_dependency/1)
+    locked = Enum.map(locked, &request_to_locked/1)
+    overridden = Enum.map(overridden, &Atom.to_string/1)
+    verify_otp_app_names(dependencies)
 
     level = Logger.level()
     Logger.configure(level: if(Hex.State.fetch!(:debug_solver), do: :debug, else: :info))
@@ -115,7 +70,7 @@ defmodule Hex.RemoteConverger do
           Registry,
           dependencies,
           locked,
-          Map.keys(overridden),
+          overridden,
           ansi: IO.ANSI.enabled?()
         )
       after
@@ -137,6 +92,34 @@ defmodule Hex.RemoteConverger do
     end
   end
 
+  defp request_to_dependency(request) do
+    constraint =
+      if request.requirement do
+        Hex.Solver.parse_constraint!(request.requirement)
+      else
+        %Hex.Solver.Constraints.Range{}
+      end
+
+    %{
+      repo: if(request.repo != "hexpm", do: request.repo),
+      name: request.name,
+      constraint: constraint,
+      optional: false,
+      label: request.app,
+      from: request.from,
+      dependencies: Enum.map(request.dependencies, &request_to_dependency/1)
+    }
+  end
+
+  defp request_to_locked(request) do
+    %{
+      repo: if(request.repo != "hexpm", do: request.repo),
+      name: request.name,
+      version: Hex.Solver.parse_constraint!(request.version),
+      label: request.app
+    }
+  end
+
   def normalize_resolved(resolved) do
     resolved
     |> Enum.map(fn {name, {version, repo}} ->
@@ -146,6 +129,16 @@ defmodule Hex.RemoteConverger do
   end
 
   defp solver_success(resolved, requests, lock, old_lock) do
+    parent_deps =
+      Enum.flat_map(requests, fn %{name: package, dependencies: deps} ->
+        if deps == [] do
+          []
+        else
+          [package]
+        end
+      end)
+
+    resolved = Enum.reject(resolved, fn {_repo, package, _version} -> package in parent_deps end)
     resolved = add_apps_to_resolved(resolved, requests)
     print_success(resolved, old_lock)
     verify_resolved(resolved, old_lock)
@@ -180,12 +173,7 @@ defmodule Hex.RemoteConverger do
             end
           end)
 
-        root_app =
-          Enum.find_value(requests, fn
-            {^repo, ^package, app, _requirement, _from} -> {"hexpm", "myapp", app}
-            {_repo, _package, _app, _requirement, _from} -> nil
-          end)
-
+        root_app = find_root_app_in_requests(requests, repo, package)
         apps = Enum.uniq_by(List.wrap(root_app) ++ apps, fn {_repo, _package, app} -> app end)
 
         case apps do
@@ -233,9 +221,18 @@ defmodule Hex.RemoteConverger do
     resolved
   end
 
+  defp find_root_app_in_requests(requests, repo, package) do
+    Enum.find_value(requests, fn
+      %{repo: ^repo, name: ^package, app: app} -> {"hexpm", "myapp", app}
+      %{dependencies: dependencies} -> find_root_app_in_requests(dependencies, repo, package)
+      %{} -> nil
+    end)
+  end
+
   defp packages_from_requests(deps) do
-    Enum.map(deps, fn {repo, package, _app, _req, _from} ->
-      {repo, package}
+    Enum.flat_map(deps, fn
+      %{repo: repo, name: package, dependencies: []} -> [{repo, package}]
+      %{dependencies: dependencies} -> packages_from_requests(dependencies)
     end)
   end
 
@@ -291,6 +288,7 @@ defmodule Hex.RemoteConverger do
     end
   end
 
+  # TODO: Use requests
   defp verify_deps(deps, top_level) do
     Enum.each(deps, fn dep ->
       if dep.app in top_level and dep.scm == Hex.SCM and dep.requirement == nil do
@@ -303,11 +301,15 @@ defmodule Hex.RemoteConverger do
   end
 
   defp verify_input(requests, locked) do
-    Enum.each(requests, fn {repo, name, _app, req, from} ->
-      verify_package_req(repo, name, req, from)
+    Enum.each(requests, fn
+      %{repo: repo, name: name, requirement: req, from: from, dependencies: []} ->
+        verify_package_req(repo, name, req, from)
+
+      %{} ->
+        nil
     end)
 
-    Enum.each(locked, fn {repo, name, _app, req} ->
+    Enum.each(locked, fn %{repo: repo, name: name, version: req} ->
       verify_package_req(repo, name, req, "mix.lock")
     end)
   end
@@ -322,6 +324,36 @@ defmodule Hex.RemoteConverger do
         "Required version #{inspect(req)} for package #{name} is incorrectly specified (from: #{from})"
       )
     end
+  end
+
+  defp verify_otp_app_names(dependencies) do
+    verify_otp_app_names(dependencies, %{})
+  end
+
+  defp verify_otp_app_names([%{dependencies: []} = dependency | dependencies], map) do
+    map =
+      Map.update(map, {dependency.repo, dependency.name}, dependency, fn existing_dependency ->
+        if existing_dependency.label != dependency.label do
+          name = Hex.Utils.package_name(dependency.repo, dependency.name)
+
+          Mix.raise("""
+          Conflicting OTP application names in dependency definition of #{inspect(name)}, in the following locations:
+
+            * #{existing_dependency.from} defined application :#{existing_dependency.label}
+            * #{dependency.from} defined application :#{dependency.label}
+          """)
+        end
+      end)
+
+    verify_otp_app_names(dependencies, map)
+  end
+
+  defp verify_otp_app_names([%{dependencies: sub_dependencies} | dependencies], map) do
+    verify_otp_app_names(sub_dependencies ++ dependencies, map)
+  end
+
+  defp verify_otp_app_names([], _map) do
+    :ok
   end
 
   defp print_success(resolved, old_lock) do
@@ -522,6 +554,7 @@ defmodule Hex.RemoteConverger do
   defp verify_deps(nil, _name, _version, _deps), do: :ok
 
   defp verify_deps(repo, name, version, deps) do
+    # TODO: Use requests?
     deps =
       Enum.map(deps, fn {app, req, opts} ->
         %{
@@ -621,7 +654,7 @@ defmodule Hex.RemoteConverger do
 
     old_lock
     |> Hex.Mix.from_lock()
-    |> Enum.reject(fn {_repo, _name, app, _version} -> app in unlock end)
+    |> Enum.reject(fn %{app: app} -> app in unlock end)
   end
 
   defp unlock_deps(deps, old_lock) do

--- a/lib/hex/solver.ex
+++ b/lib/hex/solver.ex
@@ -10,7 +10,8 @@ defmodule Hex.Solver do
           name: package(),
           constraint: constraint(),
           optional: optional(),
-          label: label()
+          label: label(),
+          dependencies: [dependency()]
         }
   @type locked() :: %{
           repo: repo(),

--- a/lib/hex/solver.ex
+++ b/lib/hex/solver.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver do
   _ = """
@@ -33,6 +33,16 @@ defmodule Hex.Solver do
 
   Takes a `Hex.Solver.Registry` implementation, a list of root dependencies, a list of locked
   package versions, and a list of packages that are overridden by the root dependencies.
+
+  Depdendencies with sub-dependencies in the `:dependencies` map field are not expected to be
+  packages in the registry. These dependencies are used to give better error messages for
+  when there are multiple declarations of the dependency with conflicting version requirements.
+  For example:
+
+      * Top dependency 1
+        * package ~> 1.0
+      * Top dependency 2
+        * package ~> 2.0
 
   Locked dependencies are treated as optional dependencies with a single version as
   their constraint.

--- a/lib/hex/solver/assignment.ex
+++ b/lib/hex/solver/assignment.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Assignment do
   @moduledoc false

--- a/lib/hex/solver/constraint.ex
+++ b/lib/hex/solver/constraint.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defprotocol Hex.Solver.Constraint do
   @moduledoc false

--- a/lib/hex/solver/constraints/empty.ex
+++ b/lib/hex/solver/constraints/empty.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Constraints.Empty do
   @moduledoc false

--- a/lib/hex/solver/constraints/impl.ex
+++ b/lib/hex/solver/constraints/impl.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Constraints.Impl do
   @moduledoc false

--- a/lib/hex/solver/constraints/range.ex
+++ b/lib/hex/solver/constraints/range.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Constraints.Range do
   @moduledoc false

--- a/lib/hex/solver/constraints/union.ex
+++ b/lib/hex/solver/constraints/union.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Constraints.Union do
   @moduledoc false

--- a/lib/hex/solver/constraints/util.ex
+++ b/lib/hex/solver/constraints/util.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Constraints.Util do
   @moduledoc false

--- a/lib/hex/solver/constraints/version.ex
+++ b/lib/hex/solver/constraints/version.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Constraints.Version do
   @moduledoc false

--- a/lib/hex/solver/failure.ex
+++ b/lib/hex/solver/failure.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Failure do
   @moduledoc false

--- a/lib/hex/solver/incompatibility.ex
+++ b/lib/hex/solver/incompatibility.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Incompatibility do
   @moduledoc false

--- a/lib/hex/solver/package_lister.ex
+++ b/lib/hex/solver/package_lister.ex
@@ -110,6 +110,7 @@ defmodule Hex.Solver.PackageLister do
 
     prefetch =
       dependencies
+      |> Enum.filter(fn {_dependency, %{prefetch: prefetch}} -> prefetch end)
       |> MapSet.new(fn {dependency, %{repo: repo}} -> {repo, dependency} end)
       |> MapSet.difference(lister.already_prefetched)
 
@@ -195,23 +196,30 @@ defmodule Hex.Solver.PackageLister do
   defp versions(_lister, _repo, "$root"), do: {:ok, [@version_1]}
   defp versions(_lister, _repo, "$lock"), do: {:ok, [@version_1]}
 
-  defp versions(%PackageLister{registry: registry}, repo, package),
-    do: registry.versions(repo, package)
+  defp versions(%PackageLister{} = lister, repo, package) do
+    root_dependency = find_root_dependency(lister, repo, package)
 
-  defp dependencies(
-         %PackageLister{root_dependencies: dependencies, locked: locked},
-         _repo,
-         "$root",
-         @version_1
-       ) do
+    if root_dependency do
+      {:ok, [@version_1]}
+    else
+      lister.registry.versions(repo, package)
+    end
+  end
+
+  defp dependencies(%PackageLister{} = lister, _repo, "$root", @version_1) do
     lock_dependency =
-      if locked == [] do
+      if lister.locked == [] do
         []
       else
         [%{repo: nil, name: "$lock", constraint: @version_1, optional: false, label: "$lock"}]
       end
 
-    {:ok, dependency_map(lock_dependency ++ dependencies)}
+    root_dependencies =
+      Enum.map(lister.root_dependencies, fn dependency ->
+        Map.put(dependency, :prefetch, dependency.dependencies == [])
+      end)
+
+    {:ok, dependency_map(lock_dependency ++ root_dependencies)}
   end
 
   defp dependencies(%PackageLister{locked: locked}, _repo, "$lock", @version_1) do
@@ -222,15 +230,22 @@ defmodule Hex.Solver.PackageLister do
           repo: dependency.repo,
           constraint: dependency.constraint,
           optional: true,
-          label: dependency.label
+          label: dependency.label,
+          prefetch: true
         }}
      end)}
   end
 
-  defp dependencies(%PackageLister{registry: registry}, repo, package, version) do
-    case registry.dependencies(repo, package, version) do
-      {:ok, dependencies} -> {:ok, dependency_map(dependencies)}
-      :error -> :error
+  defp dependencies(%PackageLister{} = lister, repo, package, version) do
+    root_dependency = find_root_dependency(lister, repo, package)
+
+    if root_dependency do
+      {:ok, dependency_map(root_dependency.dependencies)}
+    else
+      case lister.registry.dependencies(repo, package, version) do
+        {:ok, dependencies} -> {:ok, dependency_map(dependencies)}
+        :error -> :error
+      end
     end
   end
 
@@ -241,8 +256,13 @@ defmodule Hex.Solver.PackageLister do
          repo: dependency.repo,
          constraint: dependency.constraint,
          optional: dependency.optional,
-         label: dependency.label
+         label: dependency.label,
+         prefetch: Map.get(dependency, :prefetch, true)
        }}
     end)
+  end
+
+  defp find_root_dependency(%PackageLister{root_dependencies: dependencies}, repo, package) do
+    Enum.find(dependencies, &(&1.repo == repo and &1.name == package and &1.dependencies != []))
   end
 end

--- a/lib/hex/solver/package_lister.ex
+++ b/lib/hex/solver/package_lister.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.PackageLister do
   @moduledoc false

--- a/lib/hex/solver/package_range.ex
+++ b/lib/hex/solver/package_range.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.PackageRange do
   @moduledoc false

--- a/lib/hex/solver/partial_solution.ex
+++ b/lib/hex/solver/partial_solution.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.PartialSolution do
   @moduledoc false

--- a/lib/hex/solver/registry.ex
+++ b/lib/hex/solver/registry.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Registry do
   _ = """

--- a/lib/hex/solver/requirement.ex
+++ b/lib/hex/solver/requirement.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Requirement do
   @moduledoc false

--- a/lib/hex/solver/solver.ex
+++ b/lib/hex/solver/solver.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Solver do
   @moduledoc false

--- a/lib/hex/solver/term.ex
+++ b/lib/hex/solver/term.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Term do
   @moduledoc false

--- a/lib/hex/solver/util.ex
+++ b/lib/hex/solver/util.ex
@@ -1,4 +1,4 @@
-# Vendored from hex_solver v0.2.2 (2634e31), do not edit manually
+# Vendored from hex_solver v0.2.3 (057f77e), do not edit manually
 
 defmodule Hex.Solver.Util do
   @moduledoc false

--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -97,7 +97,6 @@ defmodule Mix.Tasks.Hex.Build do
     {organization, package} = Map.pop(package, :organization)
     {deps, exclude_deps} = dependencies()
     meta = meta_for(config, package, deps)
-    check_unstable_dependencies!(organization, meta)
 
     %{
       config: config,
@@ -280,13 +279,6 @@ defmodule Mix.Tasks.Hex.Build do
     end
   end
 
-  defp check_unstable_dependencies!(organization, meta) do
-    if organization in [nil, "hexpm"] and not pre_requirement?(meta.version) and
-         has_pre_requirements?(meta) do
-      Mix.raise("A stable package release cannot have a pre-release dependency")
-    end
-  end
-
   defp check_misspellings!(opts) do
     if opts[:organisation] do
       Mix.raise("Invalid Hex package config :organisation, use spelling :organization")
@@ -305,16 +297,6 @@ defmodule Mix.Tasks.Hex.Build do
         "Mix project configuration #{inspect(invalid_field)} belongs under the :package key, did you misplace it?"
       )
     end
-  end
-
-  defp pre_requirement?(version_req) do
-    String.contains?(version_req, "-")
-  end
-
-  defp has_pre_requirements?(meta) do
-    meta.requirements
-    |> Enum.map(& &1.requirement)
-    |> Enum.any?(&pre_requirement?/1)
   end
 
   @scm_keys [:git, :github, :path]

--- a/test/hex/mix_task_test.exs
+++ b/test/hex/mix_task_test.exs
@@ -651,6 +651,13 @@ defmodule Hex.MixTaskTest do
       assert_raise(Mix.Error, "Hex dependency resolution failed", fn ->
         Mix.Task.run("deps.get")
       end)
+
+      solver_output = """
+      \e[33m\e[0mBecause \e[1myour app\e[0m depends on \e[1mecto\e[0m which depends on \e[1mpostgrex 0.2.0\e[0m, \e[1mpostgrex 0.2.0\e[0m is required.
+      So, because \e[1myour app\e[0m depends on \e[1mpostgrex 0.2.1\e[0m, version solving failed.\e[0m\
+      """
+
+      assert_received {:mix_shell, :info, [^solver_output]}
     end)
   after
     purge([Ecto.Fixture.MixProject, Postgrex.NoConflict.MixProject, Ex_doc.NoConflict.MixProject])

--- a/test/hex/mix_task_test.exs
+++ b/test/hex/mix_task_test.exs
@@ -653,8 +653,8 @@ defmodule Hex.MixTaskTest do
       end)
 
       solver_output = """
-      \e[33m\e[0mBecause \e[1myour app\e[0m depends on \e[1mecto\e[0m which depends on \e[1mpostgrex 0.2.0\e[0m, \e[1mpostgrex 0.2.0\e[0m is required.
-      So, because \e[1myour app\e[0m depends on \e[1mpostgrex 0.2.1\e[0m, version solving failed.\e[0m\
+      Because "your app" depends on "ecto" which depends on "postgrex 0.2.0", "postgrex 0.2.0" is required.
+      So, because "your app" depends on "postgrex 0.2.1", version solving failed.\
       """
 
       assert_received {:mix_shell, :info, [^solver_output]}

--- a/test/hex/mix_test.exs
+++ b/test/hex/mix_test.exs
@@ -5,7 +5,10 @@ defmodule Hex.MixTest do
     lock = [ex_doc: {:hex, :ex_doc, "0.1.0"}, postgrex: {:hex, :fork, "0.2.1"}]
 
     assert Hex.Mix.from_lock(lock) ==
-             [{"hexpm", "ex_doc", "ex_doc", "0.1.0"}, {"hexpm", "fork", "postgrex", "0.2.1"}]
+             [
+               %{repo: "hexpm", name: "ex_doc", app: "ex_doc", version: "0.1.0"},
+               %{repo: "hexpm", name: "fork", app: "postgrex", version: "0.2.1"}
+             ]
   end
 
   test "from_lock/1 warns on newer lock versions" do
@@ -38,35 +41,5 @@ defmodule Hex.MixTest do
 
     Hex.Mix.from_lock(lock)
     refute_received ^message
-  end
-
-  test "flatten_deps/2 with only dependencies" do
-    ecto = %Mix.Dep{app: :ecto, deps: [], top_level: false}
-    postgrex = %Mix.Dep{app: :postgrex, deps: [], top_level: false}
-    ex_doc = %Mix.Dep{app: :ex_doc, deps: [], top_level: false, opts: [only: :doc]}
-    phoenix = %Mix.Dep{app: :phoenix, deps: [ecto, postgrex, ex_doc], top_level: true}
-
-    deps = [phoenix, ecto, postgrex]
-
-    flattened_deps = Hex.Mix.flatten_deps(deps, %{})
-    assert phoenix in flattened_deps
-    assert ecto in flattened_deps
-    assert postgrex in flattened_deps
-    refute ex_doc in flattened_deps
-  end
-
-  test "flatten_deps/2 with overridden dependencies" do
-    ecto = %Mix.Dep{app: :ecto, deps: [], top_level: false}
-    postgrex = %Mix.Dep{app: :postgrex, deps: [], top_level: false, opts: [override: true]}
-    overridden_postgrex = %Mix.Dep{app: :postgrex, deps: [], top_level: false}
-    phoenix = %Mix.Dep{app: :phoenix, deps: [ecto, overridden_postgrex], top_level: true}
-
-    deps = [ecto, postgrex, phoenix]
-
-    flattened_deps = Hex.Mix.flatten_deps(deps, %{"postgrex" => true})
-    assert phoenix in flattened_deps
-    assert ecto in flattened_deps
-    assert postgrex in flattened_deps
-    refute overridden_postgrex in flattened_deps
   end
 end

--- a/test/mix/tasks/hex.build_test.exs
+++ b/test/mix/tasks/hex.build_test.exs
@@ -341,23 +341,6 @@ defmodule Mix.Tasks.Hex.BuildTest do
     purge([ReleaseTooLongDescription.MixProject])
   end
 
-  test "error if package has unstable dependencies" do
-    Process.put(:hex_test_app_name, :build_unstable_deps)
-    Mix.Project.push(ReleasePreDeps.MixProject)
-
-    in_tmp(fn ->
-      Hex.State.put(:cache_home, tmp_path())
-
-      error_msg = "A stable package release cannot have a pre-release dependency"
-
-      assert_raise Mix.Error, error_msg, fn ->
-        Mix.Tasks.Hex.Build.run([])
-      end
-    end)
-  after
-    purge([ReleasePreDeps.MixProject])
-  end
-
   test "error if misspelled organization" do
     Process.put(:hex_test_app_name, :build_misspelled_organization)
     Mix.Project.push(ReleaseMisspelledOrganization.MixProject)

--- a/test/support/solver_helper.ex
+++ b/test/support/solver_helper.ex
@@ -33,7 +33,8 @@ defmodule HexTest.SolverHelper do
           name: to_string(package),
           constraint: Hex.Solver.parse_constraint!(requirement || ">= 0.0.0"),
           optional: false,
-          label: package
+          label: package,
+          dependencies: []
         }
 
       {package, requirement, opts} ->
@@ -46,7 +47,8 @@ defmodule HexTest.SolverHelper do
           name: to_string(package),
           constraint: Hex.Solver.parse_constraint!(requirement || ">= 0.0.0"),
           optional: optional,
-          label: app
+          label: app,
+          dependencies: []
         }
     end)
   end


### PR DESCRIPTION
Closes https://github.com/hexpm/hex/issues/972.

Before:
```
iex(1)> Mix.install([
...(1)>     {:phoenix, "~> 1.7.0"},
...(1)>     {:scrivener_html, github: "jaimeiniesta/scrivener_html", branch: "relax_phoenix_dep"},
...(1)> ])
* Getting scrivener_html (https://github.com/jaimeiniesta/scrivener_html.git - origin/relax_phoenix_dep)
remote: Enumerating objects: 831, done.
remote: Counting objects: 100% (6/6), done.
remote: Compressing objects: 100% (5/5), done.
remote: Total 831 (delta 2), reused 1 (delta 1), pack-reused 825
Resolving Hex dependencies...
Resolution completed in 0.021s
Because your app depends on phoenix empty which doesn't match any versions, version solving failed.
** (Mix.Error) Hex dependency resolution failed
```

After:
```
iex(1)> Mix.install([
...(1)>     {:phoenix, "~> 1.7.0"},
...(1)>     {:scrivener_html, github: "jaimeiniesta/scrivener_html", branch: "relax_phoenix_dep"},
...(1)> ])
* Updating scrivener_html (https://github.com/jaimeiniesta/scrivener_html.git - origin/relax_phoenix_dep)
Resolving Hex dependencies...
Resolution completed in 0.029s
Because every version of scrivener_html depends on phoenix >= 1.0.0 and < 1.7.0 and your app depends on phoenix ~> 1.7.0, no version of scrivener_html is allowed.
So, because your app depends on scrivener_html, version solving failed.
** (Mix.Error) Hex dependency resolution failed
```