### PR TITLE
Update `auth` related warning message

### DIFF
--- a/lib/hex/auth.ex
+++ b/lib/hex/auth.ex
@@ -123,7 +123,7 @@ defmodule Hex.Auth do
       "Your authentication session has expired and could not be refreshed. " <>
         "Continuing without credentials; requests for private resources will fail or " <>
         "prompt for authentication. Run `mix hex.user auth` to re-authenticate" <>
-        "or run `mix hex.user deauth` to deauthorize the user from the local machine."
+        "or run `mix hex.user deauth` to deauthorize the user on the local machine."
     )
 
     :ok

--- a/lib/hex/auth.ex
+++ b/lib/hex/auth.ex
@@ -122,7 +122,8 @@ defmodule Hex.Auth do
     Hex.Shell.warn(
       "Your authentication session has expired and could not be refreshed. " <>
         "Continuing without credentials; requests for private resources will fail or " <>
-        "prompt for authentication. Run `mix hex.user auth` to re-authenticate"
+        "prompt for authentication. Run `mix hex.user auth` to re-authenticate" <>
+        "or run `mix hex.user deauth` to deauthorize the user from the local machine."
     )
 
     :ok


### PR DESCRIPTION
Closes #1224

## Summary

Update a warning message - add a hint for `mix hex.user deauth`

## Testing

Just a textual update to a warning message - no tests needed.
