### PR TITLE
Valid licenses for hexpm integration tests

### DIFF
--- a/test/setup_hexpm.exs
+++ b/test/setup_hexpm.exs
@@ -4,7 +4,7 @@ Hexpm.init()
 Hexpm.start()
 
 pkg_meta = %{
-  "licenses" => ["GPL2", "MIT", "Apache"],
+  "licenses" => ["GPL-2.0", "MIT", "Apache-2.0"],
   "links" => %{"docs" => "http://docs", "repo" => "http://repo"},
   "description" => "Some description"
 }


### PR DESCRIPTION
…nto older hex versions for the hexpm matrix to pass

![image](https://github.com/hexpm/hex/assets/773380/6c6306a2-3851-4326-b5fd-e9178e7b520d)
