### PR TITLE
Fix organization auth to create user key instead of organization key

### DIFF
--- a/lib/mix/tasks/hex.organization.ex
+++ b/lib/mix/tasks/hex.organization.ex
@@ -170,9 +170,14 @@ defmodule Mix.Tasks.Hex.Organization do
         permissions = [%{"domain" => "repository", "resource" => organization}]
         auth = Mix.Tasks.Hex.auth_info(:write)
 
-        case Mix.Tasks.Hex.generate_organization_key(organization, key_name, permissions, auth) do
-          {:ok, key} -> key
-          :error -> nil
+        case Hex.API.Key.new(key_name, permissions, auth) do
+          {:ok, {201, _, body}} ->
+            body["secret"]
+
+          other ->
+            Mix.shell().error("Generation of key failed")
+            Hex.Utils.print_error_result(other)
+            nil
         end
       end
 

--- a/test/mix/tasks/hex.organization_test.exs
+++ b/test/mix/tasks/hex.organization_test.exs
@@ -21,7 +21,7 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
 
       {:ok, hostname} = :inet.gethostname()
       name = "#{hostname}-repository-myorgauth"
-      assert {:ok, {200, _, body}} = Hex.API.Key.Organization.get("myorgauth", auth)
+      assert {:ok, {200, _, body}} = Hex.API.Key.get(auth)
       assert name in Enum.map(body, & &1["name"])
     end)
   end
@@ -54,7 +54,7 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
       assert myorg.url == "http://localhost:4043/repo/repos/myorgauthwithkeyname"
       assert is_binary(myorg.auth_key)
 
-      assert {:ok, {200, _, body}} = Hex.API.Key.Organization.get("myorgauthwithkeyname", auth)
+      assert {:ok, {200, _, body}} = Hex.API.Key.get(auth)
       assert "orgauthkeyname-repository-myorgauthwithkeyname" in Enum.map(body, & &1["name"])
     end)
   end


### PR DESCRIPTION
The `mix hex.organization auth` command should create a user-level key with repository permissions scoped to the organization, not an organization-owned key.

Fixes #1135.