### PR TITLE
Fix duplicated policy version listing on resolution failure

### DIFF
--- a/lib/hex/remote_converger.ex
+++ b/lib/hex/remote_converger.ex
@@ -117,7 +117,9 @@ defmodule Hex.RemoteConverger do
         end
 
         print_cooldown_summary()
-        print_policy_summary()
+        # The failure note above already lists the hidden versions, so the
+        # summary here contributes only the active-policy header.
+        print_policy_summary(list_filtered: false)
         Mix.raise("Hex dependency resolution failed")
     end
   end
@@ -937,13 +939,19 @@ defmodule Hex.RemoteConverger do
   end
 
   @doc false
-  def print_policy_summary() do
+  def print_policy_summary(opts \\ []) do
     case Hex.State.fetch!(:active_policy) do
       nil ->
         :ok
 
       policy ->
-        filtered = Hex.State.fetch!(:policy_filtered_versions)
+        filtered =
+          if Keyword.get(opts, :list_filtered, true) do
+            Hex.State.fetch!(:policy_filtered_versions)
+          else
+            []
+          end
+
         local_cooldown = Hex.State.fetch!(:cooldown)
 
         if summary = Hex.Policy.Diagnostics.resolution_summary(policy, filtered, local_cooldown) do

--- a/test/hex/remote_converger_policy_test.exs
+++ b/test/hex/remote_converger_policy_test.exs
@@ -96,6 +96,29 @@ defmodule Hex.RemoteConvergerPolicyTest do
     assert output =~ "  phoenix 1.7.18 — override deny"
   end
 
+  test "print_policy_summary/1 with list_filtered: false omits the hidden versions" do
+    Mix.shell(Mix.Shell.IO)
+    on_exit(fn -> Mix.shell(Hex.Shell.Process) end)
+
+    Hex.State.put(:active_policy, %{
+      repository: "myorg",
+      name: "strict-prod",
+      visibility: :VISIBILITY_PUBLIC,
+      repositories: []
+    })
+
+    Hex.State.put(:policy_filtered_versions, [
+      %{repo: "hexpm", package: "phoenix", version: "1.7.18", reasons: [:override_deny]}
+    ])
+
+    output =
+      capture_io(fn -> Hex.RemoteConverger.print_policy_summary(list_filtered: false) end)
+
+    assert output =~ "Active policy: myorg/strict-prod"
+    refute output =~ "Policy hid"
+    refute output =~ "phoenix 1.7.18"
+  end
+
   test "print_policy_summary/0 prints nothing without an active policy" do
     Mix.shell(Mix.Shell.IO)
     on_exit(fn -> Mix.shell(Hex.Shell.Process) end)


### PR DESCRIPTION
When resolution fails under an active policy, the per-package failure note and the post-solve policy summary both rendered the hidden-version listing, so it printed twice. On the failure path the summary now contributes only the active-policy header; the failure note remains the single listing.

Closes #1187