### PR TITLE
Add download stats and release dates to mix hex.info

### DIFF
--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -118,6 +118,7 @@ defmodule Mix.Tasks.Hex.Info do
     Hex.Shell.info("Config: " <> package["configs"]["mix.exs"])
     print_locked_package(locked_package)
     Hex.Shell.info(["Releases: "] ++ format_releases(releases, Map.keys(retirements)) ++ ["\n"])
+    print_downloads(package["downloads"])
     print_meta(meta)
   end
 
@@ -129,16 +130,48 @@ defmodule Mix.Tasks.Hex.Info do
     |> add_ellipsis(rest)
   end
 
-  defp format_version(%{"version" => version}, retirements) do
+  defp format_version(%{"version" => version} = release, retirements) do
+    date = format_release_date(release["inserted_at"])
+
     if version in retirements do
-      [:yellow, version, " (retired)", :reset]
+      [:yellow, version, date, " (retired)", :reset]
     else
-      [version]
+      [version, date]
+    end
+  end
+
+  defp format_release_date(nil), do: ""
+
+  defp format_release_date(date_string) do
+    case parse_date(date_string) do
+      {:ok, date} -> " (#{date})"
+      _ -> ""
     end
   end
 
   defp add_ellipsis(output, []), do: output
   defp add_ellipsis(output, _rest), do: output ++ [", ..."]
+
+  defp print_downloads(nil), do: :ok
+
+  defp print_downloads(downloads) do
+    parts =
+      Enum.reject(
+        [
+          format_download_count("Yesterday", downloads["day"]),
+          format_download_count("Last 7 days", downloads["week"]),
+          format_download_count("All time", downloads["all"])
+        ],
+        &is_nil/1
+      )
+
+    if parts != [] do
+      Hex.Shell.info("Downloads:\n  " <> Enum.join(parts, "\n  ") <> "\n")
+    end
+  end
+
+  defp format_download_count(_label, nil), do: nil
+  defp format_download_count(label, count), do: "#{label}: #{count}"
 
   defp print_meta(meta) do
     print_list(meta, "licenses")
@@ -150,9 +183,14 @@ defmodule Mix.Tasks.Hex.Info do
 
     print_retirement(release)
     Hex.Shell.info("Config: " <> release["configs"]["mix.exs"])
+    print_release_published_at(release["inserted_at"])
 
     if release["has_docs"] do
       Hex.Shell.info("Documentation at: #{Hex.Utils.hexdocs_url(organization, package, version)}")
+    end
+
+    if downloads = release["downloads"] do
+      Hex.Shell.info("Downloads: #{downloads}")
     end
 
     if requirements = release["requirements"] do
@@ -167,6 +205,22 @@ defmodule Mix.Tasks.Hex.Info do
     end
 
     print_publisher(release)
+  end
+
+  defp print_release_published_at(nil), do: :ok
+
+  defp print_release_published_at(date_string) do
+    case parse_date(date_string) do
+      {:ok, date} -> Hex.Shell.info("Released: #{date}")
+      _ -> :ok
+    end
+  end
+
+  defp parse_date(date_string) do
+    case DateTime.from_iso8601(date_string) do
+      {:ok, datetime, _offset} -> {:ok, DateTime.to_date(datetime)}
+      _ -> Date.from_iso8601(date_string)
+    end
   end
 
   defp print_locked_package(nil), do: nil

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -130,20 +130,15 @@ defmodule Mix.Tasks.Hex.Info do
     {releases, rest} = Enum.split(releases, 8)
 
     releases
-    |> Enum.map(fn release ->
-      release
-      |> format_version(retirements)
-      |> Enum.join(" ")
-    end)
+    |> Enum.map(&["  ", format_version(&1, retirements), "\n"])
     |> add_ellipsis(rest)
-    |> Enum.map(&"  #{&1}\n")
   end
 
   defp format_version(%{"version" => version} = release, retirements) do
     date = format_release_date(release["inserted_at"])
 
     if version in retirements do
-      [:yellow, version, date, "(retired)", :reset]
+      [:yellow, version, date, " (retired)", :reset]
     else
       [version, date]
     end
@@ -153,13 +148,13 @@ defmodule Mix.Tasks.Hex.Info do
 
   defp format_release_date(date_string) do
     case parse_date(date_string) do
