### PR TITLE
Handle empty package name in mix hex.info

### DIFF
--- a/lib/hex/api/package.ex
+++ b/lib/hex/api/package.ex
@@ -3,7 +3,7 @@ defmodule Hex.API.Package do
 
   alias Hex.API
 
-  def get(repo, name, auth \\ []) do
+  def get(repo, name, auth \\ []) when name != "" do
     path = "packages/#{URI.encode(name)}"
     API.request(:get, repo, path, auth)
   end
@@ -16,7 +16,7 @@ defmodule Hex.API.Package do
   defmodule Owner do
     @moduledoc false
 
-    def add(repo, package, owner, level, transfer, auth) do
+    def add(repo, package, owner, level, transfer, auth) when package != "" do
       Hex.API.check_write_api()
 
       owner = URI.encode_www_form(owner)
@@ -25,7 +25,7 @@ defmodule Hex.API.Package do
       API.erlang_put_request(repo, path, params, auth)
     end
 
-    def delete(repo, package, owner, auth) do
+    def delete(repo, package, owner, auth) when package != "" do
       Hex.API.check_write_api()
 
       owner = URI.encode_www_form(owner)
@@ -33,7 +33,7 @@ defmodule Hex.API.Package do
       API.request(:delete, repo, path, auth)
     end
 
-    def get(repo, package, auth) do
+    def get(repo, package, auth) when package != "" do
       API.request(:get, repo, "packages/#{URI.encode(package)}/owners", auth)
     end
   end

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -68,6 +68,11 @@ defmodule Mix.Tasks.Hex.Info do
     Hex.Registry.Server.close()
   end
 
+  defp package(_organization, "") do
+    Hex.Shell.error("Package name is empty")
+    Mix.Tasks.Hex.set_exit_code(1)
+  end
+
   defp package(organization, package) do
     auth = organization && Mix.Tasks.Hex.auth_info(:read)
 

--- a/test/mix/tasks/hex.info_test.exs
+++ b/test/mix/tasks/hex.info_test.exs
@@ -21,6 +21,9 @@ defmodule Mix.Tasks.Hex.InfoTest do
 
     assert catch_throw(Mix.Tasks.Hex.Info.run(["no_package"])) == {:exit_code, 1}
     assert_received {:mix_shell, :error, ["No package with name no_package"]}
+
+    assert catch_throw(Mix.Tasks.Hex.Info.run([""])) == {:exit_code, 1}
+    assert_received {:mix_shell, :error, ["Package name is empty"]}
   end
 
   test "locked package" do


### PR DESCRIPTION
Currently, it fails as follows:

```sh
$ mix hex.info ""
** (ArgumentError) the Access module supports only keyword lists (with atom keys), got: "meta"

If you want to search lists of tuples, use List.keyfind/3
    (elixir 1.16.2) lib/access.ex:345: Access.get/3
    (hex 2.0.6) lib/mix/tasks/hex.info.ex:108: Mix.Tasks.Hex.Info.print_package/2
```

This is because we call GET packages/ on hexpm which returns a list of objects.

The second commit adds some guards on the API layer to calling the wrong URLs in the first place.

Note: While the `mix hex.info ""` command might not make sense as user input, it might happen when scripting.