### PR TITLE
Bump CI to released Elixir 1.20.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
           # - erlang: maint
           #   elixir: main
           - erlang: "29.0"
-            elixir: 1.20.0-rc.6
+            elixir: 1.20.2
           - erlang: 28.5
             elixir: 1.19.5
           - erlang: 27.3


### PR DESCRIPTION
Updates the CI matrix from the `1.20.0-rc.6` release candidate to the released `1.20.2` (on OTP 29) so the suite runs against final Elixir 1.20. This validates Hex on Elixir 1.20 ahead of v2.5.0, which adds 1.20 to the release build matrix in `scripts/release_hex.sh`.