### PR TITLE
Do not close registry server in post_converge

### DIFF
--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -17,7 +17,7 @@ defmodule Hex.RemoteConverger do
       Hex.State.put(:print_sponsored_tip, false)
     end
 
-    Registry.close()
+    Registry.persist()
   end
 
   def remote?(dep) do

--- a/test/support/hexpm.ex
+++ b/test/support/hexpm.ex
@@ -49,6 +49,7 @@ defmodule HexTest.Hexpm do
     check_hexpm()
     mix = hexpm_mix() |> List.to_string()
 
+    cmd(mix, ["deps.get"])
     cmd(mix, ["ecto.drop", "-r", "Hexpm.RepoBase", "--quiet"])
     cmd(mix, ["ecto.create", "-r", "Hexpm.RepoBase", "--quiet"])
     cmd(mix, ["ecto.load", "-r", "Hexpm.RepoBase", "--quiet"])


### PR DESCRIPTION
Mix may still need the registry in fetcher finalization steps so we shouldn't close it.