### PR TITLE
Use safe_binary_to_term! for parsing package manifests

### DIFF
--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -2,6 +2,8 @@ defmodule Hex.SCM do
   alias Hex.Registry.Server, as: Registry
   @moduledoc false
 
+  import Hex.Utils, only: [safe_binary_to_term!: 1]
+
   @behaviour Mix.SCM
   @packages_dir "packages"
   @request_timeout 60_000
@@ -296,7 +298,7 @@ defmodule Hex.SCM do
   defp ensure_lock(lock, _opts), do: lock
 
   def parse_manifest(file) do
-    case :erlang.binary_to_term(file) do
+    case safe_binary_to_term!(file) do
       {{:hex, 1, _}, map} -> {:ok, add_outer_checksum(map)}
       {{:hex, 2, _}, map} -> {:ok, map}
       _other -> :error


### PR DESCRIPTION
Replace `:erlang.binary_to_term` with `safe_binary_to_term!` when parsing hex package manifests to restrict deserialization to safe terms only.

Since hex already assumes trust in downloaded dependencies (they can execute arbitrary code during compilation), this is not a security vulnerability. However, using safe deserialization is a best practice that limits potential attack surface.