### PR TITLE
Make the description in README match the ones at other places

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/hexpm/hex/workflows/CI/badge.svg)](https://github.com/hexpm/hex/actions)
 
-Hex is package manager for the Erlang VM.
+Hex is a package manager for the Erlang ecosystem.
 
 This project currently provides tasks that integrate with Mix, [Elixir](https://github.com/elixir-lang/elixir)'s build tool.
 


### PR DESCRIPTION
* https://hex.pm/ is using the description:
```
The package manager for the Erlang ecosystem
```

* `mix hex` outputs:
```
Hex is a package manager for the Erlang ecosystem.
```

So, maybe we should replace `Erlang VM` with `Erlang ecosystem`, which is a more appropriate term.