### PR TITLE
Filter expected error logs from cache handoff tests

### DIFF
--- a/test/hex/once_cache_test.exs
+++ b/test/hex/once_cache_test.exs
@@ -243,6 +243,7 @@ defmodule Hex.OnceCacheTest do
       assert elapsed < 180_000
     end
 
+    @tag :capture_log
     test "hands off to next waiter when computing process crashes", %{cache: cache} do
       caller = self()
 


### PR DESCRIPTION
The changes filter out an expected error message from test logs.

It's a minor thing, but it took me a moment to figure out that this is an expected log message:

https://github.com/hexpm/hex/blob/8886724c138c70fa049eaa0566e3219a1ac191eb/test/hex/once_cache_test.exs#L253

<img width="1371" height="493" alt="image" src="https://github.com/user-attachments/assets/eb7b5528-4adb-4e56-abec-21c9c7f69e33" /><br/>


So, the changes silence this error log:

<img width="1025" height="408" alt="image" src="https://github.com/user-attachments/assets/f3b9c93e-d85f-44c3-a158-406ec52925eb" />

