### PR TITLE
Add help when docs download times out

### DIFF
--- a/lib/mix/tasks/hex.docs.ex
+++ b/lib/mix/tasks/hex.docs.ex
@@ -364,6 +364,17 @@ defmodule Mix.Tasks.Hex.Docs do
         File.write!(target, body)
         true
 
+      {:error, :timeout} ->
+        message = """
+        Timed out trying to download docs. Try changing your timeout settings:
+
+            HEX_HTTP_TIMEOUT=120 mix hex.docs fetch #{package} #{version}
+        """
+
+        Hex.Shell.error(message)
+
+        false
+
       _ ->
         message = "Couldn't find docs for package with name #{package} or version #{version}"
         Hex.Shell.error(message)


### PR DESCRIPTION
Before this commit, if there was a timeout when download docs, an error
like this was printed:

```
$ mix hex.docs fetch elixir
Couldn't find docs for package with name elixir or version 1.18.0
```

With this commit, the error looks like this and the suggestion helped
me, at least:

```
$ mix hex.docs fetch elixir
Timed out trying to download docs. Try changing your timeout settings:

    HEX_HTTP_TIMEOUT=120 mix hex.docs fetch elixir 1.18.0

$ HEX_HTTP_TIMEOUT=120 mix hex.docs fetch elixir 1.18.0
Docs fetched: /Users/fhunleth/.hex/docs/hexpm/elixir/1.18.0
```
