### PR TITLE
Gate API key to OAuth token exchange on oauth_exchange == true

### DIFF
--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -758,11 +758,13 @@ defmodule Hex.RemoteConverger do
           )
 
         {:error, :no_auth} ->
-          # No OAuth token - this is OK, user might only be fetching public packages
+          # No stored OAuth token to preflight; continue unauthenticated
+          # and let the repo fetch fail normally if authentication is required.
           :ok
 
         {:error, _other} ->
-          # Other errors (shouldn't happen with prompt_auth: true, but handle gracefully)
+          # Do not fail dependency resolution during OAuth preflight; continue
+          # unauthenticated and let the repo fetch surface any auth error.
           :ok
       end
     else

--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -318,11 +318,12 @@ defmodule Hex.Repo do
       cond do
         # First priority: explicit repo auth key with OAuth exchange disabled - use API key directly
         repo_config.auth_key && Map.get(repo_config, :trusted, true) &&
-            Map.get(repo_config, :oauth_exchange, false) == false ->
+            !Map.get(repo_config, :oauth_exchange, false) ->
           %{config | repo_key: repo_config.auth_key}
 
         # Second priority: Exchange API key for OAuth token if enabled
-        repo_config.auth_key && Map.get(repo_config, :trusted, true) ->
+        repo_config.auth_key && Map.get(repo_config, :trusted, true) &&
+            Map.get(repo_config, :oauth_exchange, false) ->
           case exchange_api_key_for_token(repo_config, repo_name) do
             {:ok, access_token} ->
               %{config | repo_key: "Bearer #{access_token}"}

--- a/test/hex/repo_test.exs
+++ b/test/hex/repo_test.exs
@@ -117,6 +117,61 @@ defmodule Hex.RepoTest do
     assert Map.get(repos_after["hexpm"], :oauth_token) == nil
   end
 
+  test "non-hexpm repo with oauth_exchange: false uses API key directly and does not exchange" do
+    bypass = Bypass.open()
+
+    Bypass.expect(bypass, fn %Plug.Conn{request_path: path} = conn ->
+      case path do
+        "/public_key" ->
+          assert Plug.Conn.get_req_header(conn, "authorization") == ["rawkey"]
+          Plug.Conn.resp(conn, 200, "fake_public_key_body")
+
+        "/oauth/token" ->
+          flunk("OAuth exchange must not be attempted when oauth_exchange is false")
+      end
+    end)
+
+    myrepo_config = %{
+      url: "http://localhost:#{bypass.port}",
+      public_key: nil,
+      auth_key: "rawkey",
+      trusted: true,
+      oauth_exchange: false,
+      oauth_exchange_url: "http://localhost:#{bypass.port}"
+    }
+
+    assert {:ok, {200, _, "fake_public_key_body"}} = Hex.Repo.get_public_key(myrepo_config)
+  end
+
+  test "non-hexpm repo with oauth_exchange not true does not attempt API key exchange" do
+    bypass = Bypass.open()
+    test_pid = self()
+
+    Bypass.expect(bypass, fn %Plug.Conn{request_path: path} = conn ->
+      case path do
+        "/public_key" ->
+          Plug.Conn.resp(conn, 200, "fake_public_key_body")
+
+        "/oauth/token" ->
+          send(test_pid, :exchange_attempted)
+          Plug.Conn.resp(conn, 500, "")
+      end
+    end)
+
+    myrepo_config = %{
+      url: "http://localhost:#{bypass.port}",
+      public_key: nil,
+      auth_key: "rawkey",
+      trusted: true,
+      oauth_exchange: nil,
+      oauth_exchange_url: "http://localhost:#{bypass.port}"
+    }
+
+    assert {:ok, {200, _, _}} = Hex.Repo.get_public_key(myrepo_config)
+
+    refute_received :exchange_attempted
+  end
+
   test "fetch_repo/1" do
     assert Hex.Repo.fetch_repo("foo") == :error
 


### PR DESCRIPTION
The second-priority branch in build_hex_core_config attempted to exchange
the API key for an OAuth token whenever auth_key and trusted were set,
relying on the first branch to short-circuit for the disabled case. That
left the branch's condition incomplete: any state not caught by branch 1
would fire exchange, even states that should not (e.g. organization
repos propagated from a parent without oauth_exchange set, which resolve
to an explicit nil).

Make both branches self-gated on the oauth_exchange flag so the
intent is local to each clause. Also clarify preflight comments in
remote_converger.