### PR TITLE
Do not send Hex.pm OAuth tokens to custom repositories

### DIFF
--- a/lib/hex/auth.ex
+++ b/lib/hex/auth.ex
@@ -34,16 +34,11 @@ defmodule Hex.Auth do
   end
 
   @doc false
-  @spec callbacks(keyword()) :: :mix_hex_cli_auth.callbacks()
-  def callbacks(opts \\ []) do
-    get_oauth_tokens =
-      if Keyword.get(opts, :global_oauth, true),
-        do: &get_oauth_tokens/0,
-        else: fn -> :error end
-
+  @spec callbacks() :: :mix_hex_cli_auth.callbacks()
+  def callbacks do
     %{
       get_auth_config: &get_auth_config/1,
-      get_oauth_tokens: get_oauth_tokens,
+      get_oauth_tokens: &get_oauth_tokens/0,
       persist_oauth_tokens: &persist_oauth_tokens/4,
       clear_oauth_tokens: &clear_oauth_tokens/0,
       prompt_otp: &prompt_otp/1,

--- a/lib/hex/auth.ex
+++ b/lib/hex/auth.ex
@@ -34,11 +34,16 @@ defmodule Hex.Auth do
   end
 
   @doc false
-  @spec callbacks() :: :mix_hex_cli_auth.callbacks()
-  def callbacks do
+  @spec callbacks(keyword()) :: :mix_hex_cli_auth.callbacks()
+  def callbacks(opts \\ []) do
+    get_oauth_tokens =
+      if Keyword.get(opts, :global_oauth, true),
+        do: &get_oauth_tokens/0,
+        else: fn -> :error end
+
     %{
       get_auth_config: &get_auth_config/1,
-      get_oauth_tokens: &get_oauth_tokens/0,
+      get_oauth_tokens: get_oauth_tokens,
       persist_oauth_tokens: &persist_oauth_tokens/4,
       clear_oauth_tokens: &clear_oauth_tokens/0,
       prompt_otp: &prompt_otp/1,

--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -248,7 +248,7 @@ defmodule Hex.Repo do
 
   def get_installs() do
     repo = get_repo("hexpm")
-    config = build_hex_core_config(repo, "")
+    config = build_hex_core_config(repo, "hexpm")
 
     Hex.Auth.with_repo(config, &:mix_hex_repo.get_hex_installs/1)
   end
@@ -319,7 +319,8 @@ defmodule Hex.Repo do
         repo_verify: !unsafe_registry,
         repo_verify_origin: !no_verify_repo_origin,
         trusted: Map.get(repo_config, :trusted, false),
-        oauth_exchange: Map.get(repo_config, :oauth_exchange, false)
+        oauth_exchange: Map.get(repo_config, :oauth_exchange, false),
+        cli_auth_callbacks: Hex.Auth.callbacks(global_oauth: repo_name == "hexpm")
     }
 
     if repo_config.auth_key do

--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -248,7 +248,7 @@ defmodule Hex.Repo do
 
   def get_installs() do
     repo = get_repo("hexpm")
-    config = build_hex_core_config(repo, "hexpm")
+    config = build_hex_core_config(repo, "", nil, global_oauth: true)
 
     Hex.Auth.with_repo(config, &:mix_hex_repo.get_hex_installs/1)
   end
@@ -301,6 +301,10 @@ defmodule Hex.Repo do
   end
 
   defp build_hex_core_config(repo_config, repo_name, etag \\ nil) do
+    build_hex_core_config(repo_config, repo_name, etag, [])
+  end
+
+  defp build_hex_core_config(repo_config, repo_name, etag, opts) do
     unsafe_registry = Hex.State.fetch!(:unsafe_registry)
     no_verify_repo_origin = Hex.State.fetch!(:no_verify_repo_origin)
 
@@ -320,7 +324,8 @@ defmodule Hex.Repo do
         repo_verify_origin: !no_verify_repo_origin,
         trusted: Map.get(repo_config, :trusted, false),
         oauth_exchange: Map.get(repo_config, :oauth_exchange, false),
-        cli_auth_callbacks: Hex.Auth.callbacks(global_oauth: repo_name == "hexpm")
+        cli_auth_callbacks:
+          Hex.Auth.callbacks(global_oauth: Keyword.get(opts, :global_oauth, repo_name == "hexpm"))
     }
 
     if repo_config.auth_key do

--- a/lib/hex/repo.ex
+++ b/lib/hex/repo.ex
@@ -248,7 +248,7 @@ defmodule Hex.Repo do
 
   def get_installs() do
     repo = get_repo("hexpm")
