### PR TITLE
Improve authentication error handling for package fetching

### DIFF
--- a/lib/hex/oauth.ex
+++ b/lib/hex/oauth.ex
@@ -57,32 +57,28 @@ defmodule Hex.OAuth do
         store_token(new_token_data)
         {:ok, new_token_data["access_token"]}
 
-      {:error, :refresh_failed} = error ->
+      {:error, :refresh_failed} ->
         if Keyword.get(opts, :prompt_auth, false) do
-          prompt_and_authenticate("Token refresh failed. Please re-authenticate.")
+          reauthenticate("Token refresh failed. Re-authenticating...")
         else
-          error
+          {:error, :refresh_failed}
         end
 
-      {:error, :no_refresh_token} = error ->
+      {:error, :no_refresh_token} ->
         if Keyword.get(opts, :prompt_auth, false) do
-          prompt_and_authenticate(
-            "Access token expired and could not be refreshed. Please re-authenticate."
-          )
+          reauthenticate("Access token expired and could not be refreshed. Re-authenticating...")
         else
-          error
+          {:error, :no_refresh_token}
         end
     end
   end
 
-  defp prompt_and_authenticate(message) do
+  defp reauthenticate(message) do
     Hex.Shell.info(message)
 
-    if Hex.Shell.yes?("No authenticated user found. Do you want to authenticate now?") do
+    if Hex.Shell.yes?("Do you want to authenticate now?") do
       case Mix.Tasks.Hex.auth() do
         {:ok, token_data} ->
-          # Store the new token (auth() already did this, but be explicit)
-          # Return the access token
           {:ok, token_data["access_token"]}
 
         :error ->

--- a/lib/hex/registry/server.ex
+++ b/lib/hex/registry/server.ex
@@ -409,14 +409,18 @@ defmodule Hex.Registry.Server do
       "Failed to fetch record for #{Hex.Utils.package_name(repo, package)} from registry#{cached_message}"
     )
 
-    if missing_status?(result) do
+    if missing_or_unauthorized_status?(result) do
       Hex.Shell.error(
         "This could be because the package does not exist, it was spelled " <>
           "incorrectly or you don't have permissions to it"
       )
+
+      if unauthorized_status?(result) and not Hex.OAuth.has_tokens?() do
+        Hex.Shell.error("No authenticated user found. Run `mix hex.user auth` to authenticate")
+      end
     end
 
-    if not missing_status?(result) or Mix.debug?() do
+    if not missing_or_unauthorized_status?(result) or Mix.debug?() do
       case result do
         {:error, :bad_signature} ->
           Hex.Shell.error(
@@ -442,8 +446,11 @@ defmodule Hex.Registry.Server do
     end
   end
 
-  defp missing_status?({:ok, {status, _, _}}), do: status in [403, 404]
-  defp missing_status?(_), do: false
+  defp missing_or_unauthorized_status?({:ok, {status, _, _}}), do: status in [401, 403, 404]
+  defp missing_or_unauthorized_status?(_), do: false
+
+  defp unauthorized_status?({:ok, {status, _, _}}), do: status in [401, 403]
+  defp unauthorized_status?(_), do: false
 
   defp public_key_message("hexpm:" <> _), do: "on our public keys page: #{@public_keys_html}"
   defp public_key_message("hexpm"), do: "on our public keys page: #{@public_keys_html}"

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -740,10 +740,16 @@ defmodule Hex.RemoteConverger do
         :ok
 
       {:error, :auth_failed} ->
-        Mix.raise("Authentication failed. Unable to access private packages.")
+        Hex.Shell.warn(
+          "Authentication failed. Private packages will not be available. " <>
+            "Run `mix hex.user auth` to authenticate."
+        )
 
       {:error, :auth_declined} ->
-        Mix.raise("Authentication required to access private packages. Run `mix hex.user auth`")
+        Hex.Shell.warn(
+          "Private packages will not be available. " <>
+            "Run `mix hex.user auth` to authenticate."
+        )
 
       {:error, :no_auth} ->
         # No OAuth token - this is OK, user might only be fetching public packages


### PR DESCRIPTION
Warn instead of raising when OAuth authentication fails or is declined during dependency resolution since the user may only need public packages. Improve the prompt message when re-authentication is needed. Add 401 to the recognized error statuses in the registry server and suggest running `mix hex.user auth` when no authentication token is found.