### PR TITLE
Add mix hex.search QUERY

### DIFF
--- a/lib/mix/tasks/hex.package.ex
+++ b/lib/mix/tasks/hex.package.ex
@@ -2,7 +2,7 @@ defmodule Mix.Tasks.Hex.Package do
   use Mix.Task
   alias Hex.Registry.Server, as: Registry
 
-  @shortdoc "Fetches or diffs packages"
+  @shortdoc "Fetches, diffs, or searches packages"
 
   @default_diff_command "git diff --no-index --no-prefix __PATH1__ __PATH2__"
 
@@ -38,6 +38,15 @@ defmodule Mix.Tasks.Hex.Package do
   This command fetches package tarballs for both versions,
   unpacks them into temporary directories and runs a diff command.
   Afterwards, the temporary directories are automatically deleted.
+
+  ## Search packages
+
+      $ mix hex.package search PACKAGE
+
+  Search for package names.
+
+  If you are authenticated, it will additionally search all organizations
+  you are member of.
 
   Note, similarly to when tarballs are fetched with `mix deps.get`,
   a `hex_metadata.config` is placed in each unpacked directory.
@@ -99,6 +108,9 @@ defmodule Mix.Tasks.Hex.Package do
     output = Keyword.get(opts, :output, nil)
 
     case args do
+      ["search", package] ->
+        package_search(package, opts)
+
       ["fetch", package] ->
         fetch(repo(opts), package, nil, unpack, output)
 
