### PR TITLE
mix hex.search: Add --print-url flag

### DIFF
--- a/lib/mix/tasks/hex.search.ex
+++ b/lib/mix/tasks/hex.search.ex
@@ -28,12 +28,12 @@ defmodule Mix.Tasks.Hex.Search do
   ### Options
 
     * `--organization ORGANIZATION` - Set this for private packages belonging to an organization
-    * `--output` - Output the docs URL instead of opening it in the browser
+    * `--print-url` - Print the docs URL instead of opening it in the browser
 
   """
   @behaviour Hex.Mix.TaskDescription
 
-  @switches [organization: :string, package: :string, stdlib: :boolean, output: :boolean]
+  @switches [organization: :string, package: :string, stdlib: :boolean, print_url: :boolean]
 
   @impl true
   def run(args) do
@@ -97,7 +97,7 @@ defmodule Mix.Tasks.Hex.Search do
 
     url = "https://hexdocs.pm/?packages=#{packages}&q="
 
-    if opts[:output] do
+    if opts[:print_url] do
       Hex.Shell.info(url)
     else
       Hex.Utils.system_open(url)

--- a/test/mix/tasks/hex.search_test.exs
+++ b/test/mix/tasks/hex.search_test.exs
@@ -46,12 +46,12 @@ defmodule Mix.Tasks.Hex.SearchTest do
       end)
     end
 
-    test "--output" do
+    test "--print-url" do
       Mix.Project.push(SearchDeps.MixProject)
 
       in_tmp(fn ->
         write_search_deps()
-        Mix.Tasks.Hex.Search.run(["--output"])
+        Mix.Tasks.Hex.Search.run(["--print-url"])
         assert_received {:mix_shell, :info, ["https://hexdocs.pm/?packages=" <> packages]}
 
         vsn = System.version()


### PR DESCRIPTION
This will enabls LLMs to get the URL for package docs.