### PR TITLE
Add SARIF output format to mix hex.audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 * Print warnings to standard error instead of standard output, keeping stdout clean for machine-readable output such as `mix hex.outdated --json`. Warning-colored lines that are part of a command's regular output, such as retirement notices in `mix hex.info` and the `mix deps.get` dependency listing, remain on standard output
+* Add `--format sarif` and `--output PATH` options to `mix hex.audit` to render the audit result as a SARIF v2.1.0 document that can be uploaded to GitHub code scanning and other SARIF consumers. Findings are anchored to the dependency's `mix.lock` entry and ignored findings are included as suppressed results. Requires OTP 27 or later
 
 ## v2.5.1 (2026-07-09)
 

--- a/lib/hex/sarif.ex
+++ b/lib/hex/sarif.ex
@@ -1,0 +1,552 @@
+defmodule Hex.Sarif do
+  @moduledoc false
+
+  # Renders audit findings as a SARIF v2.1.0 document
+  # (https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html) so
+  # they can be uploaded to services such as GitHub code scanning.
+  #
+  # Two note-level SARIF validator recommendations are deliberately not
+  # followed:
+  #
+  #   * SARIF2009 (conventional rule ids): advisory rules use the advisory
+  #     identifier as the rule id so each alert carries its own severity
+  #     score, title and help link, matching other dependency scanners.
+  #   * SARIF2002 (message.id instead of message.text): GitHub code
+  #     scanning and Azure DevOps require results[].message.text and do
+  #     not resolve templated messages.
+
+  @schema "https://json.schemastore.org/sarif-2.1.0.json"
+  @src_root "SRCROOT"
+
+  # One conventionally-named rule per retirement reason. Advisory rules
+  # instead use the advisory identifier as their rule id, since the rule
+  # metadata (severity score, help link, description) is per advisory.
+  @retired_rules %{
+    RETIRED_OTHER: {"HEX0001", "RetiredPackage", "Retired Hex package"},
+    RETIRED_INVALID: {"HEX0002", "RetiredPackageInvalid", "Hex package retired: invalid"},
+    RETIRED_SECURITY: {"HEX0003", "RetiredPackageSecurity", "Hex package retired: security"},
+    RETIRED_DEPRECATED:
+      {"HEX0004", "RetiredPackageDeprecated", "Hex package retired: deprecated"},
+    RETIRED_RENAMED: {"HEX0005", "RetiredPackageRenamed", "Hex package retired: renamed"}
+  }
+  @retired_rule_fallback @retired_rules[:RETIRED_OTHER]
+
+  @retired_message_template "Dependency '{0}' '{1}' is retired: '{2}'."
+  @advisory_message_template "Dependency '{0}' '{1}' is affected by security advisory " <>
+                               "'{2}': '{3}'. See '{4}'."
+
+  @doc """
+  Encodes audit findings as a SARIF JSON document.
+
+  Findings are `{:retired, package, version, retired, ignored?}` or
+  `{:advisory, package, version, advisory, ignored?}` tuples, where
+  `retired` is the retirement status map from the registry and `advisory`
+  is a display group returned by
+  `:mix_hex_advisory.group_for_display/1`. Ignored findings are included
+  with a SARIF suppression. `lockfile` is the path of the lock file the
+  results are anchored to, relative to the working directory.
+
+  Requires the `:json` module (OTP 27 or later).
+  """
+  def encode_audit(findings, lockfile) do
+    rules = rules(findings)
+
+    rule_indexes =
+      rules
+      |> Enum.with_index()
+      |> Map.new(fn {rule, index} -> {rule["id"], index} end)
+
+    git = git_work_tree()
+    artifact = artifact_location(lockfile, git)
+    lock_lines = lock_lines(lockfile)
+    results = Enum.map(findings, &result(&1, rule_indexes, artifact, lock_lines))
+
+    run = %{
+      # A stable category-style id: uploads with the same id update the
+      # same alert set on GitHub code scanning and Azure DevOps.
+      "automationDetails" => %{
+        "id" => "hex-audit/",
+        "description" => %{"text" => "Hex dependency audit (mix hex.audit)"}
+      },
+      "tool" => %{
+        "driver" => %{
+          "name" => "mix hex.audit",
+          "fullName" => "mix hex.audit (Hex #{Hex.version()})",
+          "informationUri" => "https://hex.pm",
+          "version" => Hex.version(),
+          "rules" => rules
+        }
+      },
+      "results" => results
+    }
+
+    run =
+      case git do
+        nil ->
+          run
+
+        %{root: root} ->
+          Map.put(run, "originalUriBaseIds", %{@src_root => %{"uri" => file_uri(root)}})
+      end
+
+    run =
+      case version_control_provenance(git) do
+        nil -> run
+        provenance -> Map.put(run, "versionControlProvenance", provenance)
+      end
+
+    encode_json!(%{
+      "$schema" => @schema,
+      "version" => "2.1.0",
+      "runs" => [run]
+    })
+  end
+
+  # The git binary and the root of the work tree containing the working
+  # directory, or nil when either is unavailable.
+  defp git_work_tree do
+    with git when is_binary(git) <- System.find_executable("git"),
+         {:ok, root} <- git_cmd(git, ["rev-parse", "--show-toplevel"]) do
+      %{binary: git, root: root}
+    else
+      _other -> nil
+    end
+  end
+
+  # The artifactLocation of the lock file all results point at. Inside a
+  # git work tree the uri is relative to the repository root and anchored
+  # to it with uriBaseId, so consumers can map results to repository
+  # files no matter which directory the task ran in.
+  defp artifact_location(lockfile, git) do
+    with %{root: root} <- git,
+         {:ok, relative} <- relative_to_root(Path.expand(lockfile), root) do
+      %{"uri" => relative, "uriBaseId" => @src_root}
+    else
+      _other -> %{"uri" => String.replace(lockfile, "\\", "/")}
+    end
+  end
+
+  defp relative_to_root(path, root) do
+    path = String.replace(path, "\\", "/")
+    prefix = String.replace(root, "\\", "/") <> "/"
+
+    if String.starts_with?(path, prefix) do
+      {:ok, String.replace_prefix(path, prefix, "")}
+    else
+      :error
+    end
+  end
+
+  defp file_uri(path) do
+    path = path |> String.replace("\\", "/") |> String.trim_leading("/")
+    "file:///" <> path <> "/"
+  end
+
+  # Describes the scanned revision on a best-effort basis: only when the
+  # working directory is inside a git work tree and the tracked remote
+  # has a URL that can be expressed as a URI.
+  defp version_control_provenance(nil), do: nil
+
+  defp version_control_provenance(%{binary: git}) do
+    with {:ok, url} <- repository_url(git),
+         {:ok, uri} <- repository_uri(url) do
+      details = %{
+        "repositoryUri" => uri,
+        "mappedTo" => %{"uriBaseId" => @src_root}
+      }
+
+      details =
+        case git_cmd(git, ["rev-parse", "HEAD"]) do
+          {:ok, revision} -> Map.put(details, "revisionId", revision)
+          :error -> details
+        end
+
+      details =
+        case git_cmd(git, ["rev-parse", "--abbrev-ref", "HEAD"]) do
+          # A detached HEAD has no branch
+          {:ok, "HEAD"} -> details
+          {:ok, branch} -> Map.put(details, "branch", branch)
+          :error -> details
+        end
+
+      [details]
+    else
+      _other -> nil
+    end
+  end
+
+  # The URL of the current branch's tracked remote, falling back to origin
+  # when there is no upstream (for example on a detached HEAD).
+  defp repository_url(git) do
+    remote =
+      case git_cmd(git, ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"]) do
+        {:ok, upstream} -> upstream |> String.split("/") |> hd()
+        :error -> "origin"
+      end
+
+    git_cmd(git, ["remote", "get-url", remote])
+  end
+
+  # repositoryUri must be a URI. Remote URLs in http(s)/ssh/git/file form
+  # pass through (minus embedded credentials, which CI systems commonly
+  # put in the remote URL and must not leak into an uploaded report);
+  # scp-like remotes (git@host:path) are rewritten to their equivalent
+  # ssh:// URI. Anything else, such as local paths, is dropped.
+  defp repository_uri(url) do
+    cond do
+      url == "" -> :error
+      String.contains?(url, "://") -> {:ok, strip_credentials(url)}
+      scp_like?(url) -> {:ok, "ssh://" <> String.replace(url, ":", "/", global: false)}
+      true -> :error
+    end
+  end
+
+  defp strip_credentials(url) do
+    case URI.parse(url) do
+      %URI{scheme: scheme, userinfo: userinfo} = uri
+      when scheme in ["http", "https"] and is_binary(userinfo) ->
+        URI.to_string(%{uri | userinfo: nil})
+
+      _other ->
+        url
+    end
+  end
+
+  defp scp_like?(url) do
+    case :binary.split(url, ":") do
+      [host, _path] -> not String.contains?(host, "/")
+      _other -> false
+    end
+  end
+
+  defp git_cmd(git, args) do
+    case System.cmd(git, args, stderr_to_stdout: true) do
+      {output, 0} -> {:ok, String.trim(output)}
+      {_output, _status} -> :error
+    end
+  rescue
+    _error -> :error
+  end
+
+  defp rules(findings) do
+    retired_rules =
+      findings
+      |> Enum.flat_map(fn
+        {:retired, _package, _version, retired, _ignored?} -> [Map.get(retired, :reason)]
+        {:advisory, _package, _version, _advisory, _ignored?} -> []
+      end)
+      |> Enum.uniq_by(fn reason -> elem(retired_rule_info(reason), 0) end)
+      |> Enum.map(&retired_rule/1)
+
+    advisory_rules =
+      findings
+      |> Enum.flat_map(fn
+        {:advisory, _package, _version, advisory, _ignored?} -> [advisory]
+        {:retired, _package, _version, _retired, _ignored?} -> []
+      end)
+      |> Enum.uniq_by(& &1.id)
+      |> Enum.map(&advisory_rule/1)
+
+    retired_rules ++ advisory_rules
+  end
+
+  defp retired_rule_info(reason), do: Map.get(@retired_rules, reason, @retired_rule_fallback)
+
+  defp retired_rule(reason) do
+    {id, name, short_description} = retired_rule_info(reason)
+
+    %{
+      "id" => id,
+      "name" => name,
+      "shortDescription" => %{"text" => short_description},
+      "fullDescription" => %{
+        "text" =>
+          "The locked version of this dependency has been retired by its " <>
+            "maintainers and is no longer recommended for use."
+      },
+      "helpUri" => "https://hexdocs.pm/hex/Mix.Tasks.Hex.Audit.html",
+      "help" => %{
+        "text" =>
+          "Update the dependency to a version that is not retired or " <>
+            "switch to an alternative package. A retirement you cannot " <>
+            "act on yet can be acknowledged by adding the package to the " <>
+            "ignore_retirements list in the :hex section of mix.exs.",
+        "markdown" =>
+          "Update the dependency to a version that is not retired or " <>
+            "switch to an alternative package. A retirement you cannot " <>
+            "act on yet can be acknowledged by adding the package to the " <>
+            "`ignore_retirements` list in the `:hex` section of `mix.exs`."
+      },
+      "defaultConfiguration" => %{"level" => retired_level(reason)},
+      "messageStrings" => %{
+        "default" => %{"text" => @retired_message_template}
+      }
+    }
+  end
+
+  # A retirement for security reasons points at a real vulnerability,
+  # every other reason is a maintenance warning.
+  defp retired_level(:RETIRED_SECURITY), do: "error"
+  defp retired_level(_reason), do: "warning"
+
+  defp advisory_rule(advisory) do
+    properties =
+      case security_severity(advisory) do
+        nil -> %{"tags" => ["security"]}
+        score -> %{"tags" => ["security"], "security-severity" => score}
+      end
+
+    rule = %{
+      "id" => advisory.id,
+      "name" => rule_name(advisory.id),
+      "shortDescription" => %{"text" => advisory.summary},
+      "fullDescription" => %{"text" => advisory_full_description(advisory)},
+      "help" => advisory_help(advisory),
+      "defaultConfiguration" => %{"level" => advisory_level(advisory)},
+      "messageStrings" => %{
+        "default" => %{"text" => @advisory_message_template}
+      },
+      "properties" => properties
+    }
+
+    case advisory do
+      %{html_url: url} -> Map.put(rule, "helpUri", url)
+      _other -> rule
+    end
+  end
+
+  defp result({:retired, package, version, retired, ignored?}, rule_indexes, artifact, lock_lines) do
+    reason = Map.get(retired, :reason)
+    {rule_id, _name, _short_description} = retired_rule_info(reason)
+    message = Hex.Utils.package_retirement_message(retired)
+
+    %{
+      "ruleId" => rule_id,
+      "ruleIndex" => Map.fetch!(rule_indexes, rule_id),
+      "level" => retired_level(reason),
+      "message" => result_message(@retired_message_template, [package, version, message]),
+      "locations" => [location(package, artifact, lock_lines)],
+      "partialFingerprints" => %{"hexAudit/v1" => "retired:#{package}"}
+    }
+    |> put_suppressions(ignored?)
+  end
+
+  defp result(
+         {:advisory, package, version, advisory, ignored?},
+         rule_indexes,
+         artifact,
+         lock_lines
+       ) do
+    %{
+      "ruleId" => advisory.id,
+      "ruleIndex" => Map.fetch!(rule_indexes, advisory.id),
+      "level" => advisory_level(advisory),
+      "message" => advisory_result_message(package, version, advisory),
+      "locations" => [location(package, artifact, lock_lines)],
+      "partialFingerprints" => %{"hexAudit/v1" => "advisory:#{package}:#{advisory.id}"}
+    }
+    |> put_suppressions(ignored?)
+  end
+
+  defp advisory_help(advisory) do
+    remediation =
+      "Update the affected dependency to a version that is not affected by " <>
+        "#{advisory.id}. An advisory that does not affect the project can be " <>
+        "acknowledged by adding its id to the ignore_advisories list in the " <>
+        ":hex section of mix.exs."
+
+    markdown =
+      case advisory do
+        %{html_url: url} ->
+          "See [#{advisory.id}](#{url}) for details. " <>
+            String.replace(remediation, "ignore_advisories", "`ignore_advisories`")
+
+        _other ->
+          remediation
+      end
+
+    %{"text" => remediation, "markdown" => markdown}
+  end
+
+  # The registry only carries an advisory summary, so the comprehensive
+  # description is the summary plus a pointer to the advisory page.
+  defp advisory_full_description(advisory) do
+    text =
+      if String.ends_with?(advisory.summary, [".", "!", "?"]) do
+        advisory.summary
+      else
+        advisory.summary <> "."
+      end
+
+    case advisory do
+      %{html_url: url} -> text <> " See " <> url <> " for more information."
+      _other -> text
+    end
+  end
+
+  # PascalCase name derived from the advisory id, for example
+  # "GHSA-1234-abcd" becomes "Ghsa1234Abcd".
+  defp rule_name(id) do
+    id
+    |> String.split(["-", "_", ".", ":", "/"], trim: true)
+    |> Enum.map_join(&String.capitalize/1)
+  end
+
+  defp put_suppressions(result, false), do: result
+
+  defp put_suppressions(result, true) do
+    Map.put(result, "suppressions", [
+      %{
+        "kind" => "external",
+        "justification" => "Ignored by the ignore_advisories/ignore_retirements Hex configuration"
+      }
+    ])
+  end
+
+  defp advisory_result_message(package, version, advisory) do
+    id =
+      case advisory do
+        %{aliases: [_ | _] = aliases} ->
+          "#{advisory.id} (aka #{Enum.map_join(aliases, ", ", &alias_id/1)})"
+
+        _other ->
+          advisory.id
+      end
+
+    result_message(@advisory_message_template, [
+      package,
+      version,
+      id,
+      advisory.summary,
+      advisory_url(advisory)
+    ])
+  end
+
+  defp advisory_url(%{html_url: url}), do: url
+  defp advisory_url(advisory), do: "https://osv.dev/vulnerability/#{advisory.id}"
+
+  # A result message carrying both the resolved text (required by GitHub
+  # and Azure DevOps) and the template reference with its arguments (for
+  # consumers that resolve messages through the rule's messageStrings).
+  defp result_message(template, arguments) do
+    text =
+      arguments
+      |> Enum.with_index()
+      |> Enum.reduce(template, fn {argument, index}, text ->
+        String.replace(text, "{#{index}}", argument)
+      end)
+
+    %{"text" => text, "id" => "default", "arguments" => arguments}
+  end
+
+  defp alias_id(%{id: id}), do: id
+  defp alias_id(id) when is_binary(id), do: id
+
+  defp advisory_level(%{severity: severity})
+       when severity in [:SEVERITY_CRITICAL, :SEVERITY_HIGH],
+       do: "error"
+
+  defp advisory_level(%{severity: :SEVERITY_MEDIUM}), do: "warning"
+
+  defp advisory_level(%{severity: severity}) when severity in [:SEVERITY_LOW, :SEVERITY_NONE],
+    do: "note"
+
+  defp advisory_level(_advisory), do: "warning"
+
+  # GitHub buckets `security-severity` scores as critical >= 9.0,
+  # high >= 7.0, medium >= 4.0 and low < 4.0. Advisories only carry a
+  # severity level, so map each level to a representative score.
+  defp security_severity(%{severity: :SEVERITY_CRITICAL}), do: "9.5"
+  defp security_severity(%{severity: :SEVERITY_HIGH}), do: "8.0"
+  defp security_severity(%{severity: :SEVERITY_MEDIUM}), do: "5.5"
+  defp security_severity(%{severity: :SEVERITY_LOW}), do: "3.0"
+  defp security_severity(%{severity: :SEVERITY_NONE}), do: "0.0"
+  defp security_severity(_advisory), do: nil
+
+  defp location(package, artifact, lock_lines) do
+    physical_location =
+      case Map.get(lock_lines.packages, package) do
+        nil ->
+          %{"artifactLocation" => artifact}
+
+        line ->
+          %{
+            "artifactLocation" => artifact,
+            "region" => %{
+              "startLine" => line,
+              "endLine" => line,
+              "snippet" => %{"text" => elem(lock_lines.lines, line - 1)}
+            },
+            "contextRegion" => context_region(lock_lines.lines, line)
+          }
+      end
+
+    %{"physicalLocation" => physical_location}
+  end
+
+  # The result line plus up to one surrounding line on each side.
+  defp context_region(lines, line) do
+    first = max(line - 1, 1)
+    last = min(line + 1, tuple_size(lines))
+
+    snippet = Enum.map_join(first..last, "\n", &elem(lines, &1 - 1))
+
+    %{
+      "startLine" => first,
+      "endLine" => last,
+      "snippet" => %{"text" => snippet}
+    }
+  end
+
+  # The lock file's lines plus a map from each locked package to its line
+  # number, found by looking for the `{:hex, :package_name, ...}` tuples.
+  # Keyed by package name rather than the lock entry's app name since
+  # findings carry package names.
+  defp lock_lines(lockfile) do
+    case File.read(lockfile) do
+      {:ok, contents} ->
+        lines =
+          contents
+          |> String.split("\n")
+          |> Enum.map(&String.trim_trailing/1)
+
+        lines =
+          case Enum.reverse(lines) do
+            ["" | rest] -> Enum.reverse(rest)
+            _other -> lines
+          end
+
+        packages =
+          lines
+          |> Enum.with_index(1)
+          |> Enum.reduce(%{}, fn {line, index}, acc ->
+            case package_from_line(line) do
+              nil -> acc
+              package -> Map.put_new(acc, package, index)
+            end
+          end)
+
+        %{lines: List.to_tuple(lines), packages: packages}
+
+      {:error, _reason} ->
+        %{lines: {}, packages: %{}}
+    end
+  end
+
+  defp package_from_line(line) do
+    with [_before, rest] <- :binary.split(line, "{:hex, :"),
+         [package, _rest] <- :binary.split(rest, ",") do
+      package
+    else
+      _other -> nil
+    end
+  end
+
+  defp encode_json!(term) do
+    if Code.ensure_loaded?(:json) do
+      term |> :json.encode() |> IO.iodata_to_binary()
+    else
+      Mix.raise(":json module is not available, upgrade OTP to use this feature")
+    end
+  end
+end

--- a/lib/mix/tasks/hex.audit.ex
+++ b/lib/mix/tasks/hex.audit.ex
@@ -48,6 +48,69 @@ defmodule Mix.Tasks.Hex.Audit do
   `HEX_IGNORE_RETIREMENTS` environment variables as comma-separated lists,
   where retirement entries are `NAME` or `NAME@VERSION`.
 
+  ## Command line options
+
+    * `--format FORMAT` - selects the output format. Supported formats are
+      `human` (default) and `sarif`. SARIF output requires OTP 27 or later
+    * `--output PATH` - writes the report to the given file instead of
+      printing it. Can only be used with `--format sarif`
+
+  ## SARIF output
+
+  With `--format sarif` the audit result is rendered as a
+  [SARIF](https://docs.oasis-open.org/sarif/sarif/v2.1.0/sarif-v2.1.0.html)
+  v2.1.0 document that code scanning services can ingest. Each finding is
+  anchored to the dependency's entry in `mix.lock`, advisory severities are
+  mapped to SARIF levels and GitHub `security-severity` scores, and ignored
+  findings are included with a suppression so they show up as closed
+  alerts. The exit code behaves the same as with the human format, so CI
+  jobs still fail while findings are open.
+
+  ### Usage with GitHub Actions
+
+  The report can be uploaded to [GitHub code
+  scanning](https://docs.github.com/en/code-security/code-scanning), which
+  lists the findings in the repository's Security tab and annotates
+  `mix.lock` in pull requests:
+
+  ```yaml
+  name: Audit dependencies
+
+  on:
+    push:
+      branches: [main]
+    pull_request:
+    schedule:
+      - cron: "0 6 * * *"
+
+  permissions:
+    contents: read
+    security-events: write
+
+  jobs:
+    audit:
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v5
+        - uses: erlef/setup-beam@v1
+          with:
+            otp-version: "28"
+            elixir-version: "1.18"
+        - run: mix deps.get
+        - run: mix hex.audit --format sarif --output hex-audit.sarif
+        - uses: github/codeql-action/upload-sarif@v4
+          if: always()
+          with:
+            sarif_file: hex-audit.sarif
+            category: hex-audit
+  ```
+
+  `mix hex.audit` exits with a non-zero code when it finds retired packages
+  or advisories, failing the job. `if: always()` makes sure the report is
+  still uploaded in that case. Add `continue-on-error: true` to the audit
+  step instead if the alerts should only appear in the Security tab without
+  failing the build.
+
   > In a project, this task must be invoked before any other tasks
   > that may load or start your application. Otherwise, you must
   > explicitly list `:hex` as part of your `:extra_applications`.
@@ -55,10 +118,24 @@ defmodule Mix.Tasks.Hex.Audit do
 
   @behaviour Hex.Mix.TaskDescription
 
+  @switches [format: :string, output: :string]
+
   @impl true
-  def run(_) do
+  def run(args) do
     Mix.Tasks.Deps.Loadpaths.run(["--no-compile", "--no-listeners"])
     Hex.start()
+
+    {opts, _args} = OptionParser.parse!(args, strict: @switches)
+    format = opts[:format] || "human"
+
+    unless format in ["human", "sarif"] do
+      Mix.raise("Invalid --format value, expected one of: human, sarif")
+    end
+
+    if opts[:output] && format != "sarif" do
+      Mix.raise("--output can only be used with --format sarif")
+    end
+
     Registry.open()
 
     lock = Mix.Dep.Lock.read()
@@ -80,6 +157,33 @@ defmodule Mix.Tasks.Hex.Audit do
 
     {ignored_advisories, advisories} = split_advisory_findings(raw_advisories, ignore_advisories)
 
+    case format do
+      "human" ->
+        print_human(retired, advisories, ignored_retired, ignored_advisories)
+
+      "sarif" ->
+        output_sarif(retired, advisories, ignored_retired, ignored_advisories, opts[:output])
+    end
+
+    warn_unused_ignores(all_retired, raw_advisories, ignore_advisories, ignore_retirements)
+
+    if retired != [] or advisories != [] do
+      if format == "human", do: Hex.Shell.info("")
+      if retired != [], do: Hex.Shell.error("Found retired packages")
+      if advisories != [], do: Hex.Shell.error("Found packages with security advisories")
+      Mix.Tasks.Hex.set_exit_code(1)
+    end
+  end
+
+  @impl true
+  def tasks() do
+    [
+      {"", "Shows retired Hex deps and security advisories for the current project"},
+      {"--format sarif", "Outputs the audit result as a SARIF document"}
+    ]
+  end
+
+  defp print_human(retired, advisories, ignored_retired, ignored_advisories) do
     if retired == [] and advisories == [] and ignored_retired == [] and
          ignored_advisories == [] do
       Hex.Shell.info("No retired or security advisory packages found")
@@ -91,22 +195,28 @@ defmodule Mix.Tasks.Hex.Audit do
         {:advisories, "Ignored advisories:", ignored_advisories}
       ])
     end
+  end
 
-    warn_unused_ignores(all_retired, raw_advisories, ignore_advisories, ignore_retirements)
+  defp output_sarif(retired, advisories, ignored_retired, ignored_advisories, output) do
+    findings =
+      sarif_findings(:retired, retired, false) ++
+        sarif_findings(:retired, ignored_retired, true) ++
+        sarif_findings(:advisory, advisories, false) ++
+        sarif_findings(:advisory, ignored_advisories, true)
 
-    if retired != [] or advisories != [] do
-      Hex.Shell.info("")
-      if retired != [], do: Hex.Shell.error("Found retired packages")
-      if advisories != [], do: Hex.Shell.error("Found packages with security advisories")
-      Mix.Tasks.Hex.set_exit_code(1)
+    lockfile = Mix.Project.config()[:lockfile] || "mix.lock"
+    sarif = Hex.Sarif.encode_audit(findings, lockfile)
+
+    case output do
+      nil -> Hex.Shell.info(sarif)
+      path -> File.write!(path, [sarif, ?\n])
     end
   end
 
-  @impl true
-  def tasks() do
-    [
-      {"", "Shows retired Hex deps and security advisories for the current project"}
-    ]
+  defp sarif_findings(type, entries, ignored?) do
+    Enum.map(entries, fn {package, version, detail} ->
+      {type, package, version, detail, ignored?}
+    end)
   end
 
   defp retired_packages(lock) do
@@ -115,7 +225,7 @@ defmodule Mix.Tasks.Hex.Audit do
 
   defp retirement_status(%{repo: repo, name: package, version: version}) do
     case Registry.retired(repo, package, version) do
-      %{} = retired -> [{package, version, Hex.Utils.package_retirement_message(retired)}]
+      %{} = retired -> [{package, version, retired}]
       nil -> []
     end
   end
@@ -164,7 +274,8 @@ defmodule Mix.Tasks.Hex.Audit do
   defp print_section(:retired, header, entries) do
     Hex.Shell.info(Hex.Shell.format([:bright, header, :reset]))
 
-    Enum.each(entries, fn {package, version, message} ->
+    Enum.each(entries, fn {package, version, retired} ->
+      message = Hex.Utils.package_retirement_message(retired)
       Hex.Shell.info(Hex.Shell.format(["  #{package} #{version} - ", :yellow, message, :reset]))
     end)
   end

--- a/test/mix/tasks/hex.audit_test.exs
+++ b/test/mix/tasks/hex.audit_test.exs
@@ -300,6 +300,248 @@ defmodule Mix.Tasks.Hex.AuditTest do
     end)
   end
 
+  @tag :requires_json
+  test "audit --format sarif (retirement and advisory)", context do
+    with_test_package("3.0.0", context, fn ->
+      :sys.replace_state(Hex.Registry.Server, fn %{ets: tid} = state ->
+        :ets.insert(
+          tid,
+          {{:retired, "hexpm", @package_name, "3.0.0"}, %{reason: :RETIRED_SECURITY}}
+        )
+
+        :ets.insert(tid, {{:advisories, "hexpm", @package_name, "3.0.0"}, [@advisory]})
+        state
+      end)
+
+      assert catch_throw(Mix.Task.run("hex.audit", ["--format", "sarif"])) == {:exit_code, 1}
+
+      assert_received {:mix_shell, :error, ["Found retired packages"]}
+      assert_received {:mix_shell, :error, ["Found packages with security advisories"]}
+
+      hex_version = Hex.version()
+      full_name = "mix hex.audit (Hex #{hex_version})"
+      summary = @advisory.summary
+      advisory_url = @advisory.html_url
+      full_description = "#{summary}. See #{advisory_url} for more information."
+
+      advisory_help_text =
+        "Update the affected dependency to a version that is not affected by " <>
+          "GHSA-test-0001. An advisory that does not affect the project can be " <>
+          "acknowledged by adding its id to the ignore_advisories list in the " <>
+          ":hex section of mix.exs."
+
+      advisory_help_markdown =
+        "See [GHSA-test-0001](#{advisory_url}) for details. " <>
+          String.replace(advisory_help_text, "ignore_advisories", "`ignore_advisories`")
+
+      retired_message = "Dependency '#{@package_name}' '3.0.0' is retired: '(security)'."
+
+      advisory_message =
+        "Dependency '#{@package_name}' '3.0.0' is affected by security advisory " <>
+          "'GHSA-test-0001': '#{summary}'. See '#{advisory_url}'."
+
+      assert %{
+               "$schema" => "https://json.schemastore.org/sarif-2.1.0.json",
+               "version" => "2.1.0",
+               "runs" => [
+                 %{
+                   "automationDetails" => %{
+                     "id" => "hex-audit/",
+                     "description" => %{"text" => "Hex dependency audit (mix hex.audit)"}
+                   },
+                   "originalUriBaseIds" => %{"SRCROOT" => %{"uri" => src_root}},
+                   "versionControlProvenance" => [provenance],
+                   "tool" => %{
+                     "driver" => %{
+                       "name" => "mix hex.audit",
+                       "fullName" => ^full_name,
+                       "informationUri" => "https://hex.pm",
+                       "version" => ^hex_version,
+                       "rules" => [
+                         %{
+                           "id" => "HEX0003",
+                           "name" => "RetiredPackageSecurity",
+                           "shortDescription" => %{"text" => "Hex package retired: security"},
+                           "fullDescription" => %{
+                             "text" =>
+                               "The locked version of this dependency has been retired by " <>
+                                 "its maintainers and is no longer recommended for use."
+                           },
+                           "helpUri" => "https://hexdocs.pm/hex/Mix.Tasks.Hex.Audit.html",
+                           "help" => %{
+                             "text" =>
+                               "Update the dependency to a version that is not retired or " <>
+                                 "switch to an alternative package. A retirement you cannot " <>
+                                 "act on yet can be acknowledged by adding the package to " <>
+                                 "the ignore_retirements list in the :hex section of mix.exs.",
+                             "markdown" =>
+                               "Update the dependency to a version that is not retired or " <>
+                                 "switch to an alternative package. A retirement you cannot " <>
+                                 "act on yet can be acknowledged by adding the package to " <>
+                                 "the `ignore_retirements` list in the `:hex` section of " <>
+                                 "`mix.exs`."
+                           },
+                           "defaultConfiguration" => %{"level" => "error"},
+                           "messageStrings" => %{
+                             "default" => %{
+                               "text" => "Dependency '{0}' '{1}' is retired: '{2}'."
+                             }
+                           }
+                         },
+                         %{
+                           "id" => "GHSA-test-0001",
+                           "name" => "GhsaTest0001",
+                           "shortDescription" => %{"text" => ^summary},
+                           "fullDescription" => %{"text" => ^full_description},
+                           "helpUri" => ^advisory_url,
+                           "help" => %{
+                             "text" => ^advisory_help_text,
+                             "markdown" => ^advisory_help_markdown
+                           },
+                           "defaultConfiguration" => %{"level" => "error"},
+                           "messageStrings" => %{
+                             "default" => %{
+                               "text" =>
+                                 "Dependency '{0}' '{1}' is affected by security advisory " <>
+                                   "'{2}': '{3}'. See '{4}'."
+                             }
+                           },
+                           "properties" => %{
+                             "tags" => ["security"],
+                             "security-severity" => "8.0"
+                           }
+                         }
+                       ]
+                     }
+                   },
+                   "results" => [
+                     %{
+                       "ruleId" => "HEX0003",
+                       "ruleIndex" => 0,
+                       "level" => "error",
+                       "message" => %{
+                         "text" => ^retired_message,
+                         "id" => "default",
+                         "arguments" => [@package_name, "3.0.0", "(security)"]
+                       },
+                       "locations" => [retired_location],
+                       "partialFingerprints" => %{"hexAudit/v1" => "retired:test_package"}
+                     } = retired_result,
+                     %{
+                       "ruleId" => "GHSA-test-0001",
+                       "ruleIndex" => 1,
+                       "level" => "error",
+                       "message" => %{
+                         "text" => ^advisory_message,
+                         "id" => "default",
+                         "arguments" => [
+                           @package_name,
+                           "3.0.0",
+                           "GHSA-test-0001",
+                           ^summary,
+                           ^advisory_url
+                         ]
+                       },
+                       "locations" => [advisory_location],
+                       "partialFingerprints" => %{
+                         "hexAudit/v1" => "advisory:test_package:GHSA-test-0001"
+                       }
+                     } = advisory_result
+                   ]
+                 }
+               ]
+             } = decode_sarif()
+
+      refute Map.has_key?(retired_result, "suppressions")
+      refute Map.has_key?(advisory_result, "suppressions")
+
+      # The test runs inside the Hex repository checkout, so git-derived
+      # version control provenance is available.
+      assert String.starts_with?(src_root, "file:///")
+      assert String.ends_with?(src_root, "/")
+
+      assert %{
+               "repositoryUri" => repository_uri,
+               "revisionId" => revision_id,
+               "mappedTo" => %{"uriBaseId" => "SRCROOT"}
+             } = provenance
+
+      assert repository_uri =~ "://"
+      assert is_binary(revision_id)
+
+      # The lock file lives in a tmp directory inside the Hex repository
+      # checkout, so its uri is relative to the repository root.
+      assert %{
+               "physicalLocation" => %{
+                 "artifactLocation" => %{"uri" => lock_uri, "uriBaseId" => "SRCROOT"},
+                 "region" => %{
+                   "startLine" => 2,
+                   "endLine" => 2,
+                   "snippet" => %{"text" => region_snippet}
+                 },
+                 "contextRegion" => %{
+                   "startLine" => 1,
+                   "endLine" => 3,
+                   "snippet" => %{"text" => context_snippet}
+                 }
+               }
+             } = advisory_location
+
+      assert retired_location == advisory_location
+      assert String.ends_with?(lock_uri, "/mix.lock")
+      assert region_snippet =~ ~s("#{@package_name}": {:hex, :#{@package_name}, "3.0.0")
+      assert context_snippet =~ "%{\n"
+      assert context_snippet =~ region_snippet
+    end)
+  end
+
+  @tag :requires_json
+  test "audit --format sarif (ignored findings are suppressed)", context do
+    with_test_package("3.1.0", context, fn ->
+      inject_advisory(@package_name, "3.1.0", [@advisory])
+      Hex.State.put(:ignore_advisories, ["GHSA-test-0001"])
+
+      Mix.Task.run("hex.audit", ["--format", "sarif"])
+
+      sarif = decode_sarif()
+      [run] = sarif["runs"]
+      [result] = run["results"]
+
+      assert result["ruleId"] == "GHSA-test-0001"
+      assert [%{"kind" => "external"}] = result["suppressions"]
+    end)
+  end
+
+  @tag :requires_json
+  test "audit --format sarif --output writes a file", context do
+    with_test_package("3.2.0", context, fn ->
+      Mix.Task.run("hex.audit", ["--format", "sarif", "--output", "hex-audit.sarif"])
+
+      sarif = "hex-audit.sarif" |> File.read!() |> :json.decode()
+      [run] = sarif["runs"]
+      assert run["results"] == []
+      assert run["tool"]["driver"]["rules"] == []
+
+      refute_received {:mix_shell, :info, ["No retired or security advisory packages found"]}
+    end)
+  end
+
+  test "audit --format with an invalid format", context do
+    with_test_package("3.3.0", context, fn ->
+      assert_raise Mix.Error, "Invalid --format value, expected one of: human, sarif", fn ->
+        Mix.Task.run("hex.audit", ["--format", "yaml"])
+      end
+    end)
+  end
+
+  test "audit --output without sarif format", context do
+    with_test_package("3.4.0", context, fn ->
+      assert_raise Mix.Error, "--output can only be used with --format sarif", fn ->
+        Mix.Task.run("hex.audit", ["--output", "audit.json"])
+      end
+    end)
+  end
+
   def with_test_package(version, %{auth: auth}, fun) do
     Mix.Project.push(RetiredDeps.MixProject)
 
@@ -350,5 +592,15 @@ defmodule Mix.Tasks.Hex.AuditTest do
 
   defp render(message) do
     message |> Hex.Shell.format() |> IO.iodata_to_binary()
+  end
+
+  defp decode_sarif do
+    infos =
+      for {:mix_shell, :info, [message]} <- flush() do
+        IO.chardata_to_string(message)
+      end
+
+    assert [json] = infos
+    :json.decode(json)
   end
 end


### PR DESCRIPTION
Add a `--format` sarif option that renders the audit result as a SARIF v2.1.0 document, plus an `--output PATH` option to write it to a file instead of stdout. This allows uploading audit findings to GitHub code scanning and other SARIF consumers; the`moduledoc` documents a complete GitHub Actions workflow using `github/codeql-action/upload-sarif`.

Retirements map to one rule per retirement reason (HEX0001 to HEX0005, with security retirements defaulting to level error) and advisories map to one rule per advisory identifier so each alert carries its own severity score, title and help link. Results are anchored to the dependency entry in `mix.lock`, relative to the git repository root when available, with region and context region snippets. The run includes git-derived version control provenance (with credentials stripped from
the repository URL), stable partial fingerprints, and messages that carry both resolved text and template arguments. Ignored findings are included with a suppression so they show up as closed alerts.

The exit code behaves the same as with the human format. SARIF output requires the OTP 27 `json` module, matching `mix hex.outdated --json`.

Needs #1202 