@@ -115,6 +127,7 @@ defmodule Mix.Tasks.Hex.Package do
         Mix.raise("""
           Invalid arguments, expected one of:
 
+          mix hex.package search PACKAGE
           mix hex.package fetch PACKAGE [VERSION] [--unpack]
           mix hex.package diff APP VERSION
           mix hex.package diff PACKAGE VERSION1 VERSION2
@@ -126,6 +139,7 @@ defmodule Mix.Tasks.Hex.Package do
   @impl true
   def tasks() do
     [
+      {"search PACKAGE", "Search package names"},
       {"fetch PACKAGE [VERSION] [--unpack]", "Fetch the package"},
       {"diff APP VERSION", "Diff dependency against version"},
       {"diff PACKAGE VERSION1 VERSION2", "Diff package versions"},
@@ -348,6 +362,93 @@ defmodule Mix.Tasks.Hex.Package do
     latest_stable_version
   end
 
+  defp package_search(package, opts) do
+    Hex.start()
+    auth = Mix.Tasks.Hex.auth_info(:read, auth_inline: false)
+
+    opts
+    |> search_repo()
+    |> Hex.API.Package.search(package, auth)
+    |> lookup_packages()
+  end
+
+  defp search_repo(opts) do
+    cond do
+      organization = opts[:organization] ->
+        organization
+
+      repo = opts[:repo] ->
+        repo
+
+      true ->
+        nil
+    end
+  end
+
+  defp lookup_packages({:ok, {200, _headers, []}}) do
+    Hex.Shell.info("No packages found")
+  end
+
+  defp lookup_packages({:ok, {200, _headers, packages}}) do
+    include_organizations? = Enum.any?(packages, &(&1["repository"] != "hexpm"))
+
+    if include_organizations? do
+      print_with_organizations(packages)
+    else
+      print_without_organizations(packages)
+    end
+  end
+
+  defp lookup_packages({:ok, {_status, _headers, _body}}) do
+    Hex.Shell.info("No packages found")
+  end
+
+  defp print_with_organizations(packages) do
+    values =
+      Enum.map(packages, fn package ->
+        [
+          if(package["repository"] != "hexpm", do: package["repository"]),
+          package["name"],
+          package["meta"]["description"] |> trim_heredoc() |> Hex.Utils.truncate(),
+          latest_stable_release(package["releases"]),
+          package["html_url"] || package["url"]
+        ]
+      end)
+
+    Mix.Tasks.Hex.print_table(
+      ["Organization", "Package", "Description", "Version", "URL"],
+      values
+    )
+  end
+
+  defp print_without_organizations(packages) do
+    values =
+      Enum.map(packages, fn package ->
+        [
+          package["name"],
+          package["meta"]["description"] |> trim_heredoc() |> Hex.Utils.truncate(),
+          latest_stable_release(package["releases"]),
+          package["html_url"] || package["url"]
+        ]
+      end)
+
+    Mix.Tasks.Hex.print_table(
+      ["Package", "Description", "Version", "URL"],
+      values
+    )
+  end
+
+  defp latest_stable_release(releases) do
+    %{"version" => version} =
+      Enum.find(
+        releases,
+        %{"version" => nil},
+        &(Version.parse!(&1["version"]).pre == [])
+      )
+
+    version
+  end
+
   defp retrieve_package_info(organization, name) do
     case Hex.API.Package.get(organization, name) do
       {:ok, {code, _, body}} when code in 200..299 ->
@@ -360,5 +461,13 @@ defmodule Mix.Tasks.Hex.Package do
         Hex.Shell.error("Failed to retrieve package information")
         Hex.Utils.print_error_result(other)
     end
+  end
+
+  defp trim_heredoc(nil), do: ""
+
+  defp trim_heredoc(string) do
+    string
+    |> String.split("\n", trim: true)
+    |> Enum.map_join(" ", &String.trim/1)
   end
 end

--- a/lib/mix/tasks/hex.search.ex
+++ b/lib/mix/tasks/hex.search.ex
@@ -207,16 +207,15 @@ defmodule Mix.Tasks.Hex.Search do
   end
 
   defp decode_json!(body) do
-    if Code.ensure_loaded?(JSON) do
-      case JSON.decode(body) do
-        {:ok, decoded} ->
-          decoded
-
-        {:error, reason} ->
-          Mix.raise("Docs search returned invalid JSON: #{inspect(reason)}")
+    if Code.ensure_loaded?(:json) do
+      try do
+        :json.decode(body)
+      rescue
+        error in ErlangError ->
+          Mix.raise("Docs search returned invalid JSON: #{inspect(error.original)}")
       end
     else
-      Mix.raise("JSON module is not available, upgrade Elixir to use this feature")
+      Mix.raise(":json module is not available, upgrade OTP to use this feature")
     end
   end
 
@@ -225,6 +224,8 @@ defmodule Mix.Tasks.Hex.Search do
   end
 
   defp print_results(%{"found" => _found, "hits" => hits}) do
+    total = Integer.to_string(length(hits))
+
     hits
     |> Enum.with_index(1)
     |> Enum.each(fn {hit, index} ->
@@ -237,22 +238,13 @@ defmodule Mix.Tasks.Hex.Search do
         }
       } = hit
 
-      Hex.Shell.info(
-        Hex.Shell.format([
-          :bright,
-          "# ",
-          title,
-          " - ",
-          document_url(package, ref),
-          " (",
-          Integer.to_string(index),
-          ")",
-          :reset,
-          "\n\n",
-          strip_html_comments(doc),
-          "\n\n"
-        ])
-      )
+      Hex.Shell.info([
+        :bright,
+        ["# ", title, " (", Integer.to_string(index), "/", total, ")"],
+        :reset,
+        ["\n", document_url(package, ref), "\n\n"],
+        [strip_html_comments(doc), "\n\n"]
+      ])
     end)
   end
 

--- a/lib/mix/tasks/hex.search.ex
+++ b/lib/mix/tasks/hex.search.ex
@@ -1,7 +1,9 @@
 defmodule Mix.Tasks.Hex.Search do
   use Mix.Task
 
-  @shortdoc "Open and perform searches"
+  @shortdoc "Open and perform documentation search"
+  @search_url "https://search.hexdocs.pm/"
+  @stdlib_apps [:elixir, :iex, :logger, :ex_unit, :eex, :mix]
 
   @moduledoc """
   Open and perform searches.
@@ -12,54 +14,46 @@ defmodule Mix.Tasks.Hex.Search do
 
       $ mix hex.search
       $ mix hex.search --no-stdlib
+      $ mix hex.search --packages foo,bar
 
   You may also pass command line flags, to execute searches
   via the command line, according to the modes below.
 
-  ## Package search
+  For searching package names, see `mix hex.package search`.
 
-  Specify `--package PACKAGE` to search for a given package.
+  ## Docs search
 
-      $ mix hex.search --package PACKAGE
+  Pass a single positional argument to search docs and print results
+  directly to the terminal.
 
-  If you are authenticated, it will additionally search all organizations
-  you are member of.
+      $ mix hex.search "ecto changeset"
+      $ mix hex.search "ecto changeset" --packages ecto,ecto_sql
+      $ mix hex.search "ecto changeset" --limit 25
 
   ### Options
 
-    * `--organization ORGANIZATION` - Set this for private packages belonging to an organization
+    * `--packages PACKAGE1,PACKAGE2,...` - Restrict docs search to an explicit package list
+    * `--limit NUMBER` - Limit terminal docs search results (default: 10)
     * `--print-url` - Print the docs URL instead of opening it in the browser
 
   """
   @behaviour Hex.Mix.TaskDescription
 
-  @switches [organization: :string, package: :string, stdlib: :boolean, print_url: :boolean]
+  @switches [
+    limit: :integer,
+    packages: :string,
+    stdlib: :boolean,
+    print_url: :boolean
+  ]
 
   @impl true
   def run(args) do
     {opts, args} = OptionParser.parse!(args, strict: @switches)
 
     case args do
-      [] ->
-        cond do
-          package = opts[:package] ->
-            package_search(package, opts[:organization])
-
-          true ->
-            hexdocs_search(opts)
-        end
-
-      [package] ->
-        Mix.shell().error("mix hex.search PACKAGE is deprecated, use --package PACKAGE instead")
-        package_search(package, opts[:organization])
-
-      _ ->
-        Mix.raise("""
-        Invalid arguments, expected:
-
-        mix hex.search
-        mix hex.search --package PACKAGE
-        """)
+      [] -> hexdocs_search(opts)
+      [query] -> docs_query_search(query, opts)
+      _ -> invalid_args!()
     end
   end
 
@@ -67,31 +61,26 @@ defmodule Mix.Tasks.Hex.Search do
   def tasks() do
     [
       {"", "Opens up hexdocs.pm with your dependencies"},
-      {"--package PACKAGE", "Searches for package names"}
+      {"--packages PACKAGE1,PACKAGE2,...", "Opens up hexdocs.pm with explicit packages"},
+      {"QUERY", "Searches docs and prints results"},
+      {"QUERY --packages PACKAGE1,PACKAGE2,...", "Searches docs within explicit packages"},
+      {"QUERY --limit NUMBER", "Searches docs with a custom result limit"},
+      {"QUERY --no-stdlib", "Searches docs without stdlib packages"}
     ]
   end
 
   defp hexdocs_search(opts) do
-    Mix.Tasks.Deps.Loadpaths.run(["--no-compile", "--no-listeners"])
-    Hex.start()
+    if opts[:limit] do
+      invalid_args!()
+    end
 
-    deps =
-      for {_app, info} <- Mix.Dep.Lock.read(),
-          %{repo: "hexpm", name: name, version: version} <- [Hex.Utils.lock(info)] do
-        "#{name}:#{version}"
-      end
-
-    stdlib =
-      if Keyword.get(opts, :stdlib, true) do
-        [:elixir, :iex, :logger, :ex_unit, :eex, :mix]
-        |> Enum.map(&"#{&1}:#{System.version()}")
-      else
-        []
-      end
-
+    # Hexdocs accepts package1,package2 and
+    # it will automatically fetch the latest
     packages =
-      (deps ++ stdlib)
-      |> Enum.sort()
+      case opts[:packages] do
+        nil -> project_packages(opts)
+        packages -> parse_packages!(packages)
+      end
       |> Enum.join(",")
       |> URI.encode_www_form()
 
@@ -104,65 +93,47 @@ defmodule Mix.Tasks.Hex.Search do
     end
   end
 
-  defp package_search(package, organization) do
-    Hex.start()
-    auth = Mix.Tasks.Hex.auth_info(:read, auth_inline: false)
-
-    Hex.API.Package.search(organization, package, auth)
-    |> lookup_packages()
-  end
-
-  defp lookup_packages({:ok, {200, _headers, []}}) do
-    Hex.Shell.info("No packages found")
-  end
-
-  defp lookup_packages({:ok, {200, _headers, packages}}) do
-    include_organizations? = Enum.any?(packages, &(&1["repository"] != "hexpm"))
-
-    if include_organizations? do
-      print_with_organizations(packages)
-    else
-      print_without_organizations(packages)
+  defp docs_query_search(query, opts) do
+    if opts[:print_url] do
+      invalid_args!()
     end
-  end
 
-  defp lookup_packages({:ok, {_status, _headers, _body}}) do
-    Hex.Shell.info("No packages found")
-  end
+    validate_limit!(opts[:limit])
 
-  defp print_with_organizations(packages) do
-    values =
-      Enum.map(packages, fn package ->
-        [
-          if(package["repository"] != "hexpm", do: package["repository"]),
-          package["name"],
-          package["meta"]["description"] |> trim_heredoc() |> Hex.Utils.truncate(),
-          latest_stable(package["releases"]),
-          package["html_url"] || package["url"]
-        ]
-      end)
+    # Typesense expects exact project-vsn pairs
+    packages =
+      case opts[:packages] do
+        nil ->
+          opts
+          |> project_packages()
+          |> Enum.map(&String.replace(&1, ":", "-"))
 
-    Mix.Tasks.Hex.print_table(
-      ["Organization", "Package", "Description", "Version", "URL"],
-      values
-    )
-  end
+        packages ->
+          packages
+          |> parse_packages!()
+          |> Enum.map(&add_version_to_package!/1)
+      end
 
-  defp print_without_organizations(packages) do
-    values =
-      Enum.map(packages, fn package ->
-        [
-          package["name"],
-          package["meta"]["description"] |> trim_heredoc() |> Hex.Utils.truncate(),
-          latest_stable(package["releases"]),
-          package["html_url"] || package["url"]
-        ]
-      end)
+    url =
+      @search_url <>
+        "?" <>
+        URI.encode_query(
+          %{q: query, query_by: "doc,title", filter_by: "package:=[#{Enum.join(packages, ",")}]"}
+          |> maybe_put_limit(opts[:limit])
+        )
 
-    Mix.Tasks.Hex.print_table(
-      ["Package", "Description", "Version", "URL"],
-      values
-    )
+    case search_http_module().request(:get, url, %{}, nil, %{}) do
+      {:ok, {200, _headers, body}} ->
+        body
+        |> decode_json!()
+        |> print_results()
+
+      {:ok, {status, _headers, body}} ->
+        Mix.raise("Docs search failed with HTTP status #{status}: #{inspect(body)}")
+
+      {:error, reason} ->
+        Mix.raise("Docs search request failed: #{inspect(reason)}")
+    end
   end
 
   defp latest_stable(releases) do
@@ -176,11 +147,161 @@ defmodule Mix.Tasks.Hex.Search do
     version
   end
 
-  defp trim_heredoc(nil), do: ""
+  defp project_packages(opts) do
+    Mix.Tasks.Deps.Loadpaths.run(["--no-compile", "--no-listeners"])
+    Hex.start()
 
-  defp trim_heredoc(string) do
-    string
-    |> String.split("\n", trim: true)
-    |> Enum.map_join(" ", &String.trim/1)
+    deps =
+      for {_app, info} <- Mix.Dep.Lock.read(),
+          %{repo: "hexpm", name: name, version: version} <- [Hex.Utils.lock(info)] do
+        "#{name}:#{version}"
+      end
+
+    stdlib =
+      if Keyword.get(opts, :stdlib, true) do
+        Enum.map(@stdlib_apps, &"#{&1}:#{System.version()}")
+      else
+        []
+      end
+
+    Enum.sort(deps ++ stdlib)
+  end
+
+  defp parse_packages!(packages) do
+    packages =
+      packages
+      |> String.split(",", trim: true)
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+
+    if packages == [] do
+      Mix.raise("Expected --packages to include at least one package name")
+    end
+
+    packages
+  end
+
+  defp add_version_to_package!(package)
+       when package in ["elixir", "iex", "logger", "ex_unit", "eex", "mix"] do
+    "#{package}-#{System.version()}"
+  end
+
+  defp add_version_to_package!(package) do
+    Hex.start()
+
+    case Hex.API.Package.get("hexpm", package) do
+      {:ok, {200, _headers, %{"releases" => releases}}} ->
+        case latest_stable(releases) do
+          nil -> Mix.raise("Package #{package} has no stable release for docs search")
+          version -> "#{package}-#{version}"
+        end
+
+      {:ok, {status, _headers, body}} ->
+        Mix.raise(
+          "Failed to resolve package #{package} for docs search, got HTTP status #{status}: #{inspect(body)}"
+        )
+
+      {:error, reason} ->
+        Mix.raise("Failed to resolve package #{package} for docs search: #{inspect(reason)}")
+    end
+  end
+
+  defp decode_json!(body) do
+    if Code.ensure_loaded?(JSON) do
+      case JSON.decode(body) do
+        {:ok, decoded} ->
+          decoded
+
+        {:error, reason} ->
+          Mix.raise("Docs search returned invalid JSON: #{inspect(reason)}")
+      end
+    else
+      Mix.raise("JSON module is not available, upgrade Elixir to use this feature")
+    end
+  end
+
+  defp print_results(%{"found" => 0}) do
+    Hex.Shell.info("No results found")
+  end
+
+  defp print_results(%{"found" => _found, "hits" => hits}) do
+    hits
+    |> Enum.with_index(1)
+    |> Enum.each(fn {hit, index} ->
+      %{
+        "document" => %{
+          "doc" => doc,
+          "package" => package,
+          "ref" => ref,
+          "title" => title
+        }
+      } = hit
+
+      Hex.Shell.info(
+        Hex.Shell.format([
+          :bright,
+          "# ",
+          title,
+          " - ",
+          document_url(package, ref),
+          " (",
+          Integer.to_string(index),
+          ")",
+          :reset,
+          "\n\n",
+          strip_html_comments(doc),
+          "\n\n"
+        ])
+      )
+    end)
+  end
+
+  defp document_url(package, ref) do
+    case :binary.split(package, "-") do
+      [name, version] ->
+        "https://hexdocs.pm/#{Enum.join([name, version, ref], "/")}"
+
+      _ ->
+        Mix.raise("Unexpected package search result format: #{inspect(package)}")
+    end
+  end
+
+  defp strip_html_comments(doc) do
+    case :binary.split(doc, "<!--") do
+      [before] ->
+        before
+
+      [before, rest] ->
+        case :binary.split(rest, "-->") do
+          [_comment] -> before
+          [_comment, after_comment] -> before <> strip_html_comments(after_comment)
+        end
+    end
+  end
+
+  defp maybe_put_limit(params, nil), do: params
+  defp maybe_put_limit(params, limit), do: Map.put(params, :per_page, limit)
+
+  defp validate_limit!(nil), do: :ok
+  defp validate_limit!(limit) when is_integer(limit) and limit > 0 and limit <= 250, do: :ok
+
+  defp validate_limit!(limit) do
+    Mix.raise("Expected --limit to be between 1 and 250, got: #{inspect(limit)}")
+  end
+
+  defp search_http_module do
+    Application.get_env(:hex, :search_http_module, Hex.HTTP)
+  end
+
+  defp invalid_args! do
+    Mix.raise("""
+    Invalid arguments, expected:
+
+    mix hex.search
+    mix hex.search --packages PACKAGE1,PACKAGE2,...
+    mix hex.search QUERY
+    mix hex.search QUERY --packages PACKAGE1,PACKAGE2,...
+    mix hex.search QUERY --limit NUMBER
+    """)
   end
 end

--- a/test/mix/tasks/hex.package_test.exs
+++ b/test/mix/tasks/hex.package_test.exs
@@ -215,4 +215,49 @@ defmodule Mix.Tasks.Hex.PackageTest do
   after
     purge([ReleaseDeps.MixProject])
   end
+
+  describe "search" do
+    test "no results" do
+      Mix.Tasks.Hex.Package.run(["search", "bloopdoopbloop"])
+      assert_received {:mix_shell, :info, ["No packages found"]}
+    end
+
+    test "public packages" do
+      Mix.Tasks.Hex.Package.run(["search", "doc"])
+      assert_received {:mix_shell, :info, ["ex_doc" <> ex_doc]}
+      assert_received {:mix_shell, :info, ["only_doc" <> only_doc]}
+      assert ex_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/ex_doc"
+      assert only_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/only_doc"
+    end
+
+    test "all private packages" do
+      in_tmp(fn ->
+        set_home_tmp()
+        auth = Hexpm.new_user("searchuser1", "searchuser1@mail.com", "password", "searchuser1")
+        Hexpm.new_repo("searchrepo1", auth)
+        Hex.State.put(:api_key, auth[:key])
+
+        Mix.Tasks.Hex.Package.run(["search", "doc"])
+
+        assert_received {:mix_shell, :info, ["ex_doc" <> ex_doc]}
+        assert_received {:mix_shell, :info, ["only_doc" <> only_doc]}
+        assert ex_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/ex_doc"
+        assert only_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/only_doc"
+      end)
+    end
+
+    test "org packages" do
+      in_tmp(fn ->
+        set_home_tmp()
+        auth = Hexpm.new_user("searchuser2", "searchuser2@mail.com", "password", "searchuser2")
+        Hexpm.new_repo("searchrepo2", auth)
+        Hex.State.put(:api_key, auth[:key])
+
+        Mix.Tasks.Hex.Package.run(["search", "doc", "--organization", "searchrepo2"])
+
+        refute_received {:mix_shell, :info, ["ex_doc" <> _]}
+        refute_received {:mix_shell, :info, ["only_doc" <> _]}
+      end)
+    end
+  end
 end

--- a/test/mix/tasks/hex.search_test.exs
+++ b/test/mix/tasks/hex.search_test.exs
@@ -89,14 +89,7 @@ defmodule Mix.Tasks.Hex.SearchTest do
   end
 
   describe "docs query" do
-    setup do
-      if System.otp_release() >= "27" do
-        :ok
-      else
-        {:skip, "docs query tests require OTP 27 or later"}
-      end
-    end
-
+    @tag :requires_json
     test "prints formatted results for project dependencies" do
       Mix.Project.push(SearchDeps.MixProject)
 
@@ -135,6 +128,7 @@ defmodule Mix.Tasks.Hex.SearchTest do
       end)
     end
 
+    @tag :requires_json
     test "uses explicit package filters" do
       in_tmp(fn ->
         set_home_tmp()
@@ -152,6 +146,7 @@ defmodule Mix.Tasks.Hex.SearchTest do
       end)
     end
 
+    @tag :requires_json
     test "strips html comments from results" do
       in_tmp(fn ->
         set_home_tmp()
@@ -172,6 +167,7 @@ defmodule Mix.Tasks.Hex.SearchTest do
       end)
     end
 
+    @tag :requires_json
     test "uses configurable limit" do
       in_tmp(fn ->
         set_home_tmp()
@@ -217,6 +213,7 @@ defmodule Mix.Tasks.Hex.SearchTest do
       end)
     end
 
+    @tag :requires_json
     test "raises on invalid json" do
       in_tmp(fn ->
         set_home_tmp()

--- a/test/mix/tasks/hex.search_test.exs
+++ b/test/mix/tasks/hex.search_test.exs
@@ -89,6 +89,14 @@ defmodule Mix.Tasks.Hex.SearchTest do
   end
 
   describe "docs query" do
+    setup do
+      if System.otp_release() >= "27" do
+        :ok
+      else
+        {:skip, "docs query tests require OTP 27 or later"}
+      end
+    end
+
     test "prints formatted results for project dependencies" do
       Mix.Project.push(SearchDeps.MixProject)
 
@@ -118,7 +126,7 @@ defmodule Mix.Tasks.Hex.SearchTest do
         assert_received {:mix_shell, :info, [message]}
 
         assert message =~
-                 "# cast/4 - https://hexdocs.pm/ecto/3.13.4/Ecto.Changeset.html#cast/4 (1)\n\nCast changesets.\n\n"
+                 "# cast/4 (1/1)\nhttps://hexdocs.pm/ecto/3.13.4/Ecto.Changeset.html#cast/4\n\nCast changesets.\n\n"
       end)
     end
 
@@ -154,7 +162,30 @@ defmodule Mix.Tasks.Hex.SearchTest do
         assert_received {:mix_shell, :info, [message]}
 
         assert message =~
-                 "# Examples - mix deps.tree - https://hexdocs.pm/mix/1.20.0-rc.5/Mix.Tasks.Deps.Tree.html#module-examples (1)\n\nTree docs.\n\n"
+                 "# Examples - mix deps.tree (1/1)\nhttps://hexdocs.pm/mix/1.20.0-rc.5/Mix.Tasks.Deps.Tree.html#module-examples\n\nTree docs.\n\n"
+      end)
+    end
+
+    test "includes the total result count in the heading" do
+      in_tmp(fn ->
+        set_home_tmp()
+
+        mock_search_http(fn _url ->
+          {:ok,
+           {200, %{},
+            ~s({"found":2,"hits":[{"document":{"doc":"First","package":"ecto-3.13.4","ref":"Ecto.Changeset.html#cast/4","title":"cast/4"}},{"document":{"doc":"Second","package":"ecto-3.13.4","ref":"Ecto.Changeset.html#change/2","title":"change/2"}}]})}}
+        end)
+
+        Mix.Tasks.Hex.Search.run(["query", "--packages", "foo"])
+
+        assert_received {:mix_shell, :info, [first]}
+        assert_received {:mix_shell, :info, [second]}
+
+        assert first =~
+                 "# cast/4 (1/2)\nhttps://hexdocs.pm/ecto/3.13.4/Ecto.Changeset.html#cast/4\n\nFirst\n\n"
+
+        assert second =~
+                 "# change/2 (2/2)\nhttps://hexdocs.pm/ecto/3.13.4/Ecto.Changeset.html#change/2\n\nSecond\n\n"
       end)
     end
 
@@ -218,6 +249,20 @@ defmodule Mix.Tasks.Hex.SearchTest do
         end)
 
         assert_raise Mix.Error, ~r/Docs search request failed: :econnrefused/, fn ->
+          Mix.Tasks.Hex.Search.run(["query", "--packages", "foo"])
+        end
+      end)
+    end
+
+    test "raises on invalid json" do
+      in_tmp(fn ->
+        set_home_tmp()
+
+        mock_search_http(fn _url ->
+          {:ok, {200, %{}, "{"}}
+        end)
+
+        assert_raise Mix.Error, ~r/Docs search returned invalid JSON: :unexpected_end/, fn ->
           Mix.Tasks.Hex.Search.run(["query", "--packages", "foo"])
         end
       end)

--- a/test/mix/tasks/hex.search_test.exs
+++ b/test/mix/tasks/hex.search_test.exs
@@ -1,5 +1,8 @@
 defmodule Mix.Tasks.Hex.SearchTest do
   use HexTest.IntegrationCase
+  import Mox
+
+  setup :verify_on_exit!
 
   defmodule SearchDeps.MixProject do
     def project do
@@ -65,6 +68,18 @@ defmodule Mix.Tasks.Hex.SearchTest do
       end)
     end
 
+    test "--packages opens explicit package list" do
+      Mix.Tasks.Hex.Search.run(["--packages", "foo,bar"])
+
+      assert_received {:hex_system_cmd, _, ["https://hexdocs.pm/?packages=foo%2Cbar&q="]}
+    end
+
+    test "--packages with --print-url prints explicit package list" do
+      Mix.Tasks.Hex.Search.run(["--packages", "foo,bar", "--print-url"])
+
+      assert_received {:mix_shell, :info, ["https://hexdocs.pm/?packages=foo%2Cbar&q="]}
+    end
+
     defp write_search_deps do
       set_home_tmp()
       Mix.Dep.Lock.write(%{foo: {:hex, :foo, "0.1.0"}, bar: {:hex, :bar, "0.1.0"}})
@@ -73,56 +88,170 @@ defmodule Mix.Tasks.Hex.SearchTest do
     end
   end
 
-  describe "package" do
-    test "backwards compatibility" do
-      Mix.Tasks.Hex.Search.run(["bloopdoopbloop"])
+  describe "docs query" do
+    test "prints formatted results for project dependencies" do
+      Mix.Project.push(SearchDeps.MixProject)
 
-      assert_received {:mix_shell, :error,
-                       ["mix hex.search PACKAGE is deprecated, use --package PACKAGE instead"]}
-
-      assert_received {:mix_shell, :info, ["No packages found"]}
-    end
-
-    test "no results" do
-      Mix.Tasks.Hex.Search.run(["--package", "bloopdoopbloop"])
-      assert_received {:mix_shell, :info, ["No packages found"]}
-    end
-
-    test "public packages" do
-      Mix.Tasks.Hex.Search.run(["--package", "doc"])
-      assert_received {:mix_shell, :info, ["ex_doc" <> ex_doc]}
-      assert_received {:mix_shell, :info, ["only_doc" <> only_doc]}
-      assert ex_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/ex_doc"
-      assert only_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/only_doc"
-    end
-
-    test "all private packages" do
       in_tmp(fn ->
-        set_home_tmp()
-        auth = Hexpm.new_user("searchuser1", "searchuser1@mail.com", "password", "searchuser1")
-        Hexpm.new_repo("searchrepo1", auth)
-        Hex.State.put(:api_key, auth[:key])
+        write_search_deps()
 
-        Mix.Tasks.Hex.Search.run(["--package", "doc"])
+        mock_search_http(fn url ->
+          assert URI.parse(url).host == "search.hexdocs.pm"
 
-        assert_received {:mix_shell, :info, ["ex_doc" <> ex_doc]}
-        assert_received {:mix_shell, :info, ["only_doc" <> only_doc]}
-        assert ex_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/ex_doc"
-        assert only_doc =~ ~r"\w*0\.1\.0.*http://localhost:4043/packages/only_doc"
+          query = URI.decode_query(URI.parse(url).query)
+          assert query["q"] == "ecto changeset"
+          assert query["query_by"] == "doc,title"
+          refute Map.has_key?(query, "per_page")
+
+          vsn = System.version()
+
+          assert query["filter_by"] ==
+                   "package:=[bar-0.1.0,eex-#{vsn},elixir-#{vsn},ex_unit-#{vsn},foo-0.1.0,iex-#{vsn},logger-#{vsn},mix-#{vsn}]"
+
+          {:ok,
+           {200, %{},
+            ~s({"found":1,"hits":[{"document":{"doc":"Cast changesets.","package":"ecto-3.13.4","ref":"Ecto.Changeset.html#cast/4","title":"cast/4"}}]})}}
+        end)
+
+        Mix.Tasks.Hex.Search.run(["ecto changeset"])
+
+        assert_received {:mix_shell, :info, [message]}
+
+        assert message =~
+                 "# cast/4 - https://hexdocs.pm/ecto/3.13.4/Ecto.Changeset.html#cast/4 (1)\n\nCast changesets.\n\n"
       end)
     end
 
-    test "org packages" do
+    test "uses explicit package filters" do
       in_tmp(fn ->
         set_home_tmp()
-        auth = Hexpm.new_user("searchuser2", "searchuser2@mail.com", "password", "searchuser2")
-        Hexpm.new_repo("searchrepo2", auth)
-        Hex.State.put(:api_key, auth[:key])
 
-        Mix.Tasks.Hex.Search.run(["--package", "doc", "--organization", "searchrepo2"])
+        mock_search_http(fn url ->
+          query = URI.decode_query(URI.parse(url).query)
+          assert query["q"] == "query"
+          assert query["filter_by"] == "package:=[foo-0.1.1,bar-0.1.0]"
+          {:ok, {200, %{}, ~s({"found":0,"hits":[]})}}
+        end)
 
-        refute_received {:mix_shell, :info, ["ex_doc" <> _]}
-        refute_received {:mix_shell, :info, ["only_doc" <> _]}
+        Mix.Tasks.Hex.Search.run(["query", "--packages", "foo,bar"])
+
+        assert_received {:mix_shell, :info, ["No results found"]}
+      end)
+    end
+
+    test "builds urls by splitting package on the first dash" do
+      in_tmp(fn ->
+        set_home_tmp()
+
+        mock_search_http(fn _url ->
+          {:ok,
+           {200, %{},
+            ~s({"found":1,"hits":[{"document":{"doc":"Tree docs.","package":"mix-1.20.0-rc.5","ref":"Mix.Tasks.Deps.Tree.html#module-examples","title":"Examples - mix deps.tree"}}]})}}
+        end)
+
+        Mix.Tasks.Hex.Search.run(["deps tree", "--packages", "mix"])
+
+        assert_received {:mix_shell, :info, [message]}
+
+        assert message =~
+                 "# Examples - mix deps.tree - https://hexdocs.pm/mix/1.20.0-rc.5/Mix.Tasks.Deps.Tree.html#module-examples (1)\n\nTree docs.\n\n"
+      end)
+    end
+
+    test "strips html comments from results" do
+      in_tmp(fn ->
+        set_home_tmp()
+
+        mock_search_http(fn _url ->
+          {:ok,
+           {200, %{},
+            ~s({"found":1,"hits":[{"document":{"doc":"Alpha<!-- internal -->Beta<!-- remove me -->Gamma","package":"ecto-3.13.4","ref":"Ecto.Changeset.html#cast/4","title":"cast/4"}}]})}}
+        end)
+
+        Mix.Tasks.Hex.Search.run(["query", "--packages", "foo"])
+
+        assert_received {:mix_shell, :info, [message]}
+        assert message =~ "\n\nAlphaBetaGamma\n\n"
+        refute message =~ "<!--"
+        refute message =~ "internal"
+        refute message =~ "remove me"
+      end)
+    end
+
+    test "uses configurable limit" do
+      in_tmp(fn ->
+        set_home_tmp()
+
+        mock_search_http(fn url ->
+          query = URI.decode_query(URI.parse(url).query)
+          assert query["q"] == "query"
+          assert query["per_page"] == "25"
+          {:ok, {200, %{}, ~s({"found":0,"hits":[]})}}
+        end)
+
+        Mix.Tasks.Hex.Search.run(["query", "--packages", "foo", "--limit", "25"])
+
+        assert_received {:mix_shell, :info, ["No results found"]}
+      end)
+    end
+
+    test "raises on non-200 responses" do
+      in_tmp(fn ->
+        set_home_tmp()
+
+        mock_search_http(fn _url ->
+          {:ok, {500, %{}, "oops"}}
+        end)
+
+        assert_raise Mix.Error, ~r/Docs search failed with HTTP status 500/, fn ->
+          Mix.Tasks.Hex.Search.run(["query", "--packages", "foo"])
+        end
+      end)
+    end
+
+    test "raises on transport errors" do
+      in_tmp(fn ->
+        set_home_tmp()
+
+        mock_search_http(fn _url ->
+          {:error, :econnrefused}
+        end)
+
+        assert_raise Mix.Error, ~r/Docs search request failed: :econnrefused/, fn ->
+          Mix.Tasks.Hex.Search.run(["query", "--packages", "foo"])
+        end
+      end)
+    end
+
+    test "rejects incompatible query arguments" do
+      assert_raise Mix.Error, ~r/mix hex.search QUERY/, fn ->
+        Mix.Tasks.Hex.Search.run(["query", "--print-url"])
+      end
+
+      assert_raise Mix.Error, ~r/mix hex.search QUERY/, fn ->
+        Mix.Tasks.Hex.Search.run(["--limit", "25"])
+      end
+    end
+
+    test "rejects invalid limits" do
+      assert_raise Mix.Error, ~r/Expected --limit to be between 1 and 250/, fn ->
+        Mix.Tasks.Hex.Search.run(["query", "--limit", "0"])
+      end
+
+      assert_raise Mix.Error, ~r/Expected --limit to be between 1 and 250/, fn ->
+        Mix.Tasks.Hex.Search.run(["query", "--limit", "251"])
+      end
+    end
+
+    defp mock_search_http(fun) do
+      Application.put_env(:hex, :search_http_module, Hex.HTTP.Mock)
+
+      on_exit(fn ->
+        Application.delete_env(:hex, :search_http_module)
+      end)
+
+      expect(Hex.HTTP.Mock, :request, fn :get, url, %{}, nil, %{} ->
+        fun.(url)
       end)
     end
   end

--- a/test/mix/tasks/hex.search_test.exs
+++ b/test/mix/tasks/hex.search_test.exs
@@ -118,15 +118,20 @@ defmodule Mix.Tasks.Hex.SearchTest do
 
           {:ok,
            {200, %{},
-            ~s({"found":1,"hits":[{"document":{"doc":"Cast changesets.","package":"ecto-3.13.4","ref":"Ecto.Changeset.html#cast/4","title":"cast/4"}}]})}}
+            ~s({"found":2,"hits":[{"document":{"doc":"Cast changesets.","package":"ecto-3.13.4","ref":"Ecto.Changeset.html#cast/4","title":"cast/4"}},{"document":{"doc":"Tree docs.","package":"mix-1.20.0-rc.5","ref":"Mix.Tasks.Deps.Tree.html#module-examples","title":"Examples - mix deps.tree"}}]})}}
         end)
 
         Mix.Tasks.Hex.Search.run(["ecto changeset"])
 
-        assert_received {:mix_shell, :info, [message]}
+        assert_received {:mix_shell, :info,
+                         [
+                           "# cast/4 (1/2)\nhttps://hexdocs.pm/ecto/3.13.4/Ecto.Changeset.html#cast/4\n\nCast changesets.\n\n"
+                         ]}
 
-        assert message =~
-                 "# cast/4 (1/1)\nhttps://hexdocs.pm/ecto/3.13.4/Ecto.Changeset.html#cast/4\n\nCast changesets.\n\n"
+        assert_received {:mix_shell, :info,
+                         [
+                           "# Examples - mix deps.tree (2/2)\nhttps://hexdocs.pm/mix/1.20.0-rc.5/Mix.Tasks.Deps.Tree.html#module-examples\n\nTree docs.\n\n"
+                         ]}
       end)
     end
 
@@ -144,48 +149,6 @@ defmodule Mix.Tasks.Hex.SearchTest do
         Mix.Tasks.Hex.Search.run(["query", "--packages", "foo,bar"])
 
         assert_received {:mix_shell, :info, ["No results found"]}
-      end)
-    end
-
-    test "builds urls by splitting package on the first dash" do
-      in_tmp(fn ->
-        set_home_tmp()
-
-        mock_search_http(fn _url ->
-          {:ok,
-           {200, %{},
-            ~s({"found":1,"hits":[{"document":{"doc":"Tree docs.","package":"mix-1.20.0-rc.5","ref":"Mix.Tasks.Deps.Tree.html#module-examples","title":"Examples - mix deps.tree"}}]})}}
-        end)
-
-        Mix.Tasks.Hex.Search.run(["deps tree", "--packages", "mix"])
-
-        assert_received {:mix_shell, :info, [message]}
-
-        assert message =~
-                 "# Examples - mix deps.tree (1/1)\nhttps://hexdocs.pm/mix/1.20.0-rc.5/Mix.Tasks.Deps.Tree.html#module-examples\n\nTree docs.\n\n"
-      end)
-    end
-
-    test "includes the total result count in the heading" do
-      in_tmp(fn ->
-        set_home_tmp()
-
-        mock_search_http(fn _url ->
-          {:ok,
-           {200, %{},
-            ~s({"found":2,"hits":[{"document":{"doc":"First","package":"ecto-3.13.4","ref":"Ecto.Changeset.html#cast/4","title":"cast/4"}},{"document":{"doc":"Second","package":"ecto-3.13.4","ref":"Ecto.Changeset.html#change/2","title":"change/2"}}]})}}
-        end)
-
-        Mix.Tasks.Hex.Search.run(["query", "--packages", "foo"])
-
-        assert_received {:mix_shell, :info, [first]}
-        assert_received {:mix_shell, :info, [second]}
-
-        assert first =~
-                 "# cast/4 (1/2)\nhttps://hexdocs.pm/ecto/3.13.4/Ecto.Changeset.html#cast/4\n\nFirst\n\n"
-
-        assert second =~
-                 "# change/2 (2/2)\nhttps://hexdocs.pm/ecto/3.13.4/Ecto.Changeset.html#change/2\n\nSecond\n\n"
       end)
     end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,4 +1,7 @@
-ExUnit.configure(exclude: [:skip | ExUnit.configuration()[:exclude]])
+exclude =
+  [:skip] ++ if(Code.ensure_loaded?(:json), do: [], else: [:requires_json])
+
+ExUnit.configure(exclude: exclude ++ ExUnit.configuration()[:exclude])
 ExUnit.start()
 Application.ensure_all_started(:bypass)
 


### PR DESCRIPTION
It will search for the given terms and print the results to the terminal.

Package search was moved to `mix hex.package search`, as the API was getting complex (so this should likely be a minor release).