### PR TITLE
Deprecate personal-key access to organization repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## v2.4.3-dev
 
+### Deprecations
+
+* Deprecate `mix hex.organization auth ORGANIZATION` without `--key`; authenticate as a user with `mix hex.user auth` instead, or pass a pre-generated organization key with `--key` for CI
+* Deprecate authenticating to organization repositories with a stored key; a future release will require `mix hex.user auth` or a short-lived organization token
+* Deprecate `HEX_REPOS_KEY`; authenticate per organization with `mix hex.organization auth ORGANIZATION --key KEY`
+
 ## v2.4.2 (2026-04-30)
 
 ### Enhancements

--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -324,6 +324,8 @@ defmodule Hex.Repo do
         # Second priority: Exchange API key for OAuth token if enabled
         repo_config.auth_key && Map.get(repo_config, :trusted, true) &&
             Map.get(repo_config, :oauth_exchange, false) ->
+          maybe_warn_deprecated_repo_key(repo_name, repo_config)
+
           case exchange_api_key_for_token(repo_config, repo_name) do
             {:ok, access_token} ->
               %{config | repo_key: "Bearer #{access_token}"}
@@ -389,6 +391,56 @@ defmodule Hex.Repo do
 
       _ ->
         :not_found
+    end
+  end
+
+  defp maybe_warn_deprecated_repo_key(repo_name, repo_config) do
+    if hexpm_repo_name?(repo_name) do
+      case deprecated_repo_key_source(repo_config) do
+        :env ->
+          if Hex.Server.should_warn?(:deprecated_repos_key) do
+            Hex.Shell.warn("""
+            HEX_REPOS_KEY is deprecated and will be removed.
+
+            For development authenticate as a user with `mix hex.user auth`. For CI \
+            authenticate per organization with `mix hex.organization auth ORGANIZATION --key KEY`.
+            """)
+          end
+
+        :config ->
+          organization = repo_organization(repo_name)
+
+          if Hex.Server.should_warn?({:deprecated_repo_key, organization}) do
+            Hex.Shell.warn("""
+            Authenticating to the #{organization} repository with a stored key is deprecated \
+            and will be removed.
+
+            For development authenticate as a user with `mix hex.user auth`. For CI generate an \
+            organization key with `mix hex.organization key #{organization} generate` and pass it \
+            with `mix hex.organization auth #{organization} --key KEY`.
+            """)
+          end
+      end
+    end
+  end
+
+  defp hexpm_repo_name?("hexpm"), do: true
+  defp hexpm_repo_name?("hexpm:" <> _), do: true
+  defp hexpm_repo_name?(_), do: false
+
+  defp repo_organization("hexpm:" <> organization), do: organization
+  defp repo_organization("hexpm"), do: "hexpm"
+
+  # HEX_REPOS_KEY is exposed as the hexpm source `auth_key` and inherited by
+  # `hexpm:*` repos, so an `auth_key` equal to `repos_key` came from the
+  # environment, while any other value was stored in the local config.
+  defp deprecated_repo_key_source(repo_config) do
+    repos_key = Hex.State.fetch!(:repos_key)
+
+    if repos_key != nil and repo_config.auth_key == repos_key do
+      :env
+    else
+      :config
     end
   end
 

--- a/lib/hex/server.ex
+++ b/lib/hex/server.ex
@@ -22,6 +22,10 @@ defmodule Hex.Server do
     GenServer.call(name, :should_warn_registry_version?)
   end
 
+  def should_warn?(key, name \\ @name) do
+    GenServer.call(name, {:should_warn?, key})
+  end
+
   def init([]) do
     {:ok, state()}
   end
@@ -50,10 +54,19 @@ defmodule Hex.Server do
     {:reply, false, state}
   end
 
+  def handle_call({:should_warn?, key}, _from, state) do
+    if MapSet.member?(state.warned, key) do
+      {:reply, false, state}
+    else
+      {:reply, true, %{state | warned: MapSet.put(state.warned, key)}}
+    end
+  end
+
   defp state() do
     %{
       warned_lock_version: false,
-      warned_registry_version: false
+      warned_registry_version: false,
+      warned: MapSet.new()
     }
   end
 end

