### PR TITLE
Only warn about deprecated keys for organization repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 * Deprecate `mix hex.organization auth ORGANIZATION` without `--key`; authenticate as a user with `mix hex.user auth` instead, or pass a pre-generated organization key with `--key` for CI
 * Deprecate authenticating to organization repositories with a stored key; a future release will require `mix hex.user auth` or a short-lived organization token
-* Deprecate `HEX_REPOS_KEY`; authenticate per organization with `mix hex.organization auth ORGANIZATION --key KEY`
+* Deprecate authenticating to organization repositories with `HEX_REPOS_KEY`; authenticate per organization with `mix hex.organization auth ORGANIZATION --key KEY` (`HEX_REPOS_KEY` continues to authenticate the base hexpm repository and trusted mirrors)
 
 ### Bug fixes
 

--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -332,21 +332,24 @@ defmodule Hex.Repo do
     end
   end
 
-  defp maybe_warn_deprecated_repo_key("hexpm", organization, repo_config) do
+  # Only organization repositories are deprecated here. HEX_REPOS_KEY still
+  # authenticates the base hexpm repo and trusted mirrors (organization is nil
+  # for those), so they must not be warned about.
+  defp maybe_warn_deprecated_repo_key("hexpm", organization, repo_config)
+       when is_binary(organization) do
     case deprecated_repo_key_source(repo_config) do
       :env ->
-        if Hex.Server.should_warn?(:deprecated_repos_key) do
+        if Hex.Server.should_warn?({:deprecated_repos_key, organization}) do
           Hex.Shell.warn("""
-          HEX_REPOS_KEY is deprecated and will be removed.
+          Authenticating to the #{organization} repository with HEX_REPOS_KEY is deprecated \
+          and will be removed.
 
           For development authenticate as a user with `mix hex.user auth`. For CI \
-          authenticate per organization with `mix hex.organization auth ORGANIZATION --key KEY`.
+          authenticate per organization with `mix hex.organization auth #{organization} --key KEY`.
           """)
         end
 
       :config ->
-        organization = organization || "hexpm"
-
         if Hex.Server.should_warn?({:deprecated_repo_key, organization}) do
           Hex.Shell.warn("""
           Authenticating to the #{organization} repository with a stored key is deprecated \

--- a/test/hex/repo_test.exs
+++ b/test/hex/repo_test.exs
@@ -95,25 +95,26 @@ defmodule Hex.RepoTest do
     end)
   end
 
-  test "warns about deprecation when a stored key authenticates to a hexpm repository" do
+  test "warns about deprecation when a stored key authenticates to an organization repository" do
     Hex.Server.reset()
 
-    auth =
-      HexTest.Hexpm.new_user(
-        "stored_repo_key_user",
-        "stored_repo_key@example.com",
-        "password",
-        "stored_repo_key_key"
-      )
-
     repos = Hex.State.fetch!(:repos)
-    hexpm = %{repos["hexpm"] | auth_key: auth[:key], oauth_exchange: true}
-    Hex.State.put(:repos, %{repos | "hexpm" => hexpm})
+    hexpm = repos["hexpm"]
+
+    org_repo = %{
+      url: hexpm.url <> "/repos/storedkeyorg",
+      public_key: hexpm.public_key,
+      auth_key: "stored_key_value",
+      oauth_exchange: true,
+      trusted: true
+    }
+
+    Hex.State.put(:repos, Map.put(repos, "hexpm:storedkeyorg", org_repo))
 
     # The exchange outcome is irrelevant; the warning is emitted before the
     # stored key is exchanged.
     try do
-      Hex.Repo.get_package("hexpm", "postgrex", "")
+      Hex.Repo.get_package("hexpm:storedkeyorg", "pkg", "")
     rescue
       _ -> :ok
     end
@@ -123,7 +124,34 @@ defmodule Hex.RepoTest do
     assert output =~ "mix hex.user auth"
   end
 
-  test "warns about deprecation when HEX_REPOS_KEY authenticates to a hexpm repository" do
+  test "warns about deprecation when HEX_REPOS_KEY authenticates to an organization repository" do
+    Hex.Server.reset()
+
+    repos = Hex.State.fetch!(:repos)
+    hexpm = repos["hexpm"]
+    Hex.State.put(:repos_key, "repos_key_value")
+
+    org_repo = %{
+      url: hexpm.url <> "/repos/reposkeyorg",
+      public_key: hexpm.public_key,
+      auth_key: "repos_key_value",
+      oauth_exchange: true,
+      trusted: true
+    }
+
+    Hex.State.put(:repos, Map.put(repos, "hexpm:reposkeyorg", org_repo))
+
+    try do
+      Hex.Repo.get_package("hexpm:reposkeyorg", "pkg", "")
+    rescue
+      _ -> :ok
+    end
+
+    output = Case.shell_output()
+    assert output =~ "the reposkeyorg repository with HEX_REPOS_KEY is deprecated"
+  end
+
+  test "does not warn for the base hexpm repository authenticated with HEX_REPOS_KEY" do
     Hex.Server.reset()
 
     auth =
@@ -134,6 +162,7 @@ defmodule Hex.RepoTest do
         "repos_key_key"
       )
 
+    # HEX_REPOS_KEY still authenticates the base hexpm repo (and trusted mirrors)
     Hex.State.put(:repos_key, auth[:key])
 
     try do
@@ -143,7 +172,8 @@ defmodule Hex.RepoTest do
     end
 
     output = Case.shell_output()
-    assert output =~ "HEX_REPOS_KEY is deprecated"
+    refute output =~ "HEX_REPOS_KEY"
+    refute output =~ "deprecated"
   end
 
   test "does not attempt oauth exchange when oauth_exchange is not set" do


### PR DESCRIPTION
Fixes the targeting of the deprecation warning added in #1179, which ships in the next release.

The `HEX_REPOS_KEY` / stored-key deprecation warning in `build_hex_core_config` matched the base `hexpm` repo as well as organization repos. As a result, users of **trusted mirrors** — which legitimately authenticate with `HEX_REPOS_KEY` and are **not** being deprecated — were told "HEX_REPOS_KEY is deprecated and will be removed," which is false for them.

Only authenticating to **organization repositories** with a personal/stored key or `HEX_REPOS_KEY` is deprecated. `HEX_REPOS_KEY` continues to authenticate the base `hexpm` repository and trusted mirrors. This change warns only when `organization` is set (i.e. a `hexpm:ORG` repo), and the `HEX_REPOS_KEY` message is now scoped to the organization.

Adds a test asserting the base `hexpm` repo with `HEX_REPOS_KEY` produces no warning, alongside the organization-scoped warning tests.

This should ship in the same release as the deprecation warnings, before the breaking change in #1181.
