### PR TITLE
Fix Elixir versions order in publish script

### DIFF
--- a/scripts/release_hex.sh
+++ b/scripts/release_hex.sh
@@ -26,15 +26,17 @@ function main {
   touch "${hex_csv}"
   sed -i.bak "/^${hex_version},/d" "${hex_csv}"
 
-  # UPDATE THIS FOR EVERY RELEASE
+  # UPDATE THIS FOR EVERY RELEASE, ORDER MATTERS
 
-  build ${hex_version} 25.3.2.16 1.18.0 1.18.0 noble-20241015 # need to use exactly 1.18.0 and that requires older otp & ubuntu
-  build ${hex_version} 26.2.5.6  1.18.0 1.18.0 noble-20241015 # ditto
-  build ${hex_version} 27.2      1.18.0 1.18.0 noble-20241015 # ditto
-
+  # Elixir v1.17
   build ${hex_version} 25.3.2.20 1.17.3 1.17.0 noble-20250404
   build ${hex_version} 26.2.5.11 1.17.3 1.17.0 noble-20250404
   build ${hex_version} 27.3.3    1.17.3 1.17.0 noble-20250404
+
+  # Elixir v1.18
+  build ${hex_version} 25.3.2.16 1.18.0 1.18.0 noble-20241015 # need to use exactly 1.18.0 and that requires older otp & ubuntu
+  build ${hex_version} 26.2.5.6  1.18.0 1.18.0 noble-20241015 # ditto
+  build ${hex_version} 27.2      1.18.0 1.18.0 noble-20241015 # ditto
 
   rm -rf _build
   rm "${hex_csv}.bak"


### PR DESCRIPTION
Before this patch, `mix local.hex` would pick Hex precompiled against oldest Elixir version:

```
HEX_BUILDS_URL=http://localhost:8000 mix local.hex --force && mix hex.info
* creating .mix/archives/hex-2.2.1-otp-26
Hex:    2.2.2-dev
Elixir: 1.19.0-dev
OTP:    26.2.5.11

Built with: Elixir 1.17.3 and OTP 26.2.5.11
```

now it will pick the newest:

```
HEX_BUILDS_URL=http://localhost:8000 mix local.hex --force && mix hex.info
* creating .mix/archives/hex-2.2.1-otp-26
Hex:    2.2.2-dev
Elixir: 1.19.0-dev
OTP:    26.2.5.11

Built with: Elixir 1.18.0 and OTP 26.2.5.6
```

In other words, the new hex.csv now matches the order of legacy hex-1.x.csv.