-      {:ok, date} -> "(#{date})"
+      {:ok, date} -> " (#{date})"
       _ -> ""
     end
   end
 
   defp add_ellipsis(output, []), do: output
-  defp add_ellipsis(output, _rest), do: output ++ ["..."]
+  defp add_ellipsis(output, _rest), do: output ++ ["  ...\n"]
 
   defp print_downloads(nil), do: :ok
 
@@ -208,13 +203,7 @@ defmodule Mix.Tasks.Hex.Info do
       Hex.Shell.info("Documentation at: #{Hex.Utils.hexdocs_url(organization, package, version)}")
     end
 
-    case release["downloads"] do
-      download_count when is_integer(download_count) ->
-        Hex.Shell.info("Downloads: #{add_thousands_separators(download_count)}")
-
-      _ ->
-        :ok
-    end
+    print_release_downloads(release["downloads"])
 
     if requirements = release["requirements"] do
       Hex.Shell.info("Dependencies:")
@@ -229,6 +218,12 @@ defmodule Mix.Tasks.Hex.Info do
 
     print_publisher(release)
   end
+
+  defp print_release_downloads(count) when is_integer(count) do
+    Hex.Shell.info("Downloads: #{add_thousands_separators(count)}")
+  end
+
+  defp print_release_downloads(_), do: :ok
 
   defp print_release_published_at(nil), do: :ok
 

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -118,9 +118,7 @@ defmodule Mix.Tasks.Hex.Info do
     Hex.Shell.info("Config: " <> package["configs"]["mix.exs"])
     print_locked_package(locked_package)
 
-    Hex.Shell.info(
-      ["Recent releases:\n"] ++ format_releases(releases, Map.keys(retirements)) ++ ["\n"]
-    )
+    Hex.Shell.info(["\nRecent releases:\n" | format_releases(releases, Map.keys(retirements))])
 
     print_downloads(package["downloads"])
     print_meta(meta)

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -122,7 +122,6 @@ defmodule Mix.Tasks.Hex.Info do
       ["Recent releases:\n"] ++ format_releases(releases, Map.keys(retirements)) ++ ["\n"]
     )
 
-    dbg(package["downloads"])
     print_downloads(package["downloads"])
     print_meta(meta)
   end

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -208,8 +208,12 @@ defmodule Mix.Tasks.Hex.Info do
       Hex.Shell.info("Documentation at: #{Hex.Utils.hexdocs_url(organization, package, version)}")
     end
 
-    if downloads = release["downloads"] do
-      Hex.Shell.info("Downloads: #{add_thousands_separators(downloads)}")
+    case release["downloads"] do
+      download_count when is_integer(download_count) ->
+        Hex.Shell.info("Downloads: #{add_thousands_separators(download_count)}")
+
+      _ ->
+        :ok
     end
 
     if requirements = release["requirements"] do

--- a/lib/mix/tasks/hex.info.ex
+++ b/lib/mix/tasks/hex.info.ex
@@ -117,7 +117,12 @@ defmodule Mix.Tasks.Hex.Info do
     retirements = package["retirements"] || %{}
     Hex.Shell.info("Config: " <> package["configs"]["mix.exs"])
     print_locked_package(locked_package)
-    Hex.Shell.info(["Releases: "] ++ format_releases(releases, Map.keys(retirements)) ++ ["\n"])
+
+    Hex.Shell.info(
+      ["Recent releases:\n"] ++ format_releases(releases, Map.keys(retirements)) ++ ["\n"]
+    )
+
+    dbg(package["downloads"])
     print_downloads(package["downloads"])
     print_meta(meta)
   end
@@ -125,16 +130,21 @@ defmodule Mix.Tasks.Hex.Info do
   defp format_releases(releases, retirements) do
     {releases, rest} = Enum.split(releases, 8)
 
-    Enum.map(releases, &format_version(&1, retirements))
-    |> Enum.intersperse([", "])
+    releases
+    |> Enum.map(fn release ->
+      release
+      |> format_version(retirements)
+      |> Enum.join(" ")
+    end)
     |> add_ellipsis(rest)