-    config = build_hex_core_config(repo, "", nil, global_oauth: true)
+    config = build_hex_core_config(repo, "")
 
     Hex.Auth.with_repo(config, &:mix_hex_repo.get_hex_installs/1)
   end
@@ -301,10 +301,6 @@ defmodule Hex.Repo do
   end
 
   defp build_hex_core_config(repo_config, repo_name, etag \\ nil) do
-    build_hex_core_config(repo_config, repo_name, etag, [])
-  end
-
-  defp build_hex_core_config(repo_config, repo_name, etag, opts) do
     unsafe_registry = Hex.State.fetch!(:unsafe_registry)
     no_verify_repo_origin = Hex.State.fetch!(:no_verify_repo_origin)
 
@@ -323,9 +319,7 @@ defmodule Hex.Repo do
         repo_verify: !unsafe_registry,
         repo_verify_origin: !no_verify_repo_origin,
         trusted: Map.get(repo_config, :trusted, false),
-        oauth_exchange: Map.get(repo_config, :oauth_exchange, false),
-        cli_auth_callbacks:
-          Hex.Auth.callbacks(global_oauth: Keyword.get(opts, :global_oauth, repo_name == "hexpm"))
+        oauth_exchange: Map.get(repo_config, :oauth_exchange, false)
     }
 
     if repo_config.auth_key do

--- a/src/mix_hex_advisory.erl
+++ b/src/mix_hex_advisory.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Display-time deduplication of security advisories.

--- a/src/mix_hex_api.erl
+++ b/src/mix_hex_api.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex HTTP API

--- a/src/mix_hex_api_auth.erl
+++ b/src/mix_hex_api_auth.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex HTTP API - Authentication.

--- a/src/mix_hex_api_key.erl
+++ b/src/mix_hex_api_key.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex HTTP API - Keys.

--- a/src/mix_hex_api_oauth.erl
+++ b/src/mix_hex_api_oauth.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex HTTP API - OAuth.

--- a/src/mix_hex_api_organization.erl
+++ b/src/mix_hex_api_organization.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex HTTP API - Organizations.

--- a/src/mix_hex_api_organization_member.erl
+++ b/src/mix_hex_api_organization_member.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex HTTP API - Organization Members.

--- a/src/mix_hex_api_package.erl
+++ b/src/mix_hex_api_package.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex HTTP API - Packages.

--- a/src/mix_hex_api_package_owner.erl
+++ b/src/mix_hex_api_package_owner.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex HTTP API - Package Owners.

--- a/src/mix_hex_api_release.erl
+++ b/src/mix_hex_api_release.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex HTTP API - Releases.

--- a/src/mix_hex_api_short_url.erl
+++ b/src/mix_hex_api_short_url.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex HTTP API - Short URLs.

--- a/src/mix_hex_api_user.erl
+++ b/src/mix_hex_api_user.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex HTTP API - Users.

--- a/src/mix_hex_cli_auth.erl
+++ b/src/mix_hex_cli_auth.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Authentication handling with callback functions for build-tool-specific operations.
@@ -273,7 +273,7 @@ with_repo(BaseConfig, Fun) ->
 %% <li>`repo_key' from `get_auth_config' callback - passthrough</li>
 %% <li>`auth_key' from `get_auth_config' when `trusted' is true and `oauth_exchange' is true - exchange for OAuth token</li>
 %% <li>`auth_key' from `get_auth_config' when `trusted' is true - use directly</li>
-%% <li>Global OAuth token from `get_oauth_tokens' callback</li>
+%% <li>Global OAuth token from `get_oauth_tokens' callback for Hex.pm repositories</li>
 %% <li>No auth when `optional' is true (with retry on 401)</li>
 %% <li>Prompt via `should_authenticate' when `auth_inline' is true</li>
 %% </ol>
@@ -475,7 +475,7 @@ resolve_api_auth(_Permission, Config) ->
 %% 1. repo_key from get_auth_config => passthrough
 %% 2. trusted + auth_key + oauth_exchange => exchange for OAuth token
 %% 3. trusted + auth_key => use directly
-%% 4. trusted + global OAuth tokens => use those
+%% 4. trusted Hex.pm or child repository + global OAuth tokens => use those
 %% 5. Fallthrough to no_auth (handled by with_repo/3 for optional/auth_inline)
 -spec resolve_repo_auth(mix_hex_core:config()) ->
     {ok, binary(), auth_context()} | no_auth | {error, auth_error()}.
