### PR TITLE
Fetch dependency policies with optional repository auth

### DIFF
--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -219,7 +219,8 @@ defmodule Hex.Repo do
   def get_policy(repo, name, etag) do
     repo_config = get_repo(repo)
     config = build_hex_core_config(repo_config, repo, etag)
-    :mix_hex_repo.get_policy(config, name)
+
+    Hex.Auth.with_repo(config, &:mix_hex_repo.get_policy(&1, name), optional: true)
   end
 
   def get_docs(repo, package, version) do


### PR DESCRIPTION
get_policy/3 now goes through Hex.Auth.with_repo/3 with optional: true, like get_package/3, instead of calling :mix_hex_repo.get_policy directly. It authenticates when credentials are available and fetches anonymously otherwise, so a public policy can be resolved without authenticating to the organization.