### PR TITLE
Use subdomain URLs for hexpm package docs

### DIFF
--- a/lib/hex/scm.ex
+++ b/lib/hex/scm.ex
@@ -118,7 +118,7 @@ defmodule Hex.SCM do
     end
   end
 
-  # https://hexdocs.pm/mix/Mix.Tasks.Deps.html#module-dependency-definition-options
+  # https://mix.hexdocs.pm/Mix.Tasks.Deps.html#module-dependency-definition-options
   mix_keys = ~w[app env compile optional only targets override manager runtime system_env]a
 
   # https://hex.pm/docs/usage#options

--- a/lib/hex/utils.ex
+++ b/lib/hex/utils.ex
@@ -218,31 +218,37 @@ defmodule Hex.Utils do
 
   def hexdocs_url(organization, package)
       when organization in ["hexpm", nil],
-      do: "https://#{package}.hexdocs.pm"
+      do: "https://#{package_subdomain(package)}.hexdocs.pm"
 
   def hexdocs_url(organization, package),
     do: "https://#{organization}.hexorgs.pm/#{package}"
 
   def hexdocs_url(organization, package, version)
       when organization in ["hexpm", nil],
-      do: "https://#{package}.hexdocs.pm/#{version}"
+      do: "https://#{package_subdomain(package)}.hexdocs.pm/#{version}"
 
   def hexdocs_url(organization, package, version),
     do: "https://#{organization}.hexorgs.pm/#{package}/#{version}"
 
   def hexdocs_module_url(organization, package, module)
       when organization in ["hexpm", nil],
-      do: "https://#{package}.hexdocs.pm/#{module}.html"
+      do: "https://#{package_subdomain(package)}.hexdocs.pm/#{module}.html"
 
   def hexdocs_module_url(organization, package, module),
     do: "https://#{organization}.hexorgs.pm/#{package}/#{module}.html"
 
   def hexdocs_module_url(organization, package, version, module)
       when organization in ["hexpm", nil],
-      do: "https://#{package}.hexdocs.pm/#{version}/#{module}.html"
+      do: "https://#{package_subdomain(package)}.hexdocs.pm/#{version}/#{module}.html"
 
   def hexdocs_module_url(organization, package, version, module),
     do: "https://#{organization}.hexorgs.pm/#{package}/#{version}/#{module}.html"
+
+  # Hex package names allow underscores. RFC 1123 hostname labels and
+  # RFC 6125 wildcard SAN matching don't, so Fastly returns 421 for
+  # underscore subdomains under *.hexdocs.pm. Map `_` -> `-` here; the
+  # Fastly Compute subdomain handler reverses it for the bucket lookup.
+  defp package_subdomain(package), do: String.replace(package, "_", "-")
 
   def package_retirement_reason(:RETIRED_OTHER), do: "other"
   def package_retirement_reason(:RETIRED_INVALID), do: "invalid"

--- a/lib/hex/utils.ex
+++ b/lib/hex/utils.ex
@@ -218,28 +218,28 @@ defmodule Hex.Utils do
 
   def hexdocs_url(organization, package)
       when organization in ["hexpm", nil],
-      do: "https://hexdocs.pm/#{package}"
+      do: "https://#{package}.hexdocs.pm"
 
   def hexdocs_url(organization, package),
     do: "https://#{organization}.hexorgs.pm/#{package}"
 
   def hexdocs_url(organization, package, version)
       when organization in ["hexpm", nil],
-      do: "https://hexdocs.pm/#{package}/#{version}"
+      do: "https://#{package}.hexdocs.pm/#{version}"
 
   def hexdocs_url(organization, package, version),
     do: "https://#{organization}.hexorgs.pm/#{package}/#{version}"
 
   def hexdocs_module_url(organization, package, module)
       when organization in ["hexpm", nil],
-      do: "https://hexdocs.pm/#{package}/#{module}.html"
+      do: "https://#{package}.hexdocs.pm/#{module}.html"
 
   def hexdocs_module_url(organization, package, module),
     do: "https://#{organization}.hexorgs.pm/#{package}/#{module}.html"
 
   def hexdocs_module_url(organization, package, version, module)
       when organization in ["hexpm", nil],
-      do: "https://hexdocs.pm/#{package}/#{version}/#{module}.html"
+      do: "https://#{package}.hexdocs.pm/#{version}/#{module}.html"
 
   def hexdocs_module_url(organization, package, version, module),
     do: "https://#{organization}.hexorgs.pm/#{package}/#{version}/#{module}.html"

--- a/lib/mix/tasks/hex.publish.ex
+++ b/lib/mix/tasks/hex.publish.ex
@@ -23,8 +23,8 @@ defmodule Mix.Tasks.Hex.Publish do
   is the generated documentation located in the `doc/` directory with an
   `index.html` file.
 
-  The documentation will be accessible at `https://hexdocs.pm/my_package/1.0.0`,
-  `https://hexdocs.pm/my_package` will always redirect to the latest published
+  The documentation will be accessible at `https://my_package.hexdocs.pm/1.0.0`,
+  `https://my_package.hexdocs.pm` will always redirect to the latest published
   version.
 
   Documentation will be built and published automatically. To publish a package

--- a/lib/mix/tasks/hex.search.ex
+++ b/lib/mix/tasks/hex.search.ex
@@ -251,7 +251,7 @@ defmodule Mix.Tasks.Hex.Search do
   defp document_url(package, ref) do
     case :binary.split(package, "-") do
       [name, version] ->
-        "https://hexdocs.pm/#{Enum.join([name, version, ref], "/")}"
+        "https://#{name}.hexdocs.pm/#{version}/#{ref}"
 
       _ ->
         Mix.raise("Unexpected package search result format: #{inspect(package)}")

--- a/test/mix/tasks/hex.docs_test.exs
+++ b/test/mix/tasks/hex.docs_test.exs
@@ -350,7 +350,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
         Mix.Dep.Lock.write(%{docs_package: {:hex, :docs_package, "1.1.1"}})
         Mix.Tasks.Hex.Docs.run(["online", "docs_package"])
         assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
-        assert Enum.fetch!(browser_open_cmd, -1) == "https://docs_package.hexdocs.pm/1.1.1"
+        assert Enum.fetch!(browser_open_cmd, -1) == "https://docs-package.hexdocs.pm/1.1.1"
       end)
     end
 
@@ -361,7 +361,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
         Mix.Dep.Lock.write(%{docs_package: {:hex, :docs_package, "1.1.1"}})
         Mix.Tasks.Hex.Docs.run(["online", "docs_package", "--latest"])
         assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
-        assert Enum.fetch!(browser_open_cmd, -1) == "https://docs_package.hexdocs.pm"
+        assert Enum.fetch!(browser_open_cmd, -1) == "https://docs-package.hexdocs.pm"
       end)
     end
 

--- a/test/mix/tasks/hex.docs_test.exs
+++ b/test/mix/tasks/hex.docs_test.exs
@@ -340,7 +340,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
     test "open docs online" do
       Mix.Tasks.Hex.Docs.run(["online", "ecto"])
       assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
-      assert Enum.fetch!(browser_open_cmd, -1) == "https://hexdocs.pm/ecto"
+      assert Enum.fetch!(browser_open_cmd, -1) == "https://ecto.hexdocs.pm"
     end
 
     test "open the version of a package this app uses online" do
@@ -350,7 +350,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
         Mix.Dep.Lock.write(%{docs_package: {:hex, :docs_package, "1.1.1"}})
         Mix.Tasks.Hex.Docs.run(["online", "docs_package"])
         assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
-        assert Enum.fetch!(browser_open_cmd, -1) == "https://hexdocs.pm/docs_package/1.1.1"
+        assert Enum.fetch!(browser_open_cmd, -1) == "https://docs_package.hexdocs.pm/1.1.1"
       end)
     end
 
@@ -361,14 +361,14 @@ defmodule Mix.Tasks.Hex.DocsTest do
         Mix.Dep.Lock.write(%{docs_package: {:hex, :docs_package, "1.1.1"}})
         Mix.Tasks.Hex.Docs.run(["online", "docs_package", "--latest"])
         assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
-        assert Enum.fetch!(browser_open_cmd, -1) == "https://hexdocs.pm/docs_package"
+        assert Enum.fetch!(browser_open_cmd, -1) == "https://docs_package.hexdocs.pm"
       end)
     end
 
     test "open a specific page online using the page option" do
       Mix.Tasks.Hex.Docs.run(["online", "ecto", "--page", "Ecto.Repo"])
       assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
-      assert Enum.fetch!(browser_open_cmd, -1) == "https://hexdocs.pm/ecto/Ecto.Repo.html"
+      assert Enum.fetch!(browser_open_cmd, -1) == "https://ecto.hexdocs.pm/Ecto.Repo.html"
     end
   end
 
@@ -377,7 +377,7 @@ defmodule Mix.Tasks.Hex.DocsTest do
       Mix.Tasks.Hex.Docs.run(["online", "ecto", "--module", "Ecto.Repo"])
       assert_received {:mix_shell, :error, ["--module is deprecated, use --page instead"]}
       assert_received {:hex_system_cmd, _cmd, browser_open_cmd}
-      assert Enum.fetch!(browser_open_cmd, -1) == "https://hexdocs.pm/ecto/Ecto.Repo.html"
+      assert Enum.fetch!(browser_open_cmd, -1) == "https://ecto.hexdocs.pm/Ecto.Repo.html"
     end
 
     @tag mirror: true

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -237,7 +237,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
 
         refute_received {:mix_shell, :info,
                          [
-                           "Docs will soon be available at https://hexdocs.pm/invalid_filename/0.1.0"
+                           "Docs will soon be available at https://invalid_filename.hexdocs.pm/0.1.0"
                          ]}
       end
     end)
@@ -258,7 +258,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
 
         refute_received {:mix_shell, :info,
                          [
-                           "Docs will soon be available at https://hexdocs.pm/invalid_dirname/0.1.0"
+                           "Docs will soon be available at https://invalid_dirname.hexdocs.pm/0.1.0"
                          ]}
       end
     end)
@@ -278,7 +278,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
         Mix.Tasks.Hex.Publish.run(["docs", "--no-progress", "--replace"])
 
         refute_received {:mix_shell, :info,
-                         ["Docs will soon be available at https://hexdocs.pm/ex_doc/0.1.0"]}
+                         ["Docs will soon be available at https://ex_doc.hexdocs.pm/0.1.0"]}
       end
     end)
   end

--- a/test/mix/tasks/hex.publish_test.exs
+++ b/test/mix/tasks/hex.publish_test.exs
@@ -237,7 +237,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
 
         refute_received {:mix_shell, :info,
                          [
-                           "Docs will soon be available at https://invalid_filename.hexdocs.pm/0.1.0"
+                           "Docs will soon be available at https://invalid-filename.hexdocs.pm/0.1.0"
                          ]}
       end
     end)
@@ -258,7 +258,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
 
         refute_received {:mix_shell, :info,
                          [
-                           "Docs will soon be available at https://invalid_dirname.hexdocs.pm/0.1.0"
+                           "Docs will soon be available at https://invalid-dirname.hexdocs.pm/0.1.0"
                          ]}
       end
     end)
@@ -278,7 +278,7 @@ defmodule Mix.Tasks.Hex.PublishTest do
         Mix.Tasks.Hex.Publish.run(["docs", "--no-progress", "--replace"])
 
         refute_received {:mix_shell, :info,
-                         ["Docs will soon be available at https://ex_doc.hexdocs.pm/0.1.0"]}
+                         ["Docs will soon be available at https://ex-doc.hexdocs.pm/0.1.0"]}
       end
     end)
   end

--- a/test/mix/tasks/hex.search_test.exs
+++ b/test/mix/tasks/hex.search_test.exs
@@ -118,12 +118,12 @@ defmodule Mix.Tasks.Hex.SearchTest do
 
         assert_received {:mix_shell, :info,
                          [
-                           "# cast/4 (1/2)\nhttps://hexdocs.pm/ecto/3.13.4/Ecto.Changeset.html#cast/4\n\nCast changesets.\n\n"
+                           "# cast/4 (1/2)\nhttps://ecto.hexdocs.pm/3.13.4/Ecto.Changeset.html#cast/4\n\nCast changesets.\n\n"
                          ]}
 
         assert_received {:mix_shell, :info,
                          [
-                           "# Examples - mix deps.tree (2/2)\nhttps://hexdocs.pm/mix/1.20.0-rc.5/Mix.Tasks.Deps.Tree.html#module-examples\n\nTree docs.\n\n"
+                           "# Examples - mix deps.tree (2/2)\nhttps://mix.hexdocs.pm/1.20.0-rc.5/Mix.Tasks.Deps.Tree.html#module-examples\n\nTree docs.\n\n"
                          ]}
       end)
     end


### PR DESCRIPTION
Switch hexpm-repo docs URLs the CLI emits from `https://hexdocs.pm/PACKAGE/...` to `https://PACKAGE.hexdocs.pm/...`. Org-repo URLs (`*.hexorgs.pm`) are unchanged.

Phase 3 of the hexdocs subdomain migration. The apex `https://hexdocs.pm/PACKAGE/...` URLs continue to work via a 301 to the subdomain (`Hex.HTTP` follows up to 3 redirects), so pre-existing CLIs are unaffected.

Changes:
- `lib/hex/utils.ex` — four `hexdocs_url`/`hexdocs_module_url` hexpm-repo clauses switched to subdomain form.
- `lib/mix/tasks/hex.search.ex` — `document_url/2` per-result URL switched to subdomain form. The apex search-landing-page URL (`https://hexdocs.pm/?packages=...&q=`) is unchanged; the search page lives at the apex.
- `lib/mix/tasks/hex.publish.ex` — docstring updated to describe new URL scheme.
- `lib/hex/scm.ex` — doc-link comment updated for consistency.
- Tests updated to assert the new URL format.