+    |> Enum.map(&"  #{&1}\n")
   end
 
   defp format_version(%{"version" => version} = release, retirements) do
     date = format_release_date(release["inserted_at"])
 
     if version in retirements do
-      [:yellow, version, date, " (retired)", :reset]
+      [:yellow, version, date, "(retired)", :reset]
     else
       [version, date]
     end
@@ -144,13 +154,13 @@ defmodule Mix.Tasks.Hex.Info do
 
   defp format_release_date(date_string) do
     case parse_date(date_string) do
-      {:ok, date} -> " (#{date})"
+      {:ok, date} -> "(#{date})"
       _ -> ""
     end
   end
 
   defp add_ellipsis(output, []), do: output
-  defp add_ellipsis(output, _rest), do: output ++ [", ..."]
+  defp add_ellipsis(output, _rest), do: output ++ ["..."]
 
   defp print_downloads(nil), do: :ok
 
@@ -171,7 +181,17 @@ defmodule Mix.Tasks.Hex.Info do
   end
 
   defp format_download_count(_label, nil), do: nil
-  defp format_download_count(label, count), do: "#{label}: #{count}"
+  defp format_download_count(label, count), do: "#{label}: #{add_thousands_separators(count)}"
+
+  defp add_thousands_separators(count, separator \\ " ") do
+    count
+    |> Integer.to_string()
+    |> String.reverse()
+    |> String.codepoints()
+    |> Enum.chunk_every(3)
+    |> Enum.join(separator)
+    |> String.reverse()
+  end
 
   defp print_meta(meta) do
     print_list(meta, "licenses")
@@ -190,7 +210,7 @@ defmodule Mix.Tasks.Hex.Info do
     end
 
     if downloads = release["downloads"] do
-      Hex.Shell.info("Downloads: #{downloads}")
+      Hex.Shell.info("Downloads: #{add_thousands_separators(downloads)}")
     end
 
     if requirements = release["requirements"] do

--- a/test/mix/tasks/hex.info_test.exs
+++ b/test/mix/tasks/hex.info_test.exs
@@ -54,7 +54,7 @@ defmodule Mix.Tasks.Hex.InfoTest do
         "day" => 21_494,
         "recent" => 1_421_136,
         "week" => 124_095
