### PR TITLE
Group codeql-action Dependabot updates and bump to v4.36.3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,12 +29,12 @@ jobs:
         with:
           persist-credentials: false
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: "/language:${{matrix.language}}"
 


### PR DESCRIPTION
Dependabot opens separate PRs for the `codeql-action/init` and `codeql-action/analyze` sub-actions, leaving the two pins on mismatched versions. The analyze step refuses to run when its version differs from the config written by init (`Loaded a configuration file for version '4.36.3', but running version '4.36.2'`), so neither PR can pass CI.

This adds a Dependabot group so all `github/codeql-action*` updates land in a single PR, and bumps both pins to v4.36.3.