@@ -517,8 +517,8 @@ do_resolve_repo_auth(RepoName, LookupRepo, Config) ->
                 [ParentName, _OrgName] ->
                     do_resolve_repo_auth(RepoName, ParentName, Config);
                 _ ->
-                    %% 6. trusted + global OAuth tokens => use those
-                    resolve_global_oauth_for_repo(Config)
+                    %% 6. trusted Hex.pm or child repository + global OAuth tokens => use those
+                    resolve_global_oauth_for_repo(RepoName, Config)
             end;
         _ ->
             %% 7. Not trusted, no auth
@@ -526,6 +526,13 @@ do_resolve_repo_auth(RepoName, LookupRepo, Config) ->
     end.
 
 %% @private
+resolve_global_oauth_for_repo(<<"hexpm">>, Config) ->
+    resolve_global_oauth_for_repo(Config);
+resolve_global_oauth_for_repo(<<"hexpm:", _/binary>>, Config) ->
+    resolve_global_oauth_for_repo(Config);
+resolve_global_oauth_for_repo(_RepoName, _Config) ->
+    no_auth.
+
 resolve_global_oauth_for_repo(Config) ->
     case resolve_oauth_token_with_context(Config) of
         {ok, Token, AuthContext} ->

--- a/src/mix_hex_core.erl
+++ b/src/mix_hex_core.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% `hex_core' entrypoint module.

--- a/src/mix_hex_core.hrl
+++ b/src/mix_hex_core.hrl
@@ -1,3 +1,3 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
--define(HEX_CORE_VERSION, "0.18.0").
+-define(HEX_CORE_VERSION, "0.19.0").

--- a/src/mix_hex_erl_tar.erl
+++ b/src/mix_hex_erl_tar.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% This file is a copy of erl_tar.erl from OTP with the following modifications:
 %% 1. Module renamed from erl_tar to mix_hex_erl_tar

--- a/src/mix_hex_erl_tar.hrl
+++ b/src/mix_hex_erl_tar.hrl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% This file is a copy of erl_tar.hrl from OTP with the following modifications:
 %% 1. Added chunk_size field to #read_opts{} for streaming extraction to disk

--- a/src/mix_hex_http.erl
+++ b/src/mix_hex_http.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% HTTP contract.

--- a/src/mix_hex_http_httpc.erl
+++ b/src/mix_hex_http_httpc.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% httpc-based implementation of {@link mix_hex_http} contract.

--- a/src/mix_hex_licenses.erl
+++ b/src/mix_hex_licenses.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Hex Licenses.

--- a/src/mix_hex_pb_names.erl
+++ b/src/mix_hex_pb_names.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% -*- coding: utf-8 -*-
 %% % this file is @generated

--- a/src/mix_hex_pb_package.erl
+++ b/src/mix_hex_pb_package.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% -*- coding: utf-8 -*-
 %% % this file is @generated

--- a/src/mix_hex_pb_policy.erl
+++ b/src/mix_hex_pb_policy.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% -*- coding: utf-8 -*-
 %% % this file is @generated

--- a/src/mix_hex_pb_signed.erl
+++ b/src/mix_hex_pb_signed.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% -*- coding: utf-8 -*-
 %% % this file is @generated

--- a/src/mix_hex_pb_versions.erl
+++ b/src/mix_hex_pb_versions.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% -*- coding: utf-8 -*-
 %% % this file is @generated

--- a/src/mix_hex_registry.erl
+++ b/src/mix_hex_registry.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Functions for encoding and decoding Hex registries.

--- a/src/mix_hex_repo.erl
+++ b/src/mix_hex_repo.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Repo API.

--- a/src/mix_hex_safe_binary_to_term.erl
+++ b/src/mix_hex_safe_binary_to_term.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @hidden
 %% Safe deserialization of Erlang terms from binary.

--- a/src/mix_hex_tarball.erl
+++ b/src/mix_hex_tarball.erl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %% @doc
 %% Functions for creating and unpacking Hex tarballs.

--- a/src/mix_safe_erl_term.xrl
+++ b/src/mix_safe_erl_term.xrl
@@ -1,4 +1,4 @@
-%% Vendored from hex_core v0.18.0 (d6a6a5a), do not edit manually
+%% Vendored from hex_core v0.19.0 (3133bb5), do not edit manually
 
 %%% Author  : Robert Virding
 %%% Purpose : Token definitions for Erlang.

--- a/test/hex/repo_test.exs
+++ b/test/hex/repo_test.exs
@@ -58,6 +58,32 @@ defmodule Hex.RepoTest do
     end)
   end
 
+  test "custom Hex.pm organization URL uses the global OAuth token" do
+    Hex.OAuth.store_token(%{
+      access_token: "hexpm-user-token",
+      refresh_token: "hexpm-refresh-token",
+      expires_at: System.system_time(:second) + 3600
+    })
+
+    bypass = Bypass.open()
+    repos = Hex.State.fetch!(:repos)
+
+    repos =
+      repos
+      |> Map.put("hexpm:acme", %{url: "http://localhost:#{bypass.port}"})
+      |> Hex.Repo.update_organizations()
+
+    Hex.State.put(:repos, repos)
+
+    Bypass.expect_once(bypass, "GET", "/tarballs/example-1.0.0.tar", fn conn ->
+      assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer hexpm-user-token"]
+      Plug.Conn.resp(conn, 200, "tarball")
+    end)
+
+    assert {:ok, {200, _, "tarball"}} =
+             Hex.Repo.get_tarball("hexpm:acme", "example", "1.0.0")
+  end
+
   test "get public key" do
     bypass = Bypass.open()
     repos = Hex.State.fetch!(:repos)

--- a/test/hex/repo_test.exs
+++ b/test/hex/repo_test.exs
@@ -17,6 +17,47 @@ defmodule Hex.RepoTest do
     end
   end
 
+  test "custom repository uses netrc instead of the global OAuth token" do
+    on_exit(fn -> System.delete_env("NETRC") end)
+
+    in_tmp(fn ->
+      Hex.State.put(:config_home, File.cwd!())
+
+      File.write!(".netrc", """
+      machine localhost
+        login repo-user
+        password repo-password
+      """)
+
+      System.put_env("NETRC", Path.join(File.cwd!(), ".netrc"))
+
+      Hex.OAuth.store_token(%{
+        access_token: "hexpm-user-token",
+        refresh_token: "hexpm-refresh-token",
+        expires_at: System.system_time(:second) + 3600
+      })
+
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/tarballs/example-1.0.0.tar", fn conn ->
+        assert Plug.Conn.get_req_header(conn, "authorization") == [
+                 "Basic #{Base.encode64("repo-user:repo-password")}"
+               ]
+
+        Plug.Conn.resp(conn, 200, "tarball")
+      end)
+
+      Mix.Tasks.Hex.Repo.run([
+        "add",
+        "custom",
+        "http://localhost:#{bypass.port}"
+      ])
+
+      assert {:ok, {200, _, "tarball"}} =
+               Hex.Repo.get_tarball("custom", "example", "1.0.0")
+    end)
+  end
+
   test "get public key" do
     bypass = Bypass.open()
     repos = Hex.State.fetch!(:repos)

--- a/test/hex/update_checker_test.exs
+++ b/test/hex/update_checker_test.exs
@@ -36,7 +36,7 @@ defmodule Hex.UpdateCheckerTest do
     assert {:version, _} = GenServer.call(pid, :check)
   end
 
-  test "uses the global OAuth token for Hex.pm" do
+  test "uses the global OAuth token instead of the repository key for Hex.pm" do
     flush()
 
     Hex.OAuth.store_token(%{
@@ -47,7 +47,13 @@ defmodule Hex.UpdateCheckerTest do
 
     bypass = Bypass.open()
     repos = Hex.State.fetch!(:repos)
-    repos = put_in(repos["hexpm"].url, "http://localhost:#{bypass.port}")
+
+    repos =
+      repos
+      |> put_in(["hexpm", :url], "http://localhost:#{bypass.port}")
+      |> put_in(["hexpm", :auth_key], "legacy-repo-key")
+      |> put_in(["hexpm", :oauth_exchange], false)
+
     Hex.State.put(:repos, repos)
 
     Bypass.expect_once(bypass, "GET", "/installs/hex-1.x.csv", fn conn ->

--- a/test/hex/update_checker_test.exs
+++ b/test/hex/update_checker_test.exs
@@ -36,36 +36,6 @@ defmodule Hex.UpdateCheckerTest do
     assert {:version, _} = GenServer.call(pid, :check)
   end
 
-  test "uses the global OAuth token instead of the repository key for Hex.pm" do
-    flush()
-
-    Hex.OAuth.store_token(%{
-      access_token: "hexpm-user-token",
-      refresh_token: "hexpm-refresh-token",
-      expires_at: System.system_time(:second) + 3600
-    })
-
-    bypass = Bypass.open()
-    repos = Hex.State.fetch!(:repos)
-
-    repos =
-      repos
-      |> put_in(["hexpm", :url], "http://localhost:#{bypass.port}")
-      |> put_in(["hexpm", :auth_key], "legacy-repo-key")
-      |> put_in(["hexpm", :oauth_exchange], false)
-
-    Hex.State.put(:repos, repos)
-
-    Bypass.expect_once(bypass, "GET", "/installs/hex-1.x.csv", fn conn ->
-      assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer hexpm-user-token"]
-      Plug.Conn.resp(conn, 200, versions_to_csv([{"100.0.0", "1.0.0"}]))
-    end)
-
-    {:ok, pid} = UpdateChecker.start_link(name: nil)
-    GenServer.cast(pid, :start_check)
-    assert {:version, _} = GenServer.call(pid, :check)
-  end
-
   test "dont display same hex version" do
     flush()
     bypass_csv([{"0.0.1", "1.0.0"}])

--- a/test/hex/update_checker_test.exs
+++ b/test/hex/update_checker_test.exs
@@ -36,6 +36,30 @@ defmodule Hex.UpdateCheckerTest do
     assert {:version, _} = GenServer.call(pid, :check)
   end
 
+  test "uses the global OAuth token for Hex.pm" do
+    flush()
+
+    Hex.OAuth.store_token(%{
+      access_token: "hexpm-user-token",
+      refresh_token: "hexpm-refresh-token",
+      expires_at: System.system_time(:second) + 3600
+    })
+
+    bypass = Bypass.open()
+    repos = Hex.State.fetch!(:repos)
+    repos = put_in(repos["hexpm"].url, "http://localhost:#{bypass.port}")
+    Hex.State.put(:repos, repos)
+
+    Bypass.expect_once(bypass, "GET", "/installs/hex-1.x.csv", fn conn ->
+      assert Plug.Conn.get_req_header(conn, "authorization") == ["Bearer hexpm-user-token"]
+      Plug.Conn.resp(conn, 200, versions_to_csv([{"100.0.0", "1.0.0"}]))
+    end)
+
+    {:ok, pid} = UpdateChecker.start_link(name: nil)
+    GenServer.cast(pid, :start_check)
+    assert {:version, _} = GenServer.call(pid, :check)
+  end
+
   test "dont display same hex version" do
     flush()
     bypass_csv([{"0.0.1", "1.0.0"}])

--- a/test/mix/tasks/hex.repo_test.exs
+++ b/test/mix/tasks/hex.repo_test.exs
@@ -124,6 +124,48 @@ defmodule Mix.Tasks.Hex.RepoTest do
     end)
   end
 
+  test "fetch public key uses netrc instead of the global OAuth token" do
+    on_exit(fn -> System.delete_env("NETRC") end)
+
+    in_tmp(fn ->
+      Hex.State.put(:config_home, File.cwd!())
+
+      File.write!(".netrc", """
+      machine localhost
+        login repo-user
+        password repo-password
+      """)
+
+      System.put_env("NETRC", Path.join(File.cwd!(), ".netrc"))
+
+      Hex.OAuth.store_token(%{
+        access_token: "hexpm-user-token",
+        refresh_token: "hexpm-refresh-token",
+        expires_at: System.system_time(:second) + 3600
+      })
+
+      bypass = Bypass.open()
+
+      Bypass.expect_once(bypass, "GET", "/public_key", fn conn ->
+        assert Plug.Conn.get_req_header(conn, "authorization") == [
+                 "Basic #{Base.encode64("repo-user:repo-password")}"
+               ]
+
+        Plug.Conn.resp(conn, 200, @public_key)
+      end)
+
+      Mix.Tasks.Hex.Repo.run([
+        "add",
+        "custom",
+        "http://localhost:#{bypass.port}",
+        "--fetch-public-key",
+        @public_key_fingerprint
+      ])
+
+      assert Hex.Repo.get_repo("custom").public_key == @public_key
+    end)
+  end
+
   test "remove" do
     in_tmp(fn ->
       Hex.State.put(:config_home, File.cwd!())


### PR DESCRIPTION
Prevent Hex.pm OAuth tokens from being sent to custom repositories. Repository configurations now expose the global OAuth token only for Hex.pm sources, allowing `.netrc` credentials to authenticate custom repository requests while preserving per-repository authentication.

Add regression coverage for tarball downloads and public-key fetching through `.netrc`, plus coverage that Hex.pm install checks retain global OAuth authentication.

Fixes #1216
