### PR TITLE
Set finite OnceCache timeout for OAuth token exchange and refresh

### DIFF
--- a/lib/hex/oauth.ex
+++ b/lib/hex/oauth.ex
@@ -4,6 +4,7 @@ defmodule Hex.OAuth do
   alias Hex.API.OAuth
 
   @refresh_cache __MODULE__.RefreshCache
+  @refresh_timeout 60_000
 
   def start_link(_args) do
     Hex.OnceCache.start_link(name: @refresh_cache)
@@ -41,11 +42,10 @@ defmodule Hex.OAuth do
           {:ok, token_data["access_token"]}
         else
           # Token expired, use OnceCache to ensure only one refresh/auth happens
-          # Use infinity timeout because authentication may require user interaction
           Hex.OnceCache.fetch(
             @refresh_cache,
             fn -> do_refresh_or_authenticate(token_data, opts) end,
-            timeout: :infinity
+            timeout: @refresh_timeout
           )
         end
     end

--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -2,6 +2,7 @@ defmodule Hex.Repo do
   @moduledoc false
 
   @exchange_cache __MODULE__.ExchangeCache
+  @exchange_timeout 60_000
   @hexpm_url "https://repo.hex.pm"
   @hexpm_public_key """
   -----BEGIN PUBLIC KEY-----
@@ -363,7 +364,8 @@ defmodule Hex.Repo do
         Hex.OnceCache.fetch_key(
           @exchange_cache,
           {repo_name, repo_config.auth_key},
-          fn -> do_exchange_api_key(repo_config, repo_name) end
+          fn -> do_exchange_api_key(repo_config, repo_name) end,
+          timeout: @exchange_timeout
         )
     end
   end


### PR DESCRIPTION
Waiters on Hex.OnceCache shared a hardcoded 5s default timeout while the underlying HTTP call can take up to 15s. Under concurrent private package fetches in :hex_fetcher this caused all but the computing task to time out before the token exchange completed.

Use a 60s timeout consistent with Hex.Registry.Server and other HTTP-bound GenServer calls in the codebase. Replace the :infinity timeout in Hex.OAuth with the same bound; the interactive device flow is invoked sequentially from check_and_refresh_auth before parallel fetches begin, so concurrent waiters only ever cover the HTTP refresh path.

Closes https://github.com/hexpm/hex/issues/1141.