### PR TITLE
Implement exit statuses

### DIFF
--- a/lib/hex/shell.ex
+++ b/lib/hex/shell.ex
@@ -1,6 +1,8 @@
 defmodule Hex.Shell do
   @moduledoc false
 
+  import Kernel, except: [exit: 1]
+
   def info(output) do
     validate_output!(output)
     Mix.shell().info(output)
@@ -14,6 +16,7 @@ defmodule Hex.Shell do
   def error(output) do
     validate_output!(output)
     Mix.shell().error(output)
+    exit(1)
   end
 
   def debug(output) do
@@ -123,5 +126,11 @@ defmodule Hex.Shell do
     def ansi_enabled?(), do: false
   else
     def ansi_enabled?(), do: IO.ANSI.enabled?()
+  end
+
+  if Mix.env() == :test do
+    def exit(_), do: :ok
+  else
+    def exit(reason), do: Kernel.exit(reason)
   end
 end


### PR DESCRIPTION
Thanks for merging 92b48e4279954aeae59a4eaa953e10de059a6e8e, however I just found another small thing we could improve. Currently the mix tasks included in hex do all exit with code `0`, even when an error occurred. This PR changes this to `1` which helps with scripts for example on GitHub CI.