### PR TITLE
Provide --sort flag sorting outdated results by status

### DIFF
--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -210,13 +210,19 @@ defmodule Mix.Tasks.Hex.Outdated do
   end
 
   defp maybe_sort_by(values, "status") do
+    status_order = %{
+      "Up-to-date" => 1,
+      "Update not possible" => 2,
+      "Update possible" => 3
+    }
+
     Enum.sort_by(values, fn [
-                              [_, _package],
+                              _package,
                               _lock,
-                              [_latest_color, _latest],
-                              status
+                              _latest,
+                              [_color, status]
                             ] ->
-      status
+      Map.get(status_order, status, 0)
     end)
   end
 

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -216,13 +216,8 @@ defmodule Mix.Tasks.Hex.Outdated do
       "Update possible" => 3
     }
 
-    Enum.sort_by(values, fn [
-                              _package,
-                              _lock,
-                              _latest,
-                              [_color, status]
-                            ] ->
-      Map.get(status_order, status, 0)
+    Enum.sort_by(values, fn [_package, _lock, _latest, [_color, status]] ->
+      Map.fetch!(status_order, status)
     end)
   end
 

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -44,11 +44,11 @@ defmodule Mix.Tasks.Hex.Outdated do
     * `--all` - shows all outdated packages, including children of packages defined in `mix.exs`
     * `--pre` - include pre-releases when checking for newer versions
     * `--within-requirements` - exit with non-zero code only if requirements specified in `mix.exs` is met.
-    * `--by-status` - sort results by their status
+    * `--sort <column>` - sort results by the given column. Currently supports `status`.
   """
   @behaviour Hex.Mix.TaskDescription
 
-  @switches [all: :boolean, pre: :boolean, within_requirements: :boolean, by_status: :boolean]
+  @switches [all: :boolean, pre: :boolean, within_requirements: :boolean, sort: :string]
 
   @impl true
   def run(args) do
@@ -170,14 +170,13 @@ defmodule Mix.Tasks.Hex.Outdated do
   defp all(lock, opts) do
     deps = Hex.Mix.top_level_deps()
     dep_names = if opts[:all], do: Map.keys(lock), else: Map.keys(deps)
-    sort_by_status? = if opts[:by_status], do: true, else: false
 
     versions =
       dep_names
       |> Enum.sort()
       |> get_versions(deps, lock, opts[:pre])
 
-    values = versions |> Enum.map(&format_all_row/1) |> maybe_sort_by_status(sort_by_status?)
+    values = versions |> Enum.map(&format_all_row/1) |> maybe_sort_by(opts[:sort])
 
     diff_links = Enum.map(versions, &build_diff_link/1) |> Enum.reject(&is_nil/1)
 
@@ -210,7 +209,7 @@ defmodule Mix.Tasks.Hex.Outdated do
     end
   end
 
-  defp maybe_sort_by_status(values, true) do
+  defp maybe_sort_by(values, "status") do
     Enum.sort_by(values, fn [
                               [_, _package],
                               _lock,
@@ -221,7 +220,7 @@ defmodule Mix.Tasks.Hex.Outdated do
     end)
   end
 
-  defp maybe_sort_by_status(values, false), do: values
+  defp maybe_sort_by(values, _), do: values
 
   defp get_versions(dep_names, deps, lock, pre?) do
     Enum.flat_map(dep_names, fn name ->

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -44,10 +44,11 @@ defmodule Mix.Tasks.Hex.Outdated do
     * `--all` - shows all outdated packages, including children of packages defined in `mix.exs`
     * `--pre` - include pre-releases when checking for newer versions
     * `--within-requirements` - exit with non-zero code only if requirements specified in `mix.exs` is met.
+    * `--by-status` - sort results by their status
   """
   @behaviour Hex.Mix.TaskDescription
 
-  @switches [all: :boolean, pre: :boolean, within_requirements: :boolean]
+  @switches [all: :boolean, pre: :boolean, within_requirements: :boolean, by_status: :boolean]
 
   @impl true
   def run(args) do
@@ -169,13 +170,15 @@ defmodule Mix.Tasks.Hex.Outdated do
   defp all(lock, opts) do
     deps = Hex.Mix.top_level_deps()
     dep_names = if opts[:all], do: Map.keys(lock), else: Map.keys(deps)
+    sort_by_status? = if opts[:by_status], do: true, else: false
 
     versions =
       dep_names
       |> Enum.sort()
       |> get_versions(deps, lock, opts[:pre])
 
-    values = Enum.map(versions, &format_all_row/1)
+    values = versions |> Enum.map(&format_all_row/1) |> maybe_sort_by_status(sort_by_status?)
+
     diff_links = Enum.map(versions, &build_diff_link/1) |> Enum.reject(&is_nil/1)
 
     if Enum.empty?(values) do
@@ -206,6 +209,19 @@ defmodule Mix.Tasks.Hex.Outdated do
       end
     end
   end
+
+  defp maybe_sort_by_status(values, true) do
+    Enum.sort_by(values, fn [
+                              [_, _package],
+                              _lock,
+                              [_latest_color, _latest],
+                              status
+                            ] ->
+      status
+    end)
+  end
+
+  defp maybe_sort_by_status(values, false), do: values
 
   defp get_versions(dep_names, deps, lock, pre?) do
     Enum.flat_map(dep_names, fn name ->

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -167,7 +167,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
       assert catch_throw(Mix.Task.run("hex.outdated", ["--all", "--sort", "status"])) ==
                {:exit_code, 1}
 
-      bar =
+      _bar =
         [
           [:bright, "bar", :reset],
           ["         ", "0.1.0", :reset],
@@ -178,7 +178,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
         |> IO.ANSI.format()
         |> List.to_string()
 
-      foo =
+      _foo =
         [
           [:bright, "foo", :reset],
           ["         ", "0.1.0", :reset],
@@ -189,7 +189,7 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
         |> IO.ANSI.format()
         |> List.to_string()
 
-      ex_doc =
+      _ex_doc =
         [
           [:bright, "ex_doc", :reset],
           ["      ", "0.0.1", :reset],

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -570,12 +570,10 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
   end
 
   defp extract_statuses(lines) do
-    Enum.reduce(lines, [], fn {_, _, [line]}, acc ->
-      case Regex.scan(~r/Up-to-date|Update not possible|Update possible/, line) do
-        [] -> acc
-        [[match]] -> [match | acc]
-      end
+    Enum.flat_map(lines, fn {_, _, [line]} ->
+      ~r/Up-to-date|Update not possible|Update possible/
+      |> Regex.scan(line)
+      |> List.flatten()
     end)
-    |> Enum.reverse()
   end
 end


### PR DESCRIPTION
This PR aims to add a new flag as discussed in https://github.com/hexpm/hex/issues/1005 to sort results by their status (whether an update can be performed or not).

The PR doesn't aim to provide a generic "sort by column" functionality, as the default sort is already by package name, and sorting by the other remaining fields (current or available version numbers) doesn't seem very useful.

At the time of writing, this PR is rather exploratory in nature and is seeking general feedback on direction. Does a primitive solution like this suffice here, or are there important things I'm missing here? 

Tests are currently also missing, as I wanted to verify the general idea first. In any case, the primitive case seems to work:

```
# With default sorting:

juha@local:~/projects/elixir/hourchestra$ mix hex.outdated
Dependency              Current   Latest    Status
ash                     2.19.5    2.19.12   Update possible
ash_phoenix             1.2.20    1.3.1     Update possible
benchee                 1.0.1     1.3.0     Update not possible
credo                   1.7.1     1.7.5     Update possible
gettext                 0.23.1    0.24.0    Update possible
gnuplot                 1.22.270  1.22.270  Up-to-date
jason                   1.4.1     1.4.1     Up-to-date
libgraph                0.16.0    0.16.0    Up-to-date
oban                    2.16.3    2.17.5    Update possible
phoenix                 1.7.9     1.7.11    Update possible
...

# With the new flag:

juha@local:~/projects/elixir/hourchestra$ mix hex.outdated --by-status
Dependency              Current   Latest    Status
gnuplot                 1.22.270  1.22.270  Up-to-date
jason                   1.4.1     1.4.1     Up-to-date
libgraph                0.16.0    0.16.0    Up-to-date
solverl                 1.0.16    1.0.16    Up-to-date
benchee                 1.0.1     1.3.0     Update not possible
phoenix_html            3.3.3     4.0.0     Update not possible
ash                     2.19.5    2.19.12   Update possible
ash_phoenix             1.2.20    1.3.1     Update possible
ash_postgres            1.3.56    1.5.14    Update possible
gettext                 0.23.1    0.24.0    Update possible
oban                    2.16.3    2.17.5    Update possible
...
```

Thanks for taking the time! 🙂 