### PR TITLE
Link to the hex.pm diffs page in mix hex.outdated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Print warnings to standard error instead of standard output, keeping stdout clean for machine-readable output such as `mix hex.outdated --json`. Warning-colored lines that are part of a command's regular output, such as retirement notices in `mix hex.info` and the `mix deps.get` dependency listing, remain on standard output
 * Add `--format sarif` and `--output PATH` options to `mix hex.audit` to render the audit result as a SARIF v2.1.0 document that can be uploaded to GitHub code scanning and other SARIF consumers. Findings are anchored to the dependency's `mix.lock` entry and ignored findings are included as suppressed results. Requires OTP 27 or later
+* Link to the hex.pm diffs page (`https://hex.pm/diffs`) in `mix hex.outdated` now that package diffs have moved from diff.hex.pm into hex.pm
 
 ## v2.5.1 (2026-07-09)
 

--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -433,7 +433,7 @@ defmodule Mix.Tasks.Hex.Outdated do
   end
 
   defp diff_link(diff_links) do
-    long_url = "https://diff.hex.pm/diffs?" <> Enum.join(diff_links, "&")
+    long_url = "https://hex.pm/diffs?" <> Enum.join(diff_links, "&")
 
     if Hex.State.fetch!(:no_short_urls) do
       long_url

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -784,8 +784,20 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
       lines = flush()
       output = Enum.map_join(lines, "\n", fn {_, _, [line]} -> line end)
 
+      assert output =~ "To view the diffs in each available update, visit:"
+      assert output =~ ~r"http://localhost:\d+/l/\w+"
+
       assert output =~
                "To view the diff of a specific update, run `mix hex.package diff APP FROM..TO`."
+
+      Hex.State.put(:no_short_urls, true)
+
+      assert catch_throw(Mix.Task.rerun("hex.outdated", ["--all"])) == {:exit_code, 1}
+
+      lines = flush()
+      output = Enum.map_join(lines, "\n", fn {_, _, [line]} -> line end)
+
+      assert output =~ "https://hex.pm/diffs?diffs[]=foo:0.1.0:0.1.1"
     end)
   end
 


### PR DESCRIPTION
Package diffs moved from diff.hex.pm into hex.pm, so `mix hex.outdated` now builds its combined diff link as `https://hex.pm/diffs?diffs[]=...` instead of `https://diff.hex.pm/diffs?...`, still shortened into a single short URL. Depends on the restored multi-comparison diffs view in hexpm/hexpm#1730.