-      },
+      }
     }
 
     Bypass.expect(bypass, "GET", "/api/packages/ex_doc", fn conn ->
@@ -65,6 +65,7 @@ defmodule Mix.Tasks.Hex.InfoTest do
 
     Mix.Tasks.Hex.Info.run(["ex_doc"])
     assert_received {:mix_shell, :info, ["Downloads:\n" <> downloads]}
+
     assert String.split(downloads, "\n") == [
              "  Yesterday: 21 494",
              "  Last 7 days: 124 095",
@@ -110,7 +111,7 @@ defmodule Mix.Tasks.Hex.InfoTest do
     Mix.Tasks.Hex.Info.run(["tired"])
     today = Date.utc_today()
     assert_received {:mix_shell, :info, ["Recent releases:\n" <> releases]}
-    assert releases == "  0.2.0 (#{today})\n  yellow 0.1.0 (#{today}) (retired) reset\n\n"
+    assert releases == "  0.2.0 (#{today})\n  0.1.0 (#{today}) (retired)\n\n"
   end
 
   test "package with --organization flag" do
@@ -158,7 +159,7 @@ defmodule Mix.Tasks.Hex.InfoTest do
       "retirement" => nil,
       "publisher" => nil,
       "downloads" => 26_208,
-      "configs": %{
+      "configs" => %{
         "erlang.mk" => "dep_jason = hex 1.5.0-alpha.2",
         "mix.exs" => "{:jason, \"~\u003E 1.5.0-alpha.2\"}",
         "rebar.config" => "{jason, \"1.5.0-alpha.2\"}"

--- a/test/mix/tasks/hex.info_test.exs
+++ b/test/mix/tasks/hex.info_test.exs
@@ -17,9 +17,9 @@ defmodule Mix.Tasks.Hex.InfoTest do
     Mix.Tasks.Hex.Info.run(["ex_doc"])
     assert_received {:mix_shell, :info, ["Some description\n"]}
     assert_received {:mix_shell, :info, ["Config: {:ex_doc, \"~> 0.1.0\"}"]}
-    assert_received {:mix_shell, :info, ["Recent releases:\n" <> releases]}
+    assert_received {:mix_shell, :info, ["\nRecent releases:\n" <> releases]}
     today = Date.utc_today()
-    assert releases == "  0.1.0 (#{today})\n  0.1.0-rc1 (#{today})\n  0.0.1 (#{today})\n\n"
+    assert releases == "  0.1.0 (#{today})\n  0.1.0-rc1 (#{today})\n  0.0.1 (#{today})\n"
 
     assert catch_throw(Mix.Tasks.Hex.Info.run(["no_package"])) == {:exit_code, 1}
     assert_received {:mix_shell, :error, ["No package with name no_package"]}
@@ -86,7 +86,7 @@ defmodule Mix.Tasks.Hex.InfoTest do
       assert_received {:mix_shell, :info, ["Some description\n"]}
       assert_received {:mix_shell, :info, ["Locked version: 0.2.0"]}
       assert_received {:mix_shell, :info, ["Config: {:ecto, \"~> 3.3\"}"]}
-      assert_received {:mix_shell, :info, ["Recent releases:\n" <> releases]}
+      assert_received {:mix_shell, :info, ["\nRecent releases:\n" <> releases]}
 
       today = Date.utc_today()
 
@@ -95,7 +95,6 @@ defmodule Mix.Tasks.Hex.InfoTest do
                "  3.3.1 (#{today})",
                "  0.2.1 (#{today})",
                "  0.2.0 (#{today})",
-               "",
                ""
              ]
     end)
@@ -110,8 +109,8 @@ defmodule Mix.Tasks.Hex.InfoTest do
   test "package with retired release" do
     Mix.Tasks.Hex.Info.run(["tired"])
     today = Date.utc_today()
-    assert_received {:mix_shell, :info, ["Recent releases:\n" <> releases]}
-    assert releases == "  0.2.0 (#{today})\n  0.1.0 (#{today}) (retired)\n\n"
+    assert_received {:mix_shell, :info, ["\nRecent releases:\n" <> releases]}
+    assert releases == "  0.2.0 (#{today})\n  0.1.0 (#{today}) (retired)\n"
   end
 
   test "package with --organization flag" do

--- a/test/mix/tasks/hex.info_test.exs
+++ b/test/mix/tasks/hex.info_test.exs
@@ -17,7 +17,9 @@ defmodule Mix.Tasks.Hex.InfoTest do
     Mix.Tasks.Hex.Info.run(["ex_doc"])
     assert_received {:mix_shell, :info, ["Some description\n"]}
     assert_received {:mix_shell, :info, ["Config: {:ex_doc, \"~> 0.1.0\"}"]}
-    assert_received {:mix_shell, :info, ["Releases: 0.1.0, 0.1.0-rc1, 0.0.1\n"]}
+    assert_received {:mix_shell, :info, ["Releases: " <> releases]}
+    today = Date.utc_today()
+    assert releases == "0.1.0 (#{today}), 0.1.0-rc1 (#{today}), 0.0.1 (#{today})\n"
 
     assert catch_throw(Mix.Tasks.Hex.Info.run(["no_package"])) == {:exit_code, 1}
     assert_received {:mix_shell, :error, ["No package with name no_package"]}
@@ -38,7 +40,16 @@ defmodule Mix.Tasks.Hex.InfoTest do
       assert_received {:mix_shell, :info, ["Some description\n"]}
       assert_received {:mix_shell, :info, ["Locked version: 0.2.0"]}
       assert_received {:mix_shell, :info, ["Config: {:ecto, \"~> 3.3\"}"]}
-      assert_received {:mix_shell, :info, ["Releases: 3.3.2, 3.3.1, 0.2.1, 0.2.0\n"]}
+      assert_received {:mix_shell, :info, ["Releases: " <> releases]}
+
+
+      today = Date.utc_today()
+      assert String.split(releases, ", ") == [
+               "3.3.2 (#{today})",
+               "3.3.1 (#{today})",
+               "0.2.1 (#{today})",
+               "0.2.0 (#{today})\n"
+             ]
     end)
   after
     purge([
@@ -50,7 +61,9 @@ defmodule Mix.Tasks.Hex.InfoTest do
 
   test "package with retired release" do
     Mix.Tasks.Hex.Info.run(["tired"])
-    assert_received {:mix_shell, :info, ["Releases: 0.2.0, 0.1.0 (retired)\n"]}
+    today = Date.utc_today()
+    assert_received {:mix_shell, :info, ["Releases: " <> releases]}
+    assert releases == "0.2.0 (#{today}), 0.1.0 (#{today}) (retired)\n"
   end
 
   test "package with --organization flag" do
@@ -86,5 +99,11 @@ defmodule Mix.Tasks.Hex.InfoTest do
   test "prints publisher info for releases" do
     Mix.Tasks.Hex.Info.run(["ex_doc", "0.0.1"])
     assert_received {:mix_shell, :info, ["Published by: user (user@mail.com)"]}
+  end
+
+  test "prints release date for releases" do
+    Mix.Tasks.Hex.Info.run(["ex_doc", "0.0.1"])
+    assert_received {:mix_shell, :info, ["Released: " <> date]}
+    assert date == "#{Date.utc_today()}"
   end
 end

--- a/test/mix/tasks/hex.info_test.exs
+++ b/test/mix/tasks/hex.info_test.exs
@@ -17,9 +17,12 @@ defmodule Mix.Tasks.Hex.InfoTest do
     Mix.Tasks.Hex.Info.run(["ex_doc"])
     assert_received {:mix_shell, :info, ["Some description\n"]}
     assert_received {:mix_shell, :info, ["Config: {:ex_doc, \"~> 0.1.0\"}"]}
-    assert_received {:mix_shell, :info, ["Releases: " <> releases]}
+    assert_received {:mix_shell, :info, ["Recent releases:\n" <> releases]}
+    assert_received {:mix_shell, :info, ["Downloads:\n" <> downloads]}
     today = Date.utc_today()
-    assert releases == "0.1.0 (#{today}), 0.1.0-rc1 (#{today}), 0.0.1 (#{today})\n"
+    assert releases == "  0.1.0 (#{today})\n  0.1.0-rc1 (#{today})\n  0.0.1 (#{today})\n\n"
+
+    assert downloads == "Yesterday: 123\nLast 7 days: 12 345\nAll time: 123 456\n\n"
 
     assert catch_throw(Mix.Tasks.Hex.Info.run(["no_package"])) == {:exit_code, 1}
     assert_received {:mix_shell, :error, ["No package with name no_package"]}
@@ -40,15 +43,17 @@ defmodule Mix.Tasks.Hex.InfoTest do
       assert_received {:mix_shell, :info, ["Some description\n"]}
       assert_received {:mix_shell, :info, ["Locked version: 0.2.0"]}
       assert_received {:mix_shell, :info, ["Config: {:ecto, \"~> 3.3\"}"]}
-      assert_received {:mix_shell, :info, ["Releases: " <> releases]}
-
+      assert_received {:mix_shell, :info, ["Recent releases:\n" <> releases]}
 
       today = Date.utc_today()
-      assert String.split(releases, ", ") == [
-               "3.3.2 (#{today})",
-               "3.3.1 (#{today})",
-               "0.2.1 (#{today})",
-               "0.2.0 (#{today})\n"
+
+      assert String.split(releases, "\n") == [
+               "  3.3.2 (#{today})",
+               "  3.3.1 (#{today})",
+               "  0.2.1 (#{today})",
+               "  0.2.0 (#{today})",
+               "",
+               ""
              ]
     end)
   after
@@ -62,8 +67,8 @@ defmodule Mix.Tasks.Hex.InfoTest do
   test "package with retired release" do
     Mix.Tasks.Hex.Info.run(["tired"])
     today = Date.utc_today()
-    assert_received {:mix_shell, :info, ["Releases: " <> releases]}
-    assert releases == "0.2.0 (#{today}), 0.1.0 (#{today}) (retired)\n"
+    assert_received {:mix_shell, :info, ["Recent releases:\n" <> releases]}
+    assert releases == "  0.2.0 (#{today})\n  yellow 0.1.0 (#{today}) (retired) reset\n\n"
   end
 
   test "package with --organization flag" do

--- a/test/mix/tasks/hex.info_test.exs
+++ b/test/mix/tasks/hex.info_test.exs
@@ -18,17 +18,59 @@ defmodule Mix.Tasks.Hex.InfoTest do
     assert_received {:mix_shell, :info, ["Some description\n"]}
     assert_received {:mix_shell, :info, ["Config: {:ex_doc, \"~> 0.1.0\"}"]}
     assert_received {:mix_shell, :info, ["Recent releases:\n" <> releases]}
-    assert_received {:mix_shell, :info, ["Downloads:\n" <> downloads]}
     today = Date.utc_today()
     assert releases == "  0.1.0 (#{today})\n  0.1.0-rc1 (#{today})\n  0.0.1 (#{today})\n\n"
-
-    assert downloads == "Yesterday: 123\nLast 7 days: 12 345\nAll time: 123 456\n\n"
 
     assert catch_throw(Mix.Tasks.Hex.Info.run(["no_package"])) == {:exit_code, 1}
     assert_received {:mix_shell, :error, ["No package with name no_package"]}
 
     assert catch_throw(Mix.Tasks.Hex.Info.run([""])) == {:exit_code, 1}
     assert_received {:mix_shell, :error, ["Package name is empty"]}
+  end
+
+  test "package downloads" do
+    bypass = Bypass.open()
+    Hex.State.put(:api_url, "http://localhost:#{bypass.port}/api")
+
+    today = Date.utc_today()
+    inserted_at = "#{today}T12:00:00Z"
+
+    package_body = %{
+      "name" => "ex_doc",
+      "meta" => %{
+        "description" => "Some description",
+        "licenses" => ["GPL-2.0", "MIT", "Apache-2.0"],
+        "links" => %{"docs" => "http://docs", "repo" => "http://repo"}
+      },
+      "configs" => %{"mix.exs" => "{:ex_doc, \"~> 0.1.0\"}"},
+      "releases" => [
+        %{"version" => "0.1.0", "inserted_at" => inserted_at},
+        %{"version" => "0.1.0-rc1", "inserted_at" => inserted_at},
+        %{"version" => "0.0.1", "inserted_at" => inserted_at}
+      ],
+      "retirements" => %{},
+      "downloads" => %{
+        "all" => 96_128_698,
+        "day" => 21_494,
+        "recent" => 1_421_136,
+        "week" => 124_095
+      },
+    }
+
+    Bypass.expect(bypass, "GET", "/api/packages/ex_doc", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "application/vnd.hex+erlang")
+      |> Plug.Conn.resp(200, Hex.Utils.safe_serialize_erlang(package_body))
+    end)
+
+    Mix.Tasks.Hex.Info.run(["ex_doc"])
+    assert_received {:mix_shell, :info, ["Downloads:\n" <> downloads]}
+    assert String.split(downloads, "\n") == [
+             "  Yesterday: 21 494",
+             "  Last 7 days: 124 095",
+             "  All time: 96 128 698",
+             ""
+           ]
   end
 
   test "locked package" do
@@ -99,6 +141,38 @@ defmodule Mix.Tasks.Hex.InfoTest do
 
     assert catch_throw(Mix.Tasks.Hex.Info.run(["ex_doc", "1.2.3"])) == {:exit_code, 1}
     assert_received {:mix_shell, :error, ["No release with name ex_doc 1.2.3"]}
+  end
+
+  test "release downloads" do
+    bypass = Bypass.open()
+    Hex.State.put(:api_url, "http://localhost:#{bypass.port}/api")
+
+    today = Date.utc_today()
+    inserted_at = "#{today}T12:00:00Z"
+
+    release_body = %{
+      "version" => "1.5.0-alpha.2",
+      "checksum" => "6dcaa0d9fdc22afe9b4d362f17f20844a85f121c50b6e9b9466ac04fe39f3665",
+      "inserted_at" => inserted_at,
+      "updated_at" => inserted_at,
+      "retirement" => nil,
+      "publisher" => nil,
+      "downloads" => 26_208,
+      "configs": %{
+        "erlang.mk" => "dep_jason = hex 1.5.0-alpha.2",
+        "mix.exs" => "{:jason, \"~\u003E 1.5.0-alpha.2\"}",
+        "rebar.config" => "{jason, \"1.5.0-alpha.2\"}"
+      }
+    }
+
+    Bypass.expect(bypass, "GET", "/api/packages/ex_doc/releases/0.1.0", fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("content-type", "application/vnd.hex+erlang")
+      |> Plug.Conn.resp(200, Hex.Utils.safe_serialize_erlang(release_body))
+    end)
+
+    Mix.Tasks.Hex.Info.run(["ex_doc", "0.1.0"])
+    assert_received {:mix_shell, :info, ["Downloads: 26 208"]}
   end
 
   test "prints publisher info for releases" do


### PR DESCRIPTION
This adds download counts and release dates (provided by `hex.pm/api/packages/[package_name]`) to the `mix hex.info [package_name]` and `mix hex.info [package_name] [version]` commands.

Download counts for the overall package info include yesterday, last 7 days, and all-time.

Two decisions I'm not entirely sure of, but happy to revisit:
- Showing the download numbers for the current version (like the Hex.pm website does) would require a second HTTP request, which seemed iffy.
- I wasn't clear on what the "recent" key in the downloads meant (it looks like it might be the last 8 releases?), so I left that out of the download output since I was unable to give a more concrete label for it.

(The formatting on the before/after table below is a little weird... GitHub seems to be adding additional spaces between "paragraphs.")

<table>
  <thead><tr><td>Before</td><td>After</td></tr></thead>
<tr>
<td style="max-width: 300px">
<pre><code>
$ mix hex.info jason
A blazing fast JSON parser and generator in pure Elixir.

Config: {:jason, "~> 1.4"}
Locked version: 1.4.4
Releases: 1.5.0-alpha.2, 1.5.0-alpha.1, 1.4.4, 1.4.3, 1.4.2, 1.4.1, 1.4.0, 1.3.0, ...

Licenses: Apache-2.0
Links:
&nbsp;&nbsp;GitHub: https://github.com/michalmuskala/jason
</code></pre>
</td>
<td style="max-width: 300px">
<pre><code>
$ mix hex.info jason
A blazing fast JSON parser and generator in pure Elixir.

Config: {:jason, "~> 1.4"}
Recent releases:
&nbsp;&nbsp;1.5.0-alpha.2 (2023-07-07)
&nbsp;&nbsp;1.5.0-alpha.1 (2022-10-16)
&nbsp;&nbsp;1.4.4 (2024-07-26)
&nbsp;&nbsp;1.4.3 (2024-06-29)
&nbsp;&nbsp;1.4.2 (2024-06-29)
&nbsp;&nbsp;1.4.1 (2023-07-07)
&nbsp;&nbsp;1.4.0 (2022-09-12)
&nbsp;&nbsp;1.3.0 (2021-12-21)
&nbsp;&nbsp;...

Downloads:
&nbsp;&nbsp;Yesterday: 66 791
&nbsp;&nbsp;Last 7 days: 332 386
&nbsp;&nbsp;All time: 197 507 648

Licenses: Apache-2.0
Links:
&nbsp;&nbsp;GitHub: https://github.com/michalmuskala/jason
</code></pre>
</td>
</tr>
<tr>
<td style="max-width: 300px">
<pre><code>
$ mix hex.info jason 1.5.0-alpha.2
Config: {:jason, "~> 1.5.0-alpha.2"}
Documentation at: https://hexdocs.pm/jason/1.5.0-alpha.2
Dependencies:
&nbsp;&nbsp;decimal ~> 1.0 or ~> 2.0 (optional)
&nbsp;&nbsp;jason_native >= 0.0.0 (optional)
Published by: michalmuskala (michal@muskala.eu)
</code></pre>
</td>
<td style="max-width: 300px">
<pre><code>
$ mix hex.info jason 1.5.0-alpha.2
Config: {:jason, "~> 1.5.0-alpha.2"}
Released: 2023-07-07
Documentation at: https://hexdocs.pm/jason/1.5.0-alpha.2
Downloads: 26 130
Dependencies:
&nbsp;&nbsp;decimal ~> 1.0 or ~> 2.0 (optional)
&nbsp;&nbsp;jason_native >= 0.0.0 (optional)
Published by: michalmuskala (michal@muskala.eu)
</code></pre>
</td>
</tr>


Resolves #1128