### PR TITLE
Improve deps.get error messages for 404 and 403 status codes

### DIFF
--- a/lib/hex/registry/server.ex
+++ b/lib/hex/registry/server.ex
@@ -440,7 +440,8 @@ defmodule Hex.Registry.Server do
     end
   end
 
-  defp print_missing_package_diagnostics(repo, package, result) do
+  @doc false
+  def print_missing_package_diagnostics(repo, package, result) do
     {:ok, {status, _headers, _body}} = result
     package_name = Hex.Utils.package_name(repo, package)
 

--- a/lib/hex/registry/server.ex
+++ b/lib/hex/registry/server.ex
@@ -410,10 +410,7 @@ defmodule Hex.Registry.Server do
     )
 
     if missing_status?(result) do
-      Hex.Shell.error(
-        "This could be because the package does not exist, it was spelled " <>
-          "incorrectly or you don't have permissions to it"
-      )
+      print_missing_package_diagnostics(repo, package, result)
     end
 
     if not missing_status?(result) or Mix.debug?() do
@@ -439,6 +436,22 @@ defmodule Hex.Registry.Server do
         _other ->
           Hex.Utils.print_error_result(result)
       end
+    end
+  end
+
+  defp print_missing_package_diagnostics(repo, package, result) do
+    {:ok, {status, _headers, _body}} = result
+    package_name = Hex.Utils.package_name(repo, package)
+
+    cond do
+      # Package does not exist
+      status == 404 ->
+        Hex.Shell.error(
+          "The package #{package_name} does not exist. Please verify the package name is spelled correctly"
+        )
+
+      true ->
+        Hex.Shell.error("This could be because you don't have permissions to it")
     end
   end
 

--- a/lib/hex/registry/server.ex
+++ b/lib/hex/registry/server.ex
@@ -453,28 +453,27 @@ defmodule Hex.Registry.Server do
 
       # Permission issue
       status == 403 ->
-        print_permission_error(package_name)
+        auth_status = if has_authentication?(), do: :authenticated, else: :unauthenticated
+        print_permission_error(package_name, auth_status)
 
       true ->
         Hex.Shell.error("Error encounted fetching registry entry for #{package_name}")
     end
   end
 
-  defp print_permission_error(package_name) do
-    has_auth = has_authentication?()
+  defp print_permission_error(package_name, :authenticated) do
+    Hex.Shell.error(
+      "You don't have permission to access #{package_name}. This could be because the package is private " <>
+        "and you don't have the required permissions. Contact the package owner to request access, or " <>
+        "check your permissions at: #{@dashboard_url}"
+    )
+  end
 
-    if has_auth do
-      Hex.Shell.error(
-        "You don't have permission to access #{package_name}. This could be because the package is private " <>
-          "and you don't have the required permissions. Contact the package owner to request access, or " <>
-          "check your permissions at: #{@dashboard_url}"
-      )
-    else
-      Hex.Shell.error(
-        "You don't have permission to access #{package_name}. This could be because the package is private " <>
-          "and requires authentication: run 'mix hex.user auth' to authenticate."
-      )
-    end
+  defp print_permission_error(package_name, :unauthenticated) do
+    Hex.Shell.error(
+      "You don't have permission to access #{package_name}. This could be because the package is private " <>
+        "and requires authentication: run 'mix hex.user auth' to authenticate."
+    )
   end
 
   defp has_authentication? do

--- a/lib/hex/registry/server.ex
+++ b/lib/hex/registry/server.ex
@@ -473,7 +473,7 @@ defmodule Hex.Registry.Server do
   defp print_permission_error(package_name, :unauthenticated) do
     Hex.Shell.error(
       "You don't have permission to access #{package_name}. This could be because the package is private " <>
-        "and requires authentication: run 'mix hex.user auth' to authenticate."
+        "and requires authentication, run 'mix hex.user auth' to authenticate."
     )
   end
 

--- a/test/hex/registry/error_message_test.exs
+++ b/test/hex/registry/error_message_test.exs
@@ -9,11 +9,6 @@ defmodule Hex.Registry.ErrorMessageTest do
         url: "https://repo.hex.pm",
         public_key: nil,
         auth_key: nil
-      },
-      "hexpm:acme" => %{
-        url: "https://repo.hex.pm/repos/acme",
-        public_key: nil,
-        auth_key: nil
       }
     })
 
@@ -32,16 +27,6 @@ defmodule Hex.Registry.ErrorMessageTest do
 
       assert_received {:mix_shell, :error, [msg]}
       assert msg =~ "The package nonexistent_package does not exist"
