### PR TITLE
Loosen API key format assertion to is_binary + byte_size > 0

### DIFF
--- a/test/hex/api_test.exs
+++ b/test/hex/api_test.exs
@@ -73,8 +73,8 @@ defmodule Hex.APITest do
 
     assert {:ok, {201, _, %{"secret" => key_a}}} = Hex.API.Key.new("key_a", permissions, auth)
     assert {:ok, {201, _, %{"secret" => key_b}}} = Hex.API.Key.new("key_b", permissions, auth)
-    assert byte_size(key_a) == 32
-    assert byte_size(key_b) == 32
+    assert is_binary(key_a) and byte_size(key_a) > 0
+    assert is_binary(key_b) and byte_size(key_b) > 0
     auth = [key: key_a]
 
     Hexpm.new_package("hexpm", "melon", "0.0.1", %{}, %{}, auth)
@@ -91,8 +91,8 @@ defmodule Hex.APITest do
     auth = [user: "user", pass: "hunter42"]
     assert {:ok, {201, _, %{"secret" => key_c}}} = Hex.API.Key.new("key_c", permissions, auth)
     assert {:ok, {201, _, %{"secret" => key_d}}} = Hex.API.Key.new("key_d", permissions, auth)
-    assert byte_size(key_c) == 32
-    assert byte_size(key_d) == 32
+    assert is_binary(key_c) and byte_size(key_c) > 0
+    assert is_binary(key_d) and byte_size(key_d) > 0
     auth_c = [key: key_c]
     auth_d = [key: key_d]
 


### PR DESCRIPTION
The integration test asserted \`byte_size(key) == 32\`, which pinned the
hexpm response to a specific format. Hexpm is rolling out \`hex_\`-prefixed
v2 tokens (44 bytes, see hexpm/hexpm#1536) so the strict length check
now fails for any hexpm version that issues them.

Loosening to \`is_binary/1\` + \`byte_size/1 > 0\`. The remaining test
assertions (auth still works, key list still contains it, deletion
still works) cover whether the returned secret is functionally usable.
This avoids re-pinning to a different exact length and stays
forward-compatible with future hexpm token format changes.

Plan: once main is green, the same change will be applied to v2.4,
v2.3, v2.2, v2.1 maintenance branches.