### PR TITLE
Improved Error Message (Issue #949)

### DIFF
--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -1,9 +1,7 @@
 defmodule Mix.Tasks.Hex.Publish do
-  require Logger
   use Mix.Task
   alias Mix.Tasks.Hex.Build
   alias Hex.API
-
 
   @shortdoc "Publishes a new package version"
 
@@ -155,6 +153,7 @@ defmodule Mix.Tasks.Hex.Publish do
             Hex.Shell.info("Publishing docs...")
             create_docs(build, organization, auth, opts)
             transfer_owner(build, owner, auth, opts)
+
           _ ->
             Mix.Tasks.Hex.set_exit_code(1)
         end


### PR DESCRIPTION
Hi hex maintainers,

This pull request is intended to added Issue #949 for hexpm/hex.

Basically, my changes to hex.publish under tasks directory make a call to hexpm's API to check whether a package with the same name exists and if so, create another matching condition which returns a more informative error in the format:
"Package with the name 'foobar' has already exists".

I have successfully tested the code with two identical packages with the only difference being the package name (jason vs new_jason)

However, I have not tested the code with packages publishing under an organization or repository. In which case, the code may simply return the standard error I think.

Regards,
Coreastreet (new to elixir)  