-      assert msg =~ "Please verify the package name is spelled correctly"
-    end
-
-    test "displays helpful message with different package name" do
-      result = {:ok, {404, [], %{}}}
-
-      Hex.Registry.Server.print_missing_package_diagnostics("hexpm", "typo_package", result)
-
-      assert_received {:mix_shell, :error, [msg]}
-      assert msg =~ "The package typo_package does not exist"
       assert msg =~ "Please verify the package name is spelled correctly"
     end
   end

--- a/test/hex/registry/error_message_test.exs
+++ b/test/hex/registry/error_message_test.exs
@@ -1,0 +1,146 @@
+defmodule Hex.Registry.ErrorMessageTest do
+  use HexTest.Case
+
+  setup do
+    Application.ensure_all_started(:hex)
+
+    Hex.State.put(:repos, %{
+      "hexpm" => %{
+        url: "https://repo.hex.pm",
+        public_key: nil,
+        auth_key: nil
+      },
+      "hexpm:acme" => %{
+        url: "https://repo.hex.pm/repos/acme",
+        public_key: nil,
+        auth_key: nil
+      }
+    })
+
+    :ok
+  end
+
+  describe "404 errors (package not found)" do
+    test "displays helpful message for non-existent package" do
+      result = {:ok, {404, [], %{}}}
+      send_error_message(result, "hexpm", "nonexistent_package", false)
+
+      output = get_shell_output()
+
+      assert output =~ "Failed to fetch record for nonexistent_package from registry"
+      assert output =~ "The package nonexistent_package does not exist"
+      assert output =~ "Please verify the package name is spelled correctly"
+    end
+
+    test "displays helpful message for non-existent package with cache" do
+      package_name = "typo_package"
+
+      result = {:ok, {404, [], %{}}}
+      send_error_message(result, "hexpm", package_name, true)
+
+      output = get_shell_output()
+
+      assert output =~
+               "Failed to fetch record for #{package_name} from registry (using cache instead)"
+
+      # Still shows detailed diagnostics to help user understand the issue
+      assert output =~ "The package #{package_name} does not exist"
+      assert output =~ "Please verify the package name is spelled correctly"
+    end
+  end
+
+  describe "403 errors (permission denied) - unauthenticated" do
+    setup do
+      # Clear any authentication
+      Hex.State.put(:oauth_token, nil)
+      Hex.State.put(:repos_key, nil)
+      Hex.State.put(:api_key, nil)
+      :ok
+    end
+
+    test "displays auth prompt for private package" do
+      package_name = "private_package"
+      result = {:ok, {403, [], %{}}}
+
+      Hex.Registry.Server.print_missing_package_diagnostics(
+        "hexpm",
+        package_name,
+        result
+      )
+
+      output = get_shell_output()
+
+      assert output =~ "You don't have permission to access #{package_name}"
+      assert output =~ "the package is private and requires authentication"
+      assert output =~ "run 'mix hex.user auth' to authenticate"
+    end
+  end
+
+  describe "403 errors (permission denied) - authenticated" do
+    setup do
+      # Simulate authenticated user with OAuth token
+      token_data = %{
+        "access_token" => "test_token",
+        "refresh_token" => "refresh_token",
+        "expires_at" => System.system_time(:second) + 3600
+      }
+
+      Hex.State.put(:oauth_token, token_data)
+      :ok
+    end
+
+    test "displays permission diagnostics for private package" do
+      package_name = "private_package"
+      result = {:ok, {403, [], %{}}}
+
+      Hex.Registry.Server.print_missing_package_diagnostics(
+        "hexpm",
+        package_name,
+        result
+      )
+
+      output = get_shell_output()
+
+      assert output =~ "You don't have permission to access #{package_name}"
+      assert output =~ "the package is private and you don't have the required permissions"
+      assert output =~ "Contact the package owner to request access"
+      assert output =~ "https://hex.pm/dashboard"
+    end
+  end
+
+  defp send_error_message(result, repo, package, cached?) do
+    package_name = Hex.Utils.package_name(repo, package)
+    cached_message = if cached?, do: " (using cache instead)", else: ""
+
+    Hex.Shell.error("Failed to fetch record for #{package_name} from registry#{cached_message}")
+    Hex.Registry.Server.print_missing_package_diagnostics(repo, package, result)
+  end
+
+  defp get_shell_output do
+    # Use flush to collect all shell messages
+    ref = make_ref()
+
+    Hex.Shell.Process.flush(fn
+      {:mix_shell, _, [msg]} ->
+        send(self(), {:collected, ref, msg})
+
+      _ ->
+        :ok
+    end)
+
+    # Now collect all the messages we sent back to ourselves
+    collect_messages(ref, [])
+  end
+
+  defp collect_messages(ref, acc) do
+    receive do
+      {:collected, ^ref, msg} ->
+        collect_messages(ref, [msg | acc])
+    after
+      0 ->
+        acc
+        |> Enum.reverse()
+        |> Enum.join("\n")
+    end
+  end
+end

