### PR TITLE
Fix crash when a server sends an x-hex-message header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bug fixes
 
 * Fix a crash when a server responds with an `x-hex-message` header
+* Escape terminal control sequences in server-provided `x-hex-message` headers
 
 ## v2.4.2 (2026-04-30)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 * Deprecate authenticating to organization repositories with a stored key; a future release will require `mix hex.user auth` or a short-lived organization token
 * Deprecate `HEX_REPOS_KEY`; authenticate per organization with `mix hex.organization auth ORGANIZATION --key KEY`
 
+### Bug fixes
+
+* Fix a crash when a server responds with an `x-hex-message` header
+
 ## v2.4.2 (2026-04-30)
 
 ### Enhancements

--- a/lib/hex/http.ex
+++ b/lib/hex/http.ex
@@ -402,7 +402,7 @@ defmodule Hex.HTTP do
   end
 
   def handle_hex_message(header) do
-    {message, level} = :binary.list_to_bin(header) |> parse_hex_message
+    {message, level} = IO.iodata_to_binary(header) |> parse_hex_message
 
     case level do
       "warn" -> Hex.Shell.info("API warning: " <> message)

--- a/lib/hex/http.ex
+++ b/lib/hex/http.ex
@@ -403,6 +403,7 @@ defmodule Hex.HTTP do
 
   def handle_hex_message(header) do
     {message, level} = IO.iodata_to_binary(header) |> parse_hex_message
+    message = Hex.Utils.escape_terminal(message)
 
     case level do
       "warn" -> Hex.Shell.info("API warning: " <> message)

--- a/lib/hex/utils.ex
+++ b/lib/hex/utils.ex
@@ -111,6 +111,37 @@ defmodule Hex.Utils do
     end
   end
 
+  # Unicode bidirectional formatting characters that can reorder displayed text.
+  @bidi_controls [0x061C, 0x202A, 0x202B, 0x202C, 0x202D, 0x202E, 0x2066, 0x2067, 0x2068, 0x2069]
+
+  # Escapes characters that could manipulate the terminal when printing an
+  # untrusted string. Printable characters, newlines and tabs are kept as-is;
+  # ANSI escapes, bidirectional overrides and other control characters are
+  # rendered as visible escape sequences.
+  def escape_terminal(binary) when is_binary(binary) do
+    binary
+    |> String.to_charlist()
+    |> Enum.map_join(&escape_terminal_char/1)
+  end
+
+  defp escape_terminal_char(?\n), do: "\n"
+  defp escape_terminal_char(?\t), do: "\t"
+  defp escape_terminal_char(?\e), do: "\\e"
+  defp escape_terminal_char(?\r), do: "\\r"
+  defp escape_terminal_char(?\b), do: "\\b"
+  defp escape_terminal_char(?\a), do: "\\a"
+  defp escape_terminal_char(cp) when cp in @bidi_controls, do: unicode_escape(cp)
+  defp escape_terminal_char(cp) when cp < 0x20, do: hex_escape(cp)
+  defp escape_terminal_char(0x7F), do: hex_escape(0x7F)
+  defp escape_terminal_char(cp) when cp in 0x80..0x9F, do: unicode_escape(cp)
+  defp escape_terminal_char(cp), do: <<cp::utf8>>
+
+  defp unicode_escape(cp), do: "\\u{" <> Integer.to_string(cp, 16) <> "}"
+
+  defp hex_escape(cp) do
+    "\\x" <> (cp |> Integer.to_string(16) |> String.pad_leading(2, "0"))
+  end
+
   def binarify(term, opts \\ [])
 
   def binarify(binary, _opts) when is_binary(binary) do

--- a/test/hex/http_test.exs
+++ b/test/hex/http_test.exs
@@ -59,6 +59,11 @@ defmodule Hex.HTTPTest do
     assert_received {:mix_shell, :info, ["API warning: oops, you done goofed"]}
   end
 
+  test "x-hex-message escapes terminal control sequences from the server" do
+    Hex.HTTP.handle_hex_message("\"danger\e[31m\u{202E}\";level=fatal")
+    assert_received {:mix_shell, :error, ["API error: danger\\e[31m\\u{202E}"]}
+  end
+
   test "request emits the x-hex-message response header", %{bypass: bypass} do
     # handle_response/3 runs inside Task.async, so route shell output to the test process
     Hex.State.put(:shell_process, self())

--- a/test/hex/http_test.exs
+++ b/test/hex/http_test.exs
@@ -53,6 +53,10 @@ defmodule Hex.HTTPTest do
 
     Hex.HTTP.handle_hex_message(~c"\"oops, you done goofed\";level=fatal  ")
     assert_received {:mix_shell, :error, ["API error: oops, you done goofed"]}
+
+    # Headers decoded from a real response arrive as binaries, not charlists
+    Hex.HTTP.handle_hex_message("\"oops, you done goofed\" ; level = warn")
+    assert_received {:mix_shell, :info, ["API warning: oops, you done goofed"]}
   end
 
   test "request adds no authorization header if none is given and no netrc is found", %{

--- a/test/hex/http_test.exs
+++ b/test/hex/http_test.exs
@@ -59,6 +59,22 @@ defmodule Hex.HTTPTest do
     assert_received {:mix_shell, :info, ["API warning: oops, you done goofed"]}
   end
 
+  test "request emits the x-hex-message response header", %{bypass: bypass} do
+    # handle_response/3 runs inside Task.async, so route shell output to the test process
+    Hex.State.put(:shell_process, self())
+
+    Bypass.expect(bypass, fn conn ->
+      conn
+      |> Plug.Conn.put_resp_header("x-hex-message", "\"heads up\";level=warn")
+      |> Plug.Conn.resp(200, "")
+    end)
+
+    assert {:ok, {200, _headers, _body}} =
+             Hex.HTTP.request(:get, "http://localhost:#{bypass.port}", %{}, nil)
+
+    assert_received {:mix_shell, :info, ["API warning: heads up"]}
+  end
+
   test "request adds no authorization header if none is given and no netrc is found", %{
     bypass: bypass
   } do

--- a/test/hex/utils_test.exs
+++ b/test/hex/utils_test.exs
@@ -81,6 +81,27 @@ defmodule Hex.UtilsTest do
     end
   end
 
+  describe "escape_terminal/1" do
+    test "keeps printable text, newlines and tabs" do
+      assert Hex.Utils.escape_terminal("hello world") == "hello world"
+      assert Hex.Utils.escape_terminal("café ☃") == "café ☃"
+      assert Hex.Utils.escape_terminal("line1\nline2\tend") == "line1\nline2\tend"
+    end
+
+    test "escapes ANSI escapes and other control characters" do
+      assert Hex.Utils.escape_terminal("\e[31mred\e[0m") == "\\e[31mred\\e[0m"
+      assert Hex.Utils.escape_terminal("a\rb\bc\ad") == "a\\rb\\bc\\ad"
+      assert Hex.Utils.escape_terminal(<<0x01, 0x1F>>) == "\\x01\\x1F"
+      assert Hex.Utils.escape_terminal(<<0x7F>>) == "\\x7F"
+    end
+
+    test "escapes bidirectional overrides and C1 control characters" do
+      assert Hex.Utils.escape_terminal("a\u{202E}b") == "a\\u{202E}b"
+      assert Hex.Utils.escape_terminal("\u{2066}") == "\\u{2066}"
+      assert Hex.Utils.escape_terminal(<<0x85::utf8>>) == "\\u{85}"
+    end
+  end
+
   defp render(advisory, line_prefix \\ "") do
     advisory
     |> Hex.Utils.format_advisory_ansi(line_prefix)


### PR DESCRIPTION
`Hex.HTTP.handle_hex_message/1` is meant to surface `x-hex-message` headers from the server (e.g. deprecation notices) as `API warning:` / `API error:` output. It runs `:binary.list_to_bin/1` on the header value, which requires a charlist — but `decode_header/1` converts every response header value to a binary via `List.to_string/1`. So any real `x-hex-message` header raises `ArgumentError: not an iodata term` inside the HTTP task and fails the request (e.g. `mix deps.get`).

No hex.pm endpoint currently sends `x-hex-message`, so the bug has been latent — the existing test only exercised the function with charlists. This switches to `IO.iodata_to_binary/1`, which accepts both binaries (the real path) and charlists (the existing test path), and adds a binary regression case.
