### PR TITLE
Fix registry ets package timestamp purging

### DIFF
--- a/lib/hex/registry/server.ex
+++ b/lib/hex/registry/server.ex
@@ -313,8 +313,8 @@ defmodule Hex.Registry.Server do
       {{{:outer_checksum, :"$1", :"$2", :"$3"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
       {{{:retired, :"$1", :"$2", :"$3"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
       {{{:registry_etag, :"$1", :"$2"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
-      {{{:timetamp, :"$1", :"$2"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
-      {{{:timetamp, :"$1", :"$2", :"$3"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
+      {{{:timestamp, :"$1", :"$2"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
+      {{{:timestamp, :"$1", :"$2", :"$3"}, :_}, [{:"=:=", {:const, repo}, :"$1"}], [true]},
       {:_, [], [false]}
     ]
   end


### PR DESCRIPTION
The changes fix typo in `timestamp` and now `Hex.Registry.Server.prefetch` should properly clean all entries associated with packages from `state.ets`.

The rest of the file uses `timestamp` keys, like here: https://github.com/hexpm/hex/blob/8886724c138c70fa049eaa0566e3219a1ac191eb/lib/hex/registry/server.ex#L368

I also checked for typos in other keys or key that could be omitted from `purge_repo_matchspec`, just in case, but everything seems fine aside from that typo in `timestamp`.