### PR TITLE
Support :warn_if_outdated in deps

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,7 +71,7 @@ jobs:
 
     env:
       HEXPM_OTP: OTP-27.2
-      HEXPM_ELIXIR: v1.17.3
+      HEXPM_ELIXIR: v1.18.1
       HEXPM_PATH: hexpm
       HEXPM_ELIXIR_PATH: hexpm_elixir
       HEXPM_OTP_PATH: hexpm_otp

--- a/lib/hex/mix.ex
+++ b/lib/hex/mix.ex
@@ -60,7 +60,8 @@ defmodule Hex.Mix do
             requirement: dep.requirement,
             app: Atom.to_string(dep.app),
             from: Path.relative_to_cwd(dep.from),
-            dependencies: []
+            dependencies: [],
+            warn_if_outdated: dep.opts[:warn_if_outdated]
           }
         ]
       else

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -147,7 +147,7 @@ defmodule Hex.RemoteConverger do
 
     deps_to_warn =
       for %{repo: repo, name: name, requirement: requirement, warn_if_outdated: true} <- requests do
-        requirement = Version.parse_requirement!(requirement)
+        {:ok, requirement} = Version.parse_requirement(requirement)
         {:ok, versions} = Registry.versions(repo, name)
 
         latest_version =

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -161,8 +161,7 @@ defmodule Hex.RemoteConverger do
              :gt <- Version.compare(latest_version, version) do
           {name, latest_version}
         else
-          other ->
-            dbg(other)
+          _ ->
             nil
         end
       end

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -156,10 +156,14 @@ defmodule Hex.RemoteConverger do
           |> Enum.sort(&(Version.compare(&1, &2) == :gt))
 
         with [latest_version | _] <- versions,
-             {:hex, _name, version, _checksum, _managers, _, ^repo, _checksum} <-
+             {:hex, _name, version, _checksum1, _managers, _, ^repo, _checksum2} <-
                Map.fetch!(new_lock, String.to_atom(name)),
              :gt <- Version.compare(latest_version, version) do
           {name, latest_version}
+        else
+          other ->
+            dbg(other)
+            nil
         end
       end
       |> Enum.filter(& &1)

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -150,11 +150,12 @@ defmodule Hex.RemoteConverger do
         {:ok, requirement} = Version.parse_requirement(requirement)
         {:ok, versions} = Registry.versions(repo, name)
 
-        latest_version =
+        versions =
           versions
           |> Enum.filter(&Version.match?(&1, requirement))
           |> Enum.sort(&(Version.compare(&1, &2) == :gt))
-          |> List.first()
+
+        latest_version = Enum.find(versions, &(&1.pre == [])) || List.first(versions)
 
         {:hex, _name, version, _chhecksum, _managers, _, ^repo, _checksum} =
           Map.fetch!(new_lock, String.to_atom(name))

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -153,7 +153,7 @@ defmodule Hex.RemoteConverger do
         latest_version =
           versions
           |> Enum.filter(&Version.match?(&1, requirement))
-          |> Enum.sort({:desc, Version})
+          |> Enum.sort(&(Version.compare(&1, &2) == :gt))
           |> List.first()
 
         {:hex, _name, version, _chhecksum, _managers, _, ^repo, _checksum} =

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -169,7 +169,7 @@ defmodule Hex.RemoteConverger do
     if deps_to_warn != [] do
       IO.warn(
         [
-          "the following deps set `warn_if_outdated: true` and are outdated:\n\n",
+          "the following deps are outdated and set \"warn_if_outdated: true\":\n\n",
           Enum.map_join(deps_to_warn, "\n", fn {name, version} ->
             " * #{name} #{version} is available"
           end)

--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -120,7 +120,7 @@ defmodule Hex.SCM do
   mix_keys = ~w[app env compile optional only targets override manager runtime system_env]a
 
   # https://hex.pm/docs/usage#options
-  hex_keys = ~w[hex repo organization]a
+  hex_keys = ~w[hex repo organization warn_if_outdated]a
 
   internal_keys = ~w[dest lock build]a
 
@@ -136,6 +136,7 @@ defmodule Hex.SCM do
     path = cache_path(repo, name, lock.version)
 
     unknown_options = Keyword.keys(opts) -- @allowed_keys
+    dbg(unknown_options)
 
     if unknown_options != [] do
       Hex.Shell.warn(

--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -136,7 +136,6 @@ defmodule Hex.SCM do
     path = cache_path(repo, name, lock.version)
 
     unknown_options = Keyword.keys(opts) -- @allowed_keys
-    dbg(unknown_options)
 
     if unknown_options != [] do
       Hex.Shell.warn(

--- a/test/hex/remote_converger_test.exs
+++ b/test/hex/remote_converger_test.exs
@@ -1,0 +1,50 @@
+defmodule Hex.RemoteConvergetTest do
+  use HexTest.IntegrationCase
+
+  defmodule OutdatedDepsBefore.MixProject do
+    def project do
+      [
+        app: :outdated_deps,
+        version: "0.1.0",
+        deps: [
+          {:postgrex, "0.2.1"},
+          {:ecto, "3.3.1"},
+          {:ecto_sql, "3.3.2"}
+        ]
+      ]
+    end
+  end
+
+  defmodule OutdatedDepsAfter.MixProject do
+    def project do
+      [
+        app: :outdated_deps,
+        version: "0.1.0",
+        deps: [
+          {:postgrex, ">= 0.0.0", warn_if_outdated: true},
+          {:ecto, ">= 0.0.0", warn_if_outdated: true},
+          {:ecto_sql, ">= 0.0.0", warn_if_outdated: true}
+        ]
+      ]
+    end
+  end
+
+  test "deps with warn_if_outdated: true" do
+    in_tmp(fn ->
+      Mix.Project.push(OutdatedDepsBefore.MixProject)
+      :ok = Mix.Tasks.Deps.Get.run([])
+
+      Mix.Project.pop()
+      Mix.Project.push(OutdatedDepsAfter.MixProject)
+
+      output =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          :ok = Mix.Tasks.Deps.Get.run([])
+        end)
+
+      assert output =~ "ecto 3.3.2 is available"
+      assert output =~ "ecto_sql 3.3.3 is available"
+      refute output =~ "postgrex"
+    end)
+  end
+end

--- a/test/hex/remote_converger_test.exs
+++ b/test/hex/remote_converger_test.exs
@@ -7,9 +7,9 @@ defmodule Hex.RemoteConvergetTest do
         app: :outdated_deps,
         version: "0.1.0",
         deps: [
-          {:postgrex, "0.2.1"},
-          {:ecto, "3.3.1"},
-          {:ecto_sql, "3.3.2"}
+          {:postgrex, "0.2.1", warn_if_outdated: true},
+          {:ecto, "3.3.1", warn_if_outdated: true},
+          {:ecto_sql, "3.3.2", warn_if_outdated: true}
         ]
       ]
     end


### PR DESCRIPTION
Example:

    $ mix deps.get
    Resolving Hex dependencies...
    Resolution completed in 0.0s
    Unchanged:
      ecto 3.3.1
      ecto_sql 3.3.2
      ex_doc 0.1.0
      postgrex 0.2.1
    warning: the following deps set `warn_if_outdated: true` and are outdated:

     * ecto 3.3.2 is available
     * ecto_sql 3.3.3 is available