--- a/test/hex/registry/error_message_test.exs
+++ b/test/hex/registry/error_message_test.exs
@@ -25,11 +25,12 @@ defmodule Hex.Registry.ErrorMessageTest do
       result = {:ok, {404, [], %{}}}
       send_error_message(result, "hexpm", "nonexistent_package", false)
 
-      output = get_shell_output()
+      assert_received {:mix_shell, :error, [msg]}
+      assert msg =~ "Failed to fetch record for nonexistent_package from registry"
 
-      assert output =~ "Failed to fetch record for nonexistent_package from registry"
-      assert output =~ "The package nonexistent_package does not exist"
-      assert output =~ "Please verify the package name is spelled correctly"
+      assert_received {:mix_shell, :error, [msg]}
+      assert msg =~ "The package nonexistent_package does not exist"
+      assert msg =~ "Please verify the package name is spelled correctly"
     end
 
     test "displays helpful message for non-existent package with cache" do
@@ -38,14 +39,15 @@ defmodule Hex.Registry.ErrorMessageTest do
       result = {:ok, {404, [], %{}}}
       send_error_message(result, "hexpm", package_name, true)
 
-      output = get_shell_output()
+      assert_received {:mix_shell, :error, [msg]}
 
-      assert output =~
+      assert msg =~
                "Failed to fetch record for #{package_name} from registry (using cache instead)"
 
       # Still shows detailed diagnostics to help user understand the issue
-      assert output =~ "The package #{package_name} does not exist"
-      assert output =~ "Please verify the package name is spelled correctly"
+      assert_received {:mix_shell, :error, [msg]}
+      assert msg =~ "The package #{package_name} does not exist"
+      assert msg =~ "Please verify the package name is spelled correctly"
     end
   end
 
@@ -68,11 +70,10 @@ defmodule Hex.Registry.ErrorMessageTest do
         result
       )
 
-      output = get_shell_output()
-
-      assert output =~ "You don't have permission to access #{package_name}"
-      assert output =~ "the package is private and requires authentication"
-      assert output =~ "run 'mix hex.user auth' to authenticate"
+      assert_received {:mix_shell, :error, [msg]}
+      assert msg =~ "You don't have permission to access #{package_name}"
+      assert msg =~ "the package is private and requires authentication"
+      assert msg =~ "run 'mix hex.user auth' to authenticate"
     end
   end
 
@@ -99,12 +100,11 @@ defmodule Hex.Registry.ErrorMessageTest do
         result
       )
 
-      output = get_shell_output()
-
-      assert output =~ "You don't have permission to access #{package_name}"
-      assert output =~ "the package is private and you don't have the required permissions"
-      assert output =~ "Contact the package owner to request access"
-      assert output =~ "https://hex.pm/dashboard"
+      assert_received {:mix_shell, :error, [msg]}
+      assert msg =~ "You don't have permission to access #{package_name}"
+      assert msg =~ "the package is private and you don't have the required permissions"
+      assert msg =~ "Contact the package owner to request access"
+      assert msg =~ "https://hex.pm/dashboard"
     end
   end
 
@@ -114,33 +114,5 @@ defmodule Hex.Registry.ErrorMessageTest do
 
     Hex.Shell.error("Failed to fetch record for #{package_name} from registry#{cached_message}")
     Hex.Registry.Server.print_missing_package_diagnostics(repo, package, result)
-  end
-
-  defp get_shell_output do
-    # Use flush to collect all shell messages
-    ref = make_ref()
-
-    Hex.Shell.Process.flush(fn
-      {:mix_shell, _, [msg]} ->
-        send(self(), {:collected, ref, msg})
-
-      _ ->
-        :ok
-    end)
-
-    # Now collect all the messages we sent back to ourselves
-    collect_messages(ref, [])
-  end
-
-  defp collect_messages(ref, acc) do
-    receive do
-      {:collected, ^ref, msg} ->
-        collect_messages(ref, [msg | acc])
-    after
-      0 ->
-        acc
-        |> Enum.reverse()
-        |> Enum.join("\n")
-    end
   end
 end


### PR DESCRIPTION
Improve error messages for certain scenarios described in: https://github.com/hexpm/hex/issues/627

Please let me know if there's any suggestions to adjust the error message text, or if the print logic should be moved to a separate module with a public interface instead of using the `@doc false` syntax to facilitate testing.