### PR TITLE
Restore Hex code paths after compilation pruning

### DIFF
--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -25,6 +25,10 @@ defmodule Hex.RemoteConverger do
   end
 
   def converge(deps, lock) do
+    unless Code.ensure_loaded?(Hex.Mix) do
+      Hex.Stdlib.ensure_application!(:hex)
+    end
+
     Registry.open()
 
     # Check and refresh OAuth token before fetching packages

--- a/lib/hex/stdlib.ex
+++ b/lib/hex/stdlib.ex
@@ -16,4 +16,12 @@ defmodule Hex.Stdlib do
         apply(:public_key, :ssh_hostkey_fingerprint, [digset_type, key])
     end
   end
+
+  # Compilation prunes code paths for isolation, which may remove archive
+  # paths like Hex. Restore them so all Hex modules are available.
+  def ensure_application!(app) do
+    if function_exported?(Mix, :ensure_application!, 1) do
+      apply(Mix, :ensure_application!, [app])
+    end
+  end
 end


### PR DESCRIPTION
Compilation prunes code paths for isolation, which may remove archive paths like Hex. When a task like `format` triggers compilation and then `deps.get` runs in the same VM, Hex.Mix becomes unavailable.

Call Mix.ensure_application!(:hex) to restore the code paths before converging dependencies.

Closes #1109