### PR TITLE
Support organization packages in the outdated diffs link

### DIFF
--- a/lib/mix/tasks/hex.outdated.ex
+++ b/lib/mix/tasks/hex.outdated.ex
@@ -140,7 +140,7 @@ defmodule Mix.Tasks.Hex.Outdated do
   end
 
   defp display_table(
-         [{_package, _dep_only, current, latest, requirements, outdated?, cooldown}],
+         [{_repo, _package, _dep_only, current, latest, requirements, outdated?, cooldown}],
          [_app],
          _opts
        ) do
@@ -198,7 +198,7 @@ defmodule Mix.Tasks.Hex.Outdated do
   defp maybe_print_cooldown_legend(versions) do
     entries =
       Enum.flat_map(versions, fn
-        {package, _, _, latest, _, _, %{eligible_on: eligible_on}} ->
+        {_repo, package, _, _, latest, _, _, %{eligible_on: eligible_on}} ->
           [{package, latest, eligible_on}]
 
         _ ->
@@ -223,7 +223,7 @@ defmodule Mix.Tasks.Hex.Outdated do
 
   defp set_exit_code(versions, args, opts) do
     outdated_versions =
-      Enum.filter(versions, fn {_p, _o, _l, _la, _r, outdated?, cooldown} ->
+      Enum.filter(versions, fn {_repo, _p, _o, _l, _la, _r, outdated?, cooldown} ->
         outdated? and is_nil(cooldown)
       end)
 
@@ -301,7 +301,8 @@ defmodule Mix.Tasks.Hex.Outdated do
         # deps can have multiple `only` values, so we separate by `,`
         only_values = String.split(only_value, ",", trim: true)
 
-        Enum.filter(versions, fn {_package, dep_only, _lock, _latest, _reqs, _outdated?, _c} ->
+        Enum.filter(versions, fn {_repo, _package, dep_only, _lock, _latest, _reqs, _outdated?,
+                                  _c} ->
           dep_only_parts = String.split(dep_only, ",")
           Enum.any?(dep_only_parts, &(&1 in only_values))
         end)
@@ -337,7 +338,7 @@ defmodule Mix.Tasks.Hex.Outdated do
             end
 
           [
-            {Atom.to_string(name), dep_only, lock_version, latest_version, requirements,
+            {repo, Atom.to_string(name), dep_only, lock_version, latest_version, requirements,
              outdated?, cooldown}
           ]
 
@@ -385,7 +386,7 @@ defmodule Mix.Tasks.Hex.Outdated do
     List.last(versions)
   end
 
-  defp format_all_row({package, dep_only, lock, latest, requirements, outdated?, cooldown}) do
+  defp format_all_row({_repo, package, dep_only, lock, latest, requirements, outdated?, cooldown}) do
     latest_color = if outdated?, do: :red, else: :green
     req_matches? = req_matches?(requirements, latest)
 
@@ -407,14 +408,23 @@ defmodule Mix.Tasks.Hex.Outdated do
     ]
   end
 
-  defp build_diff_link({package, _dep_only, lock, latest, requirements, outdated?, _cooldown}) do
+  defp build_diff_link(
+         {repo, package, _dep_only, lock, latest, requirements, outdated?, _cooldown}
+       ) do
     req_matches? = req_matches?(requirements, latest)
 
-    case {outdated?, req_matches?} do
-      {true, true} -> "diffs[]=#{package}:#{lock}:#{latest}"
-      {_, _} -> nil
+    with true <- outdated?,
+         true <- req_matches?,
+         comparison_package when is_binary(comparison_package) <- diff_package(repo, package) do
+      "diffs[]=#{comparison_package}:#{lock}:#{latest}"
+    else
+      _ -> nil
     end
   end
+
+  defp diff_package("hexpm", package), do: package
+  defp diff_package("hexpm:" <> organization, package), do: "#{organization}/#{package}"
+  defp diff_package(_repo, _package), do: nil
 
   defp version_match?(_version, nil), do: true
   defp version_match?(version, req), do: Version.match?(version, req)
@@ -435,11 +445,15 @@ defmodule Mix.Tasks.Hex.Outdated do
   defp diff_link(diff_links) do
     long_url = "https://hex.pm/diffs?" <> Enum.join(diff_links, "&")
 
-    if Hex.State.fetch!(:no_short_urls) do
+    if Hex.State.fetch!(:no_short_urls) or private_comparison?(diff_links) do
       long_url
     else
       maybe_get_short_link(long_url)
     end
+  end
+
+  defp private_comparison?(diff_links) do
+    Enum.any?(diff_links, &String.contains?(&1, "/"))
   end
 
   defp maybe_get_short_link(long_url) do
@@ -450,8 +464,8 @@ defmodule Mix.Tasks.Hex.Outdated do
   end
 
   defp any_possible_to_update?(outdated_versions) do
-    Enum.any?(outdated_versions, fn {_package, _dep_only, _lock, latest, requirements, _outdated?,
-                                     _cooldown} ->
+    Enum.any?(outdated_versions, fn {_repo, _package, _dep_only, _lock, latest, requirements,
+                                     _outdated?, _cooldown} ->
       req_matches?(requirements, latest)
     end)
   end
@@ -476,7 +490,9 @@ defmodule Mix.Tasks.Hex.Outdated do
     |> Enum.join(",")
   end
 
-  defp cast_version_map({package, dep_only, lock, latest, requirements, outdated?, cooldown}) do
+  defp cast_version_map(
+         {_repo, package, dep_only, lock, latest, requirements, outdated?, cooldown}
+       ) do
     %{
       package: package,
       only: dep_only,

--- a/test/mix/tasks/hex.outdated_test.exs
+++ b/test/mix/tasks/hex.outdated_test.exs
@@ -14,6 +14,18 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
     end
   end
 
+  defmodule OutdatedOrganizationDeps.MixProject do
+    def project do
+      [
+        app: :outdated_app,
+        version: "0.0.1",
+        deps: [
+          {:foo, "~> 0.1.0", repo: "hexpm:testorg"}
+        ]
+      ]
+    end
+  end
+
   defmodule OutdatedBetaDeps.MixProject do
     def project do
       [
@@ -798,6 +810,39 @@ defmodule Mix.Tasks.Hex.OutdatedTest do
       output = Enum.map_join(lines, "\n", fn {_, _, [line]} -> line end)
 
       assert output =~ "https://hex.pm/diffs?diffs[]=foo:0.1.0:0.1.1"
+    end)
+  end
+
+  test "outdated links organization diffs without shortening the URL" do
+    Mix.Project.push(OutdatedOrganizationDeps.MixProject)
+
+    in_tmp(fn ->
+      set_home_tmp()
+
+      suffix = System.unique_integer([:positive])
+
+      auth =
+        Hexpm.new_user(
+          "outdated_org_#{suffix}",
+          "outdated_org_#{suffix}@mail.com",
+          "password",
+          "outdated_org_key_#{suffix}"
+        )
+
+      repos = Hex.State.fetch!(:repos)
+      Hex.State.put(:repos, put_in(repos["hexpm"].auth_key, auth[:key]))
+
+      Mix.Dep.Lock.write(%{foo: {:hex, :foo, "0.1.0", nil, nil, nil, "hexpm:testorg", nil}})
+
+      Mix.Task.run("deps.get")
+      flush()
+
+      assert catch_throw(Mix.Task.run("hex.outdated", ["--all"])) == {:exit_code, 1}
+
+      lines = flush()
+      output = Enum.map_join(lines, "\n", fn {_, _, [line]} -> line end)
+
+      assert output =~ "https://hex.pm/diffs?diffs[]=testorg/foo:0.1.0:0.1.1"
     end)
   end
 

--- a/test/setup_hexpm.exs
+++ b/test/setup_hexpm.exs
@@ -87,6 +87,7 @@ Hexpm.new_package(
 
 Hexpm.new_repo("testorg", auth)
 Hexpm.new_package("testorg", "foo", "0.1.0", [], pkg_meta, auth)
+Hexpm.new_package("testorg", "foo", "0.1.1", [], pkg_meta, auth)
 Hexpm.new_package("testorg", "bar", "0.1.0", [foo: "~> 0.1.0"], pkg_meta, auth)
 
 Hexpm.new_repo("remote_converger_org", auth)


### PR DESCRIPTION
Make `mix hex.outdated` produce working diff links for organization packages.
Today the repository is dropped when building the `hex.pm/diffs` link, so private
packages get a public-style `name:from:to` comparison that resolves against the
wrong package or 404s.

The lock repository is now carried through to `build_diff_link/1`, which maps:

- `hexpm` to `name:from:to` (unchanged)
- `hexpm:ORG` to `ORG/name:from:to`, matching the repo-scoped diff route
- any other repository to no link, since hex.pm cannot diff packages it does not
  host (this also drops today's broken links for custom repositories)

Repository-qualified links are never run through the short-URL service. Short
codes are unauthenticated redirects, so shortening one would expose the
organization and package names in the `Location` header. The long URL is printed
instead.

Builds on #1204 and pairs with hexpm#1728, which adds the
`/diff/:repository/:package/:versions` route and repository-qualified parsing on
the `/diffs` index.
