### PR TITLE
DO NOT MERGE: Require an organization key and store short-lived tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## v2.4.3-dev
 
+### Breaking changes
+
+* `mix hex.organization auth ORGANIZATION` now requires `--key`; for development authenticate as a user with `mix hex.user auth`, which grants access to all your organizations
+* `mix hex.organization auth ORGANIZATION --key KEY` now exchanges the key for a short-lived token and stores only the token, not the key
+* Organization repositories no longer authenticate with a stored API key; they use the short-lived token from `mix hex.organization auth --key` or your `mix hex.user auth` authentication
+* `HEX_REPOS_KEY` no longer grants access to organization repositories; authenticate with `mix hex.organization auth ORGANIZATION --key KEY`
+
 ### Deprecations
 
 * Deprecate `mix hex.organization auth ORGANIZATION` without `--key`; authenticate as a user with `mix hex.user auth` instead, or pass a pre-generated organization key with `--key` for CI

--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -910,6 +910,6 @@ defmodule Hex.RemoteConverger do
   end
 
   defp repo_uses_user_oauth?(repo_config) do
-    Map.get(repo_config, :trusted, true) && !repo_config.auth_key
+    Map.get(repo_config, :trusted, true) and not Hex.Repo.valid_oauth_token?(repo_config)
   end
 end

--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -316,16 +316,22 @@ defmodule Hex.Repo do
 
     config =
       cond do
-        # First priority: explicit repo auth key with OAuth exchange disabled - use API key directly
+        # Organization repos use a short-lived token cached by
+        # `mix hex.organization auth --key`, falling back to the user's OAuth
+        # token. A stored API key is no longer used for organization repos.
+        organization_repo_name?(repo_name) ->
+          organization_repo_key(config, repo_name, repo_config)
+
+        # Explicit repo auth key with OAuth exchange disabled - use API key directly
         repo_config.auth_key && Map.get(repo_config, :trusted, true) &&
             !Map.get(repo_config, :oauth_exchange, false) ->
           %{config | repo_key: repo_config.auth_key}
 
-        # Second priority: Exchange API key for OAuth token if enabled
+        # Exchange API key for OAuth token if enabled. Used by the base hexpm
+        # repo (including trusted mirrors authenticated with HEX_REPOS_KEY) and
+        # custom repos that opt into the exchange.
         repo_config.auth_key && Map.get(repo_config, :trusted, true) &&
             Map.get(repo_config, :oauth_exchange, false) ->
-          maybe_warn_deprecated_repo_key(repo_name, repo_config)
-
           case exchange_api_key_for_token(repo_config, repo_name) do
             {:ok, access_token} ->
               %{config | repo_key: "Bearer #{access_token}"}
@@ -334,9 +340,8 @@ defmodule Hex.Repo do
               raise "Failed to exchange API key for OAuth token: #{inspect(reason)}"
           end
 
-        # Third priority: fallback to OAuth token if available, but only for
-        # trusted repos. Untrusted mirrors/custom repos must not receive the
-        # user bearer token.
+        # Fallback to OAuth token if available, but only for trusted repos.
+        # Untrusted mirrors/custom repos must not receive the user bearer token.
         Map.get(repo_config, :trusted, true) ->
           case Hex.OAuth.get_token() do
             {:ok, access_token} ->
@@ -394,53 +399,54 @@ defmodule Hex.Repo do
     end
   end
 
-  defp maybe_warn_deprecated_repo_key(repo_name, repo_config) do
-    if hexpm_repo_name?(repo_name) do
-      case deprecated_repo_key_source(repo_config) do
-        :env ->
-          if Hex.Server.should_warn?(:deprecated_repos_key) do
-            Hex.Shell.warn("""
-            HEX_REPOS_KEY is deprecated and will be removed.
+  @doc false
+  def valid_oauth_token?(repo_config) do
+    match?({:ok, _}, get_cached_token(repo_config))
+  end
 
-            For development authenticate as a user with `mix hex.user auth`. For CI \
-            authenticate per organization with `mix hex.organization auth ORGANIZATION --key KEY`.
-            """)
-          end
+  defp organization_repo_name?("hexpm:" <> _), do: true
+  defp organization_repo_name?(_), do: false
 
-        :config ->
-          organization = repo_organization(repo_name)
+  defp organization_repo_key(config, "hexpm:" <> organization, repo_config) do
+    case get_cached_token(repo_config) do
+      {:ok, access_token} ->
+        %{config | repo_key: "Bearer #{access_token}"}
 
-          if Hex.Server.should_warn?({:deprecated_repo_key, organization}) do
-            Hex.Shell.warn("""
-            Authenticating to the #{organization} repository with a stored key is deprecated \
-            and will be removed.
+      _expired_or_not_found ->
+        case Hex.OAuth.get_token() do
+          {:ok, access_token} ->
+            %{config | repo_key: "Bearer #{access_token}"}
 
-            For development authenticate as a user with `mix hex.user auth`. For CI generate an \
-            organization key with `mix hex.organization key #{organization} generate` and pass it \
-            with `mix hex.organization auth #{organization} --key KEY`.
-            """)
-          end
-      end
+          {:error, _reason} ->
+            warn_missing_organization_auth(organization, repo_config)
+            config
+        end
     end
   end
 
-  defp hexpm_repo_name?("hexpm"), do: true
-  defp hexpm_repo_name?("hexpm:" <> _), do: true
-  defp hexpm_repo_name?(_), do: false
+  # Only warns when the organization repository actually has no usable
+  # authentication. HEX_REPOS_KEY is called out only here, where it no longer
+  # works (organization access); it still authenticates the base hexpm repo and
+  # trusted mirrors, which never reach this branch.
+  defp warn_missing_organization_auth(organization, repo_config) do
+    if Hex.Server.should_warn?({:organization_auth, organization}) do
+      repos_key = Hex.State.fetch!(:repos_key)
 
-  defp repo_organization("hexpm:" <> organization), do: organization
-  defp repo_organization("hexpm"), do: "hexpm"
+      reason =
+        if repos_key != nil and repo_config.auth_key == repos_key do
+          "HEX_REPOS_KEY no longer grants access to the #{organization} repository."
+        else
+          "Not authenticated to the #{organization} repository."
+        end
 
-  # HEX_REPOS_KEY is exposed as the hexpm source `auth_key` and inherited by
-  # `hexpm:*` repos, so an `auth_key` equal to `repos_key` came from the
-  # environment, while any other value was stored in the local config.
-  defp deprecated_repo_key_source(repo_config) do
-    repos_key = Hex.State.fetch!(:repos_key)
+      Hex.Shell.warn("""
+      #{reason}
 
-    if repos_key != nil and repo_config.auth_key == repos_key do
-      :env
-    else
-      :config
+      For development authenticate as a user with `mix hex.user auth`. For CI \
+      authenticate with an organization key:
+
+          mix hex.organization auth #{organization} --key KEY
+      """)
     end
   end
 

--- a/lib/mix/tasks/hex.ex
+++ b/lib/mix/tasks/hex.ex
@@ -276,18 +276,6 @@ defmodule Mix.Tasks.Hex do
   end
 
   @doc false
-  def repository_key_name(organization, key) do
-    {:ok, hostname} = :inet.gethostname()
-    "#{key || hostname}-repository-#{organization}"
-  end
-
-  @doc false
-  def repositories_key_name(key) do
-    {:ok, hostname} = :inet.gethostname()
-    "#{key || hostname}-repositories"
-  end
-
-  @doc false
   def revoke_existing_oauth_tokens do
     case Hex.Config.read()[:"$oauth_token"] do
       nil ->
@@ -335,13 +323,55 @@ defmodule Mix.Tasks.Hex do
   end
 
   @doc false
-  def auth_organization(name, key) do
-    repo = Hex.Repo.get_repo(name) || Hex.Repo.default_hexpm_repo()
-    repo = Map.put(repo, :auth_key, key)
+  def auth_organization("hexpm:" <> organization = name, key) do
+    case exchange_organization_key(key, organization) do
+      {:ok, token} ->
+        repo =
+          (Hex.Repo.get_repo(name) || Hex.Repo.default_hexpm_repo())
+          |> Map.delete(:auth_key)
+          |> Map.put(:oauth_token, token)
 
-    Hex.State.fetch!(:repos)
-    |> Map.put(name, repo)
-    |> Hex.Config.update_repos()
+        Hex.State.fetch!(:repos)
+        |> Map.put(name, repo)
+        |> Hex.Config.update_repos()
+
+      :error ->
+        :ok
+    end
+  end
+
+  defp exchange_organization_key(key, organization) do
+    case Hex.API.OAuth.exchange_api_key(key, "repositories", get_hostname()) do
+      {:ok, {200, _, response}} ->
+        scopes = String.split(response["scope"] || "", " ", trim: true)
+
+        if "repository:#{organization}" in scopes do
+          expires_in = response["expires_in"] || 1800
+          expires_at = System.system_time(:second) + expires_in
+          {:ok, %{"access_token" => response["access_token"], "expires_at" => expires_at}}
+        else
+          Hex.Shell.error(
+            "The given key does not grant access to the #{organization} repository."
+          )
+
+          set_exit_code(1)
+          :error
+        end
+
+      {:ok, {code, _, _}} when code in [401, 403] ->
+        Hex.Shell.error(
+          "Failed to authenticate against the #{organization} repository with the given key."
+        )
+
+        set_exit_code(1)
+        :error
+
+      other ->
+        Hex.Utils.print_error_result(other)
+        Hex.Shell.error("Failed to authenticate against the #{organization} repository.")
+        set_exit_code(1)
+        :error
+    end
   end
 
   defp prompt_otp() do

--- a/lib/mix/tasks/hex.organization.ex
+++ b/lib/mix/tasks/hex.organization.ex
@@ -9,19 +9,16 @@ defmodule Mix.Tasks.Hex.Organization do
   Organizations is a feature of Hex.pm to host and manage private packages. See
   <https://hex.pm/docs/private> for more information.
 
-  By default you will be authorized to all your applications when running
-  `mix hex.user auth` and this is the recommended approach. This task is mainly
-  provided for CI and build systems where access to an organization is needed
-  without authorizing a user.
+  By default you will be authorized to all your organizations when running
+  `mix hex.user auth` and this is the recommended approach for development. This
+  task is mainly provided for CI and build systems where access to an organization
+  is needed without authorizing a user.
 
   For CI, generate an organization key with `mix hex.organization key ORGANIZATION generate`
-  and pass it with `mix hex.organization auth ORGANIZATION --key KEY`.
+  and authenticate with it. The key is exchanged for a short-lived token that is
+  stored locally; the key itself is not stored:
 
-  > #### Deprecation {: .warning}
-  >
-  > Authorizing an organization without `--key` is deprecated and will be removed.
-  > It creates a user key tied to your account; use `mix hex.user auth` for
-  > development instead, or pass a pre-generated organization key with `--key` for CI.
+      mix hex.organization auth ORGANIZATION --key KEY
 
   To use a package from an organization add `organization: "my_organization"` to the
   dependency declaration in `mix.exs`:
@@ -30,10 +27,11 @@ defmodule Mix.Tasks.Hex.Organization do
 
   ## Authorize an organization
 
-  This command will generate an API key used to authenticate access to the organization.
-  See the `hex.user` tasks to list and control all your active API keys.
+  Exchanges an organization key for a short-lived token used to fetch the
+  organization's packages. The key must be passed with `--key` (generate one with
+  `mix hex.organization key`); for development use `mix hex.user auth` instead.
 
-      $ mix hex.organization auth ORGANIZATION  [--key KEY] [--key-name KEY_NAME]
+      $ mix hex.organization auth ORGANIZATION --key KEY
 
   ## Deauthorize and remove an organization
 
@@ -81,14 +79,13 @@ defmodule Mix.Tasks.Hex.Organization do
 
   ## Command line options
 
-    * `--key KEY` - Hash of key used to authenticate HTTP requests to repository, if
-      omitted will generate a new key with your account credentials. This flag
-      is useful if you have a key pre-generated with `mix hex.organization key`
-      and want to authenticate on a CI server or similar system. Omitting `--key`
-      is deprecated; authenticate as a user with `mix hex.user auth` instead
+    * `--key KEY` - Required for `auth`. Hash of an organization key, generated with
+      `mix hex.organization key`, used to authenticate to the repository. The key is
+      exchanged for a short-lived token; for development authenticate as a user with
+      `mix hex.user auth` instead
 
-    * `--key-name KEY_NAME` - By default Hex will base the key name on your machine's
-      hostname and the organization name, use this option to give your own name.
+    * `--key-name KEY_NAME` - Used with `key generate` to name the generated key. By
+      default Hex bases the name on your machine's hostname.
 
     * `--permission PERMISSION` - Sets the permissions on the key, this option can be given
       multiple times, possibly values are:
@@ -165,15 +162,10 @@ defmodule Mix.Tasks.Hex.Organization do
   end
 
   defp auth(organization, opts) do
-    key = opts[:key]
-
-    key =
-      if key do
-        test_key(key, organization)
-        key
-      else
-        Hex.Shell.warn("""
-        Authorizing an organization without --key is deprecated and will be removed.
+    case opts[:key] do
+      nil ->
+        Mix.raise("""
+        Authorizing an organization requires an organization key passed with --key.
 
         For development authenticate as a user instead, which gives you access to \
         all your organizations:
@@ -186,23 +178,8 @@ defmodule Mix.Tasks.Hex.Organization do
             mix hex.organization auth #{organization} --key KEY
         """)
 
-        key_name = Mix.Tasks.Hex.repository_key_name(organization, opts[:key_name])
-        permissions = [%{"domain" => "repository", "resource" => organization}]
-        auth = Mix.Tasks.Hex.auth_info(:write)
-
-        case Hex.API.Key.new(key_name, permissions, auth) do
-          {:ok, {201, _, body}} ->
-            body["secret"]
-
-          other ->
-            Mix.shell().error("Generation of key failed")
-            Hex.Utils.print_error_result(other)
-            nil
-        end
-      end
-
-    if key do
-      Mix.Tasks.Hex.auth_organization("hexpm:#{organization}", key)
+      key ->
+        Mix.Tasks.Hex.auth_organization("hexpm:#{organization}", key)
     end
   end
 
@@ -290,24 +267,5 @@ defmodule Mix.Tasks.Hex.Organization do
           :ok
       end
     end)
-  end
-
-  defp test_key(key, name) do
-    case Hex.API.Auth.get("repository", name, key: key) do
-      {:ok, {code, _, _body}} when code in 200..299 ->
-        :ok
-
-      {:ok, {code, _, %{"message" => message}}} when code in [401, 403] ->
-        Hex.Shell.error(
-          "Failed to authenticate against organization repository with given key because of: #{message}"
-        )
-
-        Mix.Tasks.Hex.set_exit_code(1)
-
-      other ->
-        Hex.Utils.print_error_result(other)
-        Hex.Shell.error("Failed to verify authentication key")
-        Mix.Tasks.Hex.set_exit_code(1)
-    end
   end
 end

--- a/test/hex/remote_converger_test.exs
+++ b/test/hex/remote_converger_test.exs
@@ -105,17 +105,6 @@ defmodule Hex.RemoteConvergerTest do
     })
   end
 
-  defp new_repo_auth_user(prefix) do
-    suffix = System.unique_integer([:positive])
-
-    Hexpm.new_user(
-      "#{prefix}_#{suffix}",
-      "#{prefix}_#{suffix}@mail.com",
-      "password",
-      "#{prefix}_#{suffix}_key"
-    )
-  end
-
   test "deps with warn_if_outdated: true and hex: option" do
     in_tmp(fn ->
       Mix.Project.push(WarnOutdatedWithHexOption.MixProject)
@@ -156,11 +145,15 @@ defmodule Hex.RemoteConvergerTest do
     in_tmp(fn ->
       set_home_cwd()
 
-      auth = new_repo_auth_user("remote_converger_repo_auth_preflight")
-
       repos = Hex.State.fetch!(:repos)
-      repos = put_in(repos["hexpm"].auth_key, auth[:key])
-      Hex.State.put(:repos, repos)
+
+      org_repo =
+        Map.put(repos["hexpm"], :oauth_token, %{
+          "access_token" => "token",
+          "expires_at" => System.system_time(:second) + 3600
+        })
+
+      Hex.State.put(:repos, Map.put(repos, "hexpm:remote_converger_org", org_repo))
 
       assert Hex.RemoteConverger.auth_preflight_required?([
                {"hexpm:remote_converger_org", "private_prompt_pkg"}
@@ -183,12 +176,21 @@ defmodule Hex.RemoteConvergerTest do
     in_tmp(fn ->
       set_home_cwd()
 
-      auth = new_repo_auth_user("remote_converger_repo_auth_deps_get")
-
       repos = Hex.State.fetch!(:repos)
-      repos = put_in(repos["hexpm"].auth_key, auth[:key])
-      Hex.State.put(:repos, repos)
 
+      org_repo =
+        Map.merge(repos["hexpm"], %{
+          url: repos["hexpm"].url <> "/repos/remote_converger_org",
+          oauth_token: %{
+            "access_token" => "token",
+            "expires_at" => System.system_time(:second) + 3600
+          }
+        })
+
+      Hex.State.put(:repos, Map.put(repos, "hexpm:remote_converger_org", org_repo))
+
+      # An expired user token is not consulted because the organization repo has
+      # a valid cached token.
       store_expired_oauth_token()
 
       with_project(OrganizationDepsWithExpiredOAuth.MixProject, fn ->

--- a/test/hex/repo_test.exs
+++ b/test/hex/repo_test.exs
@@ -95,35 +95,64 @@ defmodule Hex.RepoTest do
     end)
   end
 
-  test "warns about deprecation when a stored key authenticates to a hexpm repository" do
+  test "ignores a stored key for an organization repository" do
     Hex.Server.reset()
 
-    auth =
-      HexTest.Hexpm.new_user(
-        "stored_repo_key_user",
-        "stored_repo_key@example.com",
-        "password",
-        "stored_repo_key_key"
-      )
-
     repos = Hex.State.fetch!(:repos)
-    hexpm = %{repos["hexpm"] | auth_key: auth[:key], oauth_exchange: true}
-    Hex.State.put(:repos, %{repos | "hexpm" => hexpm})
+    hexpm = repos["hexpm"]
 
-    # The exchange outcome is irrelevant; the warning is emitted before the
-    # stored key is exchanged.
+    org_repo = %{
+      url: hexpm.url <> "/repos/ignoredorg",
+      public_key: hexpm.public_key,
+      auth_key: "ignored_stored_key",
+      oauth_exchange: true,
+      trusted: true
+    }
+
+    Hex.State.put(:repos, Map.put(repos, "hexpm:ignoredorg", org_repo))
+
+    # With no cached token and no user authentication, the stored key is
+    # ignored: the request is made unauthenticated and the user is told to
+    # authenticate (the key is never exchanged).
     try do
-      Hex.Repo.get_package("hexpm", "postgrex", "")
+      Hex.Repo.get_package("hexpm:ignoredorg", "pkg", "")
     rescue
       _ -> :ok
     end
 
     output = Case.shell_output()
-    assert output =~ "stored key is deprecated"
+    assert output =~ "Not authenticated to the ignoredorg repository"
     assert output =~ "mix hex.user auth"
   end
 
-  test "warns about deprecation when HEX_REPOS_KEY authenticates to a hexpm repository" do
+  test "warns that HEX_REPOS_KEY no longer grants access to an organization repository" do
+    Hex.Server.reset()
+
+    repos = Hex.State.fetch!(:repos)
+    hexpm = repos["hexpm"]
+    Hex.State.put(:repos_key, "repos_key_value")
+
+    org_repo = %{
+      url: hexpm.url <> "/repos/reposkeyorg",
+      public_key: hexpm.public_key,
+      auth_key: "repos_key_value",
+      oauth_exchange: true,
+      trusted: true
+    }
+
+    Hex.State.put(:repos, Map.put(repos, "hexpm:reposkeyorg", org_repo))
+
+    try do
+      Hex.Repo.get_package("hexpm:reposkeyorg", "pkg", "")
+    rescue
+      _ -> :ok
+    end
+
+    output = Case.shell_output()
+    assert output =~ "HEX_REPOS_KEY no longer grants access to the reposkeyorg repository"
+  end
+
+  test "does not warn for the base hexpm repository authenticated with HEX_REPOS_KEY" do
     Hex.Server.reset()
 
     auth =
@@ -134,6 +163,7 @@ defmodule Hex.RepoTest do
         "repos_key_key"
       )
 
+    # HEX_REPOS_KEY still authenticates the base hexpm repo (and trusted mirrors)
     Hex.State.put(:repos_key, auth[:key])
 
     try do
@@ -143,7 +173,8 @@ defmodule Hex.RepoTest do
     end
 
     output = Case.shell_output()
-    assert output =~ "HEX_REPOS_KEY is deprecated"
+    refute output =~ "HEX_REPOS_KEY"
+    refute output =~ "deprecated"
   end
 
   test "does not attempt oauth exchange when oauth_exchange is not set" do
@@ -323,7 +354,7 @@ defmodule Hex.RepoTest do
   end
 
   describe "automatic API key to OAuth token exchange" do
-    test "organization repo inherits oauth_exchange from parent" do
+    test "does not exchange a stored key for an organization repo on fetch" do
       auth =
         HexTest.Hexpm.new_user(
           "org_oauth_user",
@@ -338,27 +369,8 @@ defmodule Hex.RepoTest do
 
       assert {:ok, {200, _, _}} = Hex.Repo.get_package("hexpm:testorg", "foo", "")
 
-      repos_after = Hex.State.fetch!(:repos)
-      token_data = repos_after["hexpm:testorg"].oauth_token
-      assert is_binary(token_data["access_token"])
-    end
-
-    test "organization repo skips oauth_exchange when disabled on parent" do
-      auth =
-        HexTest.Hexpm.new_user(
-          "org_no_oauth_user",
-          "org_no_oauth@example.com",
-          "password",
-          "org_no_oauth_key"
-        )
-
-      repos = Hex.State.fetch!(:repos)
-      repos = put_in(repos["hexpm"].auth_key, auth[:key])
-      repos = put_in(repos["hexpm"], Map.put(repos["hexpm"], :oauth_exchange, false))
-      Hex.State.put(:repos, repos)
-
-      assert {:ok, {200, _, _}} = Hex.Repo.get_package("hexpm:testorg", "foo", "")
-
+      # Organization repos no longer exchange a stored or inherited key on fetch;
+      # the exchange happens once during `mix hex.organization auth --key`.
       repos_after = Hex.State.fetch!(:repos)
       org_repo = Map.get(repos_after, "hexpm:testorg")
       assert org_repo == nil or Map.get(org_repo, :oauth_token) == nil

--- a/test/mix/tasks/hex.organization_test.exs
+++ b/test/mix/tasks/hex.organization_test.exs
@@ -1,85 +1,17 @@
 defmodule Mix.Tasks.Hex.OrganizationTest do
   use HexTest.IntegrationCase
 
-  test "auth" do
-    in_tmp(fn ->
-      set_home_cwd()
-      auth = Hexpm.new_user("orgauth", "orgauth@mail.com", "password", "key")
-      Hex.State.put(:api_key, auth[:key])
-      Hexpm.new_repo("myorgauth", auth)
-
-      send(self(), {:mix_shell_input, :yes?, true})
-      send(self(), {:mix_shell_input, :prompt, "password"})
-      Mix.Tasks.Hex.Organization.run(["auth", "myorgauth"])
-
-      myorg = Hex.Repo.get_repo("hexpm:myorgauth")
-      hexpm = Hex.Repo.get_repo("hexpm")
-
-      assert myorg.public_key == hexpm.public_key
-      assert myorg.url == "http://localhost:4043/repo/repos/myorgauth"
-      assert is_binary(myorg.auth_key)
-
-      {:ok, hostname} = :inet.gethostname()
-      name = "#{hostname}-repository-myorgauth"
-      assert {:ok, {200, _, body}} = Hex.API.Key.get(auth)
-      assert name in Enum.map(body, & &1["name"])
-    end)
-  end
-
-  test "auth without --key warns about deprecation" do
-    in_tmp(fn ->
-      set_home_cwd()
-      auth = Hexpm.new_user("orgauthdeprecated", "orgauthdeprecated@mail.com", "password", "key")
-      Hex.State.put(:api_key, auth[:key])
-      Hexpm.new_repo("myorgauthdeprecated", auth)
-
-      send(self(), {:mix_shell_input, :yes?, true})
-      send(self(), {:mix_shell_input, :prompt, "password"})
-      Mix.Tasks.Hex.Organization.run(["auth", "myorgauthdeprecated"])
-
-      output = Case.shell_output()
-      assert output =~ "deprecated"
-      assert output =~ "mix hex.user auth"
-
-      # Still authorizes (warning only, no behavior change)
-      assert is_binary(Hex.Repo.get_repo("hexpm:myorgauthdeprecated").auth_key)
-    end)
-  end
-
-  test "auth with --keyname" do
+  test "auth without --key raises" do
     in_tmp(fn ->
       set_home_cwd()
 
-      auth =
-        Hexpm.new_user("orgauthwithkeyname", "orgauthwithkeyname@mail.com", "password", "key")
-
-      Hex.State.put(:api_key, auth[:key])
-
-      Hexpm.new_repo("myorgauthwithkeyname", auth)
-
-      send(self(), {:mix_shell_input, :yes?, true})
-      send(self(), {:mix_shell_input, :prompt, "password"})
-
-      Mix.Tasks.Hex.Organization.run([
-        "auth",
-        "myorgauthwithkeyname",
-        "--key-name",
-        "orgauthkeyname"
-      ])
-
-      myorg = Hex.Repo.get_repo("hexpm:myorgauthwithkeyname")
-      hexpm = Hex.Repo.get_repo("hexpm")
-
-      assert myorg.public_key == hexpm.public_key
-      assert myorg.url == "http://localhost:4043/repo/repos/myorgauthwithkeyname"
-      assert is_binary(myorg.auth_key)
-
-      assert {:ok, {200, _, body}} = Hex.API.Key.get(auth)
-      assert "orgauthkeyname-repository-myorgauthwithkeyname" in Enum.map(body, & &1["name"])
+      assert_raise Mix.Error, ~r/requires an organization key passed with --key/, fn ->
+        Mix.Tasks.Hex.Organization.run(["auth", "myorg"])
+      end
     end)
   end
 
-  test "auth --key" do
+  test "auth --key exchanges the key for a short-lived token" do
     in_tmp(fn ->
       set_home_cwd()
       auth = Hexpm.new_user("orgauthkey", "orgauthkey@mail.com", "password", "key")
@@ -95,15 +27,42 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
 
       assert myorg.public_key == hexpm.public_key
       assert myorg.url == "http://localhost:4043/repo/repos/myorgauthkey"
-      assert myorg.auth_key == body["secret"]
+
+      # Only the short-lived token is stored, never the key
+      refute myorg[:auth_key]
+      assert %{"access_token" => access_token, "expires_at" => expires_at} = myorg.oauth_token
+      assert is_binary(access_token)
+      assert is_integer(expires_at)
 
       repos = Hex.Config.read_repos(Hex.Config.read())
       assert repo = repos["hexpm:myorgauthkey"]
-      assert repo[:auth_key]
-      assert repo[:trusted]
-      assert repo[:url] == "http://localhost:4043/repo/repos/myorgauthkey"
+      refute repo[:auth_key]
+      assert repo[:oauth_token]["access_token"] == access_token
+    end)
+  end
 
-      refute Map.has_key?(Hex.Config.read()[:"$repos"]["hexpm:myorgauthkey"], :trusted)
+  test "auth --key with a key that does not grant access to the organization" do
+    in_tmp(fn ->
+      set_home_cwd()
+      auth = Hexpm.new_user("orgauthwrong", "orgauthwrong@mail.com", "password", "key")
+      Hexpm.new_repo("orgauthwrong_a", auth)
+      Hexpm.new_repo("orgauthwrong_b", auth)
+
+      parameters = [%{"domain" => "repository", "resource" => "orgauthwrong_a"}]
+      {:ok, {201, _, body}} = Hex.API.Key.new("orgauthwrong", parameters, auth)
+
+      assert catch_throw(
+               Mix.Tasks.Hex.Organization.run([
+                 "auth",
+                 "orgauthwrong_b",
+                 "--key",
+                 body["secret"]
+               ])
+             ) == {:exit_code, 1}
+
+      assert_received {:mix_shell, :error, [error]}
+      assert error =~ "does not grant access to the orgauthwrong_b repository"
+      refute Hex.Config.read_repos(Hex.Config.read())["hexpm:orgauthwrong_b"]
     end)
   end
 
@@ -114,10 +73,8 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
       assert catch_throw(Mix.Tasks.Hex.Organization.run(["auth", "myorg", "--key", "mykey"])) ==
                {:exit_code, 1}
 
-      assert_received {:mix_shell, :error,
-                       [
-                         "Failed to authenticate against organization repository with given key because of: invalid API key"
-                       ]}
+      assert_received {:mix_shell, :error, [error]}
+      assert error =~ "Failed to authenticate against the myorg repository"
     end)
   end
 
@@ -125,12 +82,13 @@ defmodule Mix.Tasks.Hex.OrganizationTest do
     in_tmp(fn ->
       set_home_cwd()
       auth = Hexpm.new_user("orgdeauth", "orgdeauth@mail.com", "password", "key")
-      Hex.State.put(:api_key, auth[:key])
       Hexpm.new_repo("myorgdeauth", auth)
 
-      send(self(), {:mix_shell_input, :yes?, true})
-      send(self(), {:mix_shell_input, :prompt, "password"})
-      Mix.Tasks.Hex.Organization.run(["auth", "myorgdeauth"])
+      parameters = [%{"domain" => "repository", "resource" => "myorgdeauth"}]
+      {:ok, {201, _, body}} = Hex.API.Key.new("orgdeauth", parameters, auth)
+
+      Mix.Tasks.Hex.Organization.run(["auth", "myorgdeauth", "--key", body["secret"]])
+      assert Hex.Config.read_repos(Hex.Config.read())["hexpm:myorgdeauth"]
 
       Mix.Tasks.Hex.Organization.run(["deauth", "myorgdeauth"])
       refute Hex.Config.read_repos(Hex.Config.read())["hexpm:myorgdeauth"]

--- a/test/mix/tasks/hex.user_test.exs
+++ b/test/mix/tasks/hex.user_test.exs
@@ -399,9 +399,18 @@ defmodule Mix.Tasks.Hex.UserTest do
       # Verify OAuth tokens exist
       assert Hex.Config.read()[:"$oauth_token"]
 
-      # Create organization auth
-      send(self(), {:mix_shell_input, :prompt, "password"})
-      Mix.Tasks.Hex.Organization.run(["auth", "myorguserdeauth1"])
+      # Authorize an organization (auth --key stores a short-lived token)
+      Hex.State.fetch!(:repos)
+      |> Map.put("hexpm:myorguserdeauth1", %{
+        url: "http://localhost:4043/repo/repos/myorguserdeauth1",
+        oauth_token: %{
+          "access_token" => "org_token",
+          "expires_at" => System.system_time(:second) + 3600
+        }
+      })
+      |> Hex.Config.update_repos()
+
+      assert Hex.Config.read()[:"$repos"]["hexpm:myorguserdeauth1"]
 
       Mix.Tasks.Hex.User.run(["deauth"])
 


### PR DESCRIPTION
Follow-up to the deprecations in #1179 — this is the breaking change that removes the deprecated paths. **It must ship in a release after the one that carries the deprecation warnings, not together with them.** Draft until then.

### What changes

- `mix hex.organization auth ORGANIZATION` now **requires `--key`**. Without it, the task raises and points to `mix hex.user auth` (development) or `mix hex.organization key … generate` (CI).
- `mix hex.organization auth ORGANIZATION --key KEY` now **exchanges the key for a short-lived token immediately and stores only the token**, never the key. The exchange also verifies the key grants access to the organization.
- **Organization repositories no longer authenticate with a stored API key.** They use the cached short-lived token (from `auth --key`) or, failing that, the user's `mix hex.user auth` authentication. A stored `auth_key` left in `hex.config` by an older client is ignored.
- **`HEX_REPOS_KEY` no longer grants access to organization repositories** — authenticate per organization with `auth --key` instead.
- When neither a valid cached token nor user authentication is available for an organization repository, the client prints how to authenticate instead of silently failing.

### Scope / compatibility

- The base `hexpm` repository is unchanged, **including trusted mirrors authenticated with `HEX_REPOS_KEY`**. Full removal of `HEX_REPOS_KEY` is intentionally out of scope here because it is also used for mirror authentication.
- The `client_credentials` exchange itself is unchanged, so CI keeps working: a job runs `mix hex.organization auth ORGANIZATION --key $KEY` and fetches with the resulting token. Since that exchange issues no refresh token, the token must be re-obtained after it expires (~30 min) — fine for a typical CI job, and the intended friction for a human pasting a key on a workstation.

### Follow-up (separate, later)

The hexpm server should eventually **reject** the exchange of a user-owned key for repository scopes (returning `invalid_scope`), so the constraint reaches clients that are pinned to old Hex versions. That is deliberately deferred — it is a server-side breaking change to be timed against customer comms, and it is not part of this PR.