--- a/lib/mix/tasks/hex.organization.ex
+++ b/lib/mix/tasks/hex.organization.ex
@@ -11,12 +11,17 @@ defmodule Mix.Tasks.Hex.Organization do
 
   By default you will be authorized to all your applications when running
   `mix hex.user auth` and this is the recommended approach. This task is mainly
-  provided for a CI and build systems where access to an organization is needed
+  provided for CI and build systems where access to an organization is needed
   without authorizing a user.
 
-  By authorizing a new organization a new key is created for fetching packages
-  from the organizations repository and the repository key is stored on the
-  local machine.
+  For CI, generate an organization key with `mix hex.organization key ORGANIZATION generate`
+  and pass it with `mix hex.organization auth ORGANIZATION --key KEY`.
+
+  > #### Deprecation {: .warning}
+  >
+  > Authorizing an organization without `--key` is deprecated and will be removed.
+  > It creates a user key tied to your account; use `mix hex.user auth` for
+  > development instead, or pass a pre-generated organization key with `--key` for CI.
 
   To use a package from an organization add `organization: "my_organization"` to the
   dependency declaration in `mix.exs`:
@@ -79,7 +84,8 @@ defmodule Mix.Tasks.Hex.Organization do
     * `--key KEY` - Hash of key used to authenticate HTTP requests to repository, if
       omitted will generate a new key with your account credentials. This flag
       is useful if you have a key pre-generated with `mix hex.organization key`
-      and want to authenticate on a CI server or similar system
+      and want to authenticate on a CI server or similar system. Omitting `--key`
+      is deprecated; authenticate as a user with `mix hex.user auth` instead
 
     * `--key-name KEY_NAME` - By default Hex will base the key name on your machine's
       hostname and the organization name, use this option to give your own name.
@@ -166,6 +172,20 @@ defmodule Mix.Tasks.Hex.Organization do
         test_key(key, organization)
         key
       else
+        Hex.Shell.warn("""
+        Authorizing an organization without --key is deprecated and will be removed.
+
+        For development authenticate as a user instead, which gives you access to \
+        all your organizations:
+
+            mix hex.user auth
+
+        For CI generate an organization key and pass it with --key:
+
+            mix hex.organization key #{organization} generate
+            mix hex.organization auth #{organization} --key KEY
+        """)
+
         key_name = Mix.Tasks.Hex.repository_key_name(organization, opts[:key_name])
         permissions = [%{"domain" => "repository", "resource" => organization}]
         auth = Mix.Tasks.Hex.auth_info(:write)

--- a/test/hex/repo_test.exs
+++ b/test/hex/repo_test.exs
@@ -95,6 +95,57 @@ defmodule Hex.RepoTest do
     end)
   end
 
+  test "warns about deprecation when a stored key authenticates to a hexpm repository" do
+    Hex.Server.reset()
+
+    auth =
+      HexTest.Hexpm.new_user(
+        "stored_repo_key_user",
+        "stored_repo_key@example.com",
+        "password",
+        "stored_repo_key_key"
+      )
+
+    repos = Hex.State.fetch!(:repos)
+    hexpm = %{repos["hexpm"] | auth_key: auth[:key], oauth_exchange: true}
+    Hex.State.put(:repos, %{repos | "hexpm" => hexpm})
+
+    # The exchange outcome is irrelevant; the warning is emitted before the
+    # stored key is exchanged.
+    try do
+      Hex.Repo.get_package("hexpm", "postgrex", "")
+    rescue
+      _ -> :ok
+    end
+
+    output = Case.shell_output()
+    assert output =~ "stored key is deprecated"
+    assert output =~ "mix hex.user auth"
+  end
+
+  test "warns about deprecation when HEX_REPOS_KEY authenticates to a hexpm repository" do
+    Hex.Server.reset()
+
+    auth =
+      HexTest.Hexpm.new_user(
+        "repos_key_user",
+        "repos_key@example.com",
+        "password",
+        "repos_key_key"
+      )
+
+    Hex.State.put(:repos_key, auth[:key])
+
+    try do
+      Hex.Repo.get_package("hexpm", "postgrex", "")
+    rescue
+      _ -> :ok
+    end
+
+    output = Case.shell_output()
+    assert output =~ "HEX_REPOS_KEY is deprecated"
+  end
+
   test "does not attempt oauth exchange when oauth_exchange is not set" do
     # Simulates a repo configured before v2.4.0 (no oauth_exchange key).
     # If oauth exchange were attempted with an invalid key it would raise.

--- a/test/hex/server_test.exs
+++ b/test/hex/server_test.exs
@@ -12,4 +12,19 @@ defmodule Hex.ServerTest do
     assert Hex.Server.should_warn_registry_version?(pid)
     refute Hex.Server.should_warn_registry_version?(pid)
   end
+
+  test "should_warn?/1 returns true only once per key" do
+    {:ok, pid} = Hex.Server.start_link(name: nil)
+    assert Hex.Server.should_warn?(:one, pid)
+    refute Hex.Server.should_warn?(:one, pid)
+    assert Hex.Server.should_warn?(:two, pid)
+    refute Hex.Server.should_warn?(:two, pid)
+  end
+
+  test "should_warn?/1 tracks keys independently" do
+    {:ok, pid} = Hex.Server.start_link(name: nil)
+    assert Hex.Server.should_warn?({:repo, "acme"}, pid)
+    assert Hex.Server.should_warn?({:repo, "other"}, pid)
+    refute Hex.Server.should_warn?({:repo, "acme"}, pid)
+  end
 end

--- a/test/mix/tasks/hex.organization_test.exs
+++ b/test/mix/tasks/hex.organization_test.exs
@@ -26,6 +26,26 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
     end)
   end
 
+  test "auth without --key warns about deprecation" do
+    in_tmp(fn ->
+      set_home_cwd()
+      auth = Hexpm.new_user("orgauthdeprecated", "orgauthdeprecated@mail.com", "password", "key")
+      Hex.State.put(:api_key, auth[:key])
+      Hexpm.new_repo("myorgauthdeprecated", auth)
+
+      send(self(), {:mix_shell_input, :yes?, true})
+      send(self(), {:mix_shell_input, :prompt, "password"})
+      Mix.Tasks.Hex.Organization.run(["auth", "myorgauthdeprecated"])
+
+      output = Case.shell_output()
+      assert output =~ "deprecated"
+      assert output =~ "mix hex.user auth"
+
+      # Still authorizes (warning only, no behavior change)
+      assert is_binary(Hex.Repo.get_repo("hexpm:myorgauthdeprecated").auth_key)
+    end)
+  end
+
   test "auth with --keyname" do
     in_tmp(fn ->
       set_home_cwd()

--- a/test/support/case.ex
+++ b/test/support/case.ex
@@ -21,6 +21,19 @@ defmodule HexTest.Case do
     end
   end
 
+  @doc """
+  Drains all pending `Mix.Shell.Process` messages and joins the `:info` and
+  `:error` output into a single string for substring assertions.
+  """
+  def shell_output do
+    flush()
+    |> Enum.flat_map(fn
+      {:mix_shell, kind, args} when kind in [:info, :error] -> [IO.chardata_to_string(args)]
+      _ -> []
+    end)
+    |> Enum.join("\n")
+  end
+
   def tmp_path() do
     Path.expand("../../tmp", __DIR__)
   end


### PR DESCRIPTION
Deprecates the ways of authenticating to organization repositories that rely on a long-lived key stored on (or read from) the local machine, in favour of user authentication and short-lived organization tokens. This release only emits warnings — the deprecated paths still work unchanged, and a future release will remove them.

### Deprecated → replacement

- **`mix hex.organization auth ORGANIZATION` without `--key`** — creates a user-owned `repository:ORGANIZATION` key tied to your account.
  - For development, run `mix hex.user auth`, which grants access to the repositories of all organizations you are a member of.
  - For CI, generate an organization-owned key with `mix hex.organization key ORGANIZATION generate` and pass it with `mix hex.organization auth ORGANIZATION --key KEY`.
- **Authenticating to a repository with a stored key** — a repository key persisted in `hex.config` (e.g. written by an earlier `mix hex.organization auth`).
  - Use `mix hex.user auth` for development, or `mix hex.organization auth ORGANIZATION --key KEY` for CI.
- **`HEX_REPOS_KEY`** — a long-lived key supplied via the environment.
  - Authenticate per organization with `mix hex.organization auth ORGANIZATION --key KEY`.

Each warning is emitted at most once per invocation. There is no behaviour change in this release: every deprecated path continues to work.
