### PR TITLE
Allow a secret_scan package metadata key

### DIFF
--- a/lib/hex/package.ex
+++ b/lib/hex/package.ex
@@ -53,6 +53,12 @@ defmodule Hex.Package do
         package. If a `rebar` or `rebar.config` file is present Hex will mark it
         as able to build with rebar. This detection can be overridden by setting
         this field.
+      * `:secret_scan` - Configuration for the repository's secret scanning of
+        the package. Supports `:ignore`, a list of file path globs whose
+        findings are suppressed, for paths that deliberately ship secret-like
+        values such as test fixtures:
+
+            secret_scan: [ignore: ["test/fixtures/**"]]
     """
   end
 end

--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -367,8 +367,16 @@ defmodule Mix.Tasks.Hex.Build do
     end
   end
 
+  defp format_metadata_value([]) do
+    ""
+  end
+
   defp format_metadata_value(list) when is_list(list) do
-    Enum.join(list, ", ")
+    if Keyword.keyword?(list) do
+      format_metadata_value(Map.new(list))
+    else
+      Enum.join(list, ", ")
+    end
   end
 
   defp format_metadata_value(map) when is_map(map) do

--- a/lib/mix/tasks/hex.build.ex
+++ b/lib/mix/tasks/hex.build.ex
@@ -33,7 +33,7 @@ defmodule Mix.Tasks.Hex.Build do
 
   @error_fields ~w(app name files version build_tools)a
   @warn_fields ~w(description licenses links)a
-  @meta_fields @error_fields ++ @warn_fields ++ ~w(elixir extra)a
+  @meta_fields @error_fields ++ @warn_fields ++ ~w(elixir extra secret_scan)a
   @root_fields ~w(app version elixir description)a
   @max_description_length 300
   @default_repo "hexpm"

--- a/test/mix/tasks/hex.build_test.exs
+++ b/test/mix/tasks/hex.build_test.exs
@@ -403,23 +403,26 @@ defmodule Mix.Tasks.Hex.BuildTest do
     purge([ReleaseMeta.MixProject])
   end
 
-  test "keeps secret_scan config in the metadata" do
-    meta =
-      Mix.Tasks.Hex.Build.package(
-        %{
-          secret_scan: [ignore: ["test/fixtures/**"]],
-          files: [],
-          app: :demo,
-          name: "demo",
-          description: "d",
-          licenses: ["MIT"],
-          build_tools: ["mix"]
-        },
-        app: :demo,
-        version: "1.0.0"
-      )
+  test "create with secret_scan" do
+    Process.put(:hex_test_app_name, :build_secret_scan)
+    Mix.Project.push(ReleaseSecretScan.MixProject)
 
-    assert meta[:secret_scan] == [ignore: ["test/fixtures/**"]]
+    in_tmp(fn ->
+      Hex.State.put(:cache_home, tmp_path())
+
+      File.write!("myfile.txt", "hello")
+      File.chmod!("myfile.txt", 0o100644)
+
+      Mix.Tasks.Hex.Build.run(["--unpack"])
+
+      # A keyword list has to print like a map does, not blow up on the tuples.
+      assert_received {:mix_shell, :info, ["  Secret scan: \n    ignore: test/fixtures/**"]}
+
+      {:ok, metadata} = :file.consult("build_secret_scan-0.0.1/hex_metadata.config")
+      assert {"secret_scan", [{"ignore", ["test/fixtures/**"]}]} in metadata
+    end)
+  after
+    purge([ReleaseSecretScan.MixProject])
   end
 
   test "reject package if description is missing" do

--- a/test/mix/tasks/hex.build_test.exs
+++ b/test/mix/tasks/hex.build_test.exs
@@ -403,6 +403,25 @@ defmodule Mix.Tasks.Hex.BuildTest do
     purge([ReleaseMeta.MixProject])
   end
 
+  test "keeps secret_scan config in the metadata" do
+    meta =
+      Mix.Tasks.Hex.Build.package(
+        %{
+          secret_scan: [ignore: ["test/fixtures/**"]],
+          files: [],
+          app: :demo,
+          name: "demo",
+          description: "d",
+          licenses: ["MIT"],
+          build_tools: ["mix"]
+        },
+        app: :demo,
+        version: "1.0.0"
+      )
+
+    assert meta[:secret_scan] == [ignore: ["test/fixtures/**"]]
+  end
+
   test "reject package if description is missing" do
     Process.put(:hex_test_app_name, :build_no_description)
     Mix.Project.push(ReleaseNoDescription.MixProject)

--- a/test/support/release_samples.ex
+++ b/test/support/release_samples.ex
@@ -29,6 +29,22 @@ defmodule ReleaseSimple.MixProject do
   end
 end
 
+defmodule ReleaseSecretScan.MixProject do
+  def project do
+    [
+      app: Process.get(:hex_test_app_name) || raise("missing app name"),
+      description: "baz",
+      version: "0.0.1",
+      package: [
+        licenses: ["MIT"],
+        files: ["myfile.txt"],
+        links: %{"a" => "http://a"},
+        secret_scan: [ignore: ["test/fixtures/**"]]
+      ]
+    ]
+  end
+end
+
 defmodule ReleaseNewSimple.MixProject do
   def project do
     [


### PR DESCRIPTION
Adds `:secret_scan` to the package metadata carried into the tarball, so hexpm's credential scanner can read a per-package ignore list:

    package: [
      secret_scan: [ignore: ["test/fixtures/**", "priv/certs/*.pem"]]
    ]

Documented in `Hex.Package.configuration_doc/0`. Companion to the hexpm scanner and the field definition in the specifications repo.

Companion PRs: hexpm/hexpm#1806, hexpm/specifications#77
