### PR TITLE
Warn when the OAuth session cannot be refreshed

### DIFF
--- a/lib/hex/oauth.ex
+++ b/lib/hex/oauth.ex
@@ -61,6 +61,7 @@ defmodule Hex.OAuth do
         if Keyword.get(opts, :prompt_auth, false) do
           reauthenticate("Token refresh failed. Re-authenticating...")
         else
+          warn_unusable_token()
           {:error, :refresh_failed}
         end
 
@@ -68,9 +69,23 @@ defmodule Hex.OAuth do
         if Keyword.get(opts, :prompt_auth, false) do
           reauthenticate("Access token expired and could not be refreshed. Re-authenticating...")
         else
+          warn_unusable_token()
           {:error, :no_refresh_token}
         end
     end
+  end
+
+  # Runs at most once per VM: the refresh result, including errors, is
+  # cached in the OnceCache. Without this warning an expired session
+  # degrades silently — requests are sent without credentials and
+  # private resources fail with errors that look like permission
+  # problems.
+  defp warn_unusable_token() do
+    Hex.Shell.warn(
+      "Your authentication session has expired and could not be refreshed. " <>
+        "Continuing without credentials, requests for private resources will fail. " <>
+        "Run `mix hex.user auth` to re-authenticate"
+    )
   end
 
   defp reauthenticate(message) do

--- a/test/hex/oauth_test.exs
+++ b/test/hex/oauth_test.exs
@@ -31,6 +31,9 @@ defmodule Hex.OAuthTest do
       Hex.OAuth.store_token(token_data)
 
       assert {:error, :no_refresh_token} = Hex.OAuth.get_token()
+      assert_received {:mix_shell, :info, [warning]}
+      assert warning =~ "could not be refreshed"
+      assert warning =~ "mix hex.user auth"
     end
 
     test "returns error when token is expired and refresh fails" do
@@ -46,6 +49,33 @@ defmodule Hex.OAuthTest do
 
       # Should fail to refresh and return error
       assert {:error, :refresh_failed} = Hex.OAuth.get_token()
+      assert_received {:mix_shell, :info, [warning]}
+      assert warning =~ "could not be refreshed"
+      assert warning =~ "mix hex.user auth"
+    end
+
+    test "warns only once when the cached refresh failure is hit repeatedly" do
+      past_time = System.system_time(:second) - 100
+
+      token_data = %{
+        "access_token" => "expired_token",
+        "refresh_token" => "invalid_refresh_token",
+        "expires_at" => past_time
+      }
+
+      Hex.OAuth.store_token(token_data)
+
+      assert {:error, :refresh_failed} = Hex.OAuth.get_token()
+      assert {:error, :refresh_failed} = Hex.OAuth.get_token()
+
+      assert_received {:mix_shell, :info, [warning]}
+      assert warning =~ "could not be refreshed"
+      refute_received {:mix_shell, :info, _}
+    end
+
+    test "does not warn when no tokens are stored" do
+      assert {:error, :no_auth} = Hex.OAuth.get_token()
+      refute_received {:mix_shell, :info, _}
     end
   end
 


### PR DESCRIPTION
When the stored access token has expired and the refresh fails (for example because the refresh token was consumed by a rotation from another process or revoked by a re-authentication), repo requests were silently sent without credentials. Public resources still resolve, so the broken session goes unnoticed until a private resource fails with an error that reads like a permission problem.

Warn once per invocation - the refresh result is cached in the OnceCache, so the warning naturally fires at most once - and tell the user to run mix hex.user auth. Fully anonymous use (no stored tokens) stays silent.