### PR TITLE
Drop support for the Elixir config format

### DIFF
--- a/lib/hex/config.ex
+++ b/lib/hex/config.ex
@@ -131,6 +131,7 @@ defmodule Hex.Config do
     case :io.read(pid, ~c"") do
       {:ok, term} -> consult(pid, [term | acc], string)
       {:error, reason} -> {:error, reason}
+      :error -> {:error, :invalid_term}
       :eof -> {:ok, Enum.reverse(acc)}
     end
   end

--- a/lib/hex/config.ex
+++ b/lib/hex/config.ex
@@ -9,9 +9,10 @@ defmodule Hex.Config do
             migrate(term)
 
           {:error, _} ->
-            config = decode_elixir(binary)
-            write(config)
-            migrate(config)
+            Mix.raise(
+              "Could not read #{config_path()}, remove the file and run " <>
+                "`mix hex.user auth` to authenticate again"
+            )
         end
 
       {:error, _} ->
@@ -132,11 +133,6 @@ defmodule Hex.Config do
       {:error, reason} -> {:error, reason}
       :eof -> {:ok, Enum.reverse(acc)}
     end
-  end
-
-  defp decode_elixir(string) do
-    {term, _binding} = Code.eval_string(string)
-    term
   end
 
   def read_repos(config) do

--- a/test/hex/config_test.exs
+++ b/test/hex/config_test.exs
@@ -39,6 +39,18 @@ defmodule Hex.ConfigTest do
     System.delete_env("MIX_XDG")
   end
 
+  test "read/0 raises when the config is not readable" do
+    in_tmp(fn ->
+      set_home_cwd()
+
+      File.write!(Path.join(Hex.State.fetch!(:config_home), "hex.config"), "[foo: :bar]")
+
+      assert_raise Mix.Error, ~r/remove the file and run `mix hex\.user auth`/, fn ->
+        Config.read()
+      end
+    end)
+  end
+
   test "read/0 migrates string-keyed OAuth tokens to atom keys" do
     in_tmp(fn ->
       set_home_cwd()

--- a/test/hex/config_test.exs
+++ b/test/hex/config_test.exs
@@ -51,6 +51,18 @@ defmodule Hex.ConfigTest do
     end)
   end
 
+  test "read/0 raises when a stored binary is not valid UTF-8" do
+    in_tmp(fn ->
+      set_home_cwd()
+
+      Config.write(foo: [<<0xFF, 0xFE>>])
+
+      assert_raise Mix.Error, ~r/remove the file and run `mix hex\.user auth`/, fn ->
+        Config.read()
+      end
+    end)
+  end
+
   test "read/0 migrates string-keyed OAuth tokens to atom keys" do
     in_tmp(fn ->
       set_home_cwd()


### PR DESCRIPTION
`Hex.Config.do_read/0` fell back to `Code.eval_string/1` when `hex.config` failed Erlang term decoding, so an unreadable config was evaluated as Elixir source. That file holds the API key and the OAuth tokens.

The fallback dates to v0.5.0 (2014-09-19), which switched the write format to Erlang terms and kept an Elixir reader for existing files. v0.13.0 removed the reader and v0.13.1 reverted that, so the fallback has been in place continuously since 2014. It never converted anything on read, but `update/1` is read-modify-write against the term writer, so any config change (`mix hex.user auth`, adding an organization, anything touching `$repos`) has rewritten the file in the term format for the last ten years. A config still in the Elixir format is one no hex has written in that time.

The branch was also reached by any term decode failure, not only old-format files, so a truncated or corrupt config took the eval path too. It now raises and names the recovery step:

    Could not read ~/.hex/hex.config, remove the file and run `mix hex.user auth` to authenticate again

The second commit closes the other half of the same read path. `:io.read/2` answers a bare `:error` atom rather than an `{:error, reason}` tuple when a term is syntactically valid but cannot be read back, and `consult/3` had no clause for it, so the whole of `mix` raised `CaseClauseError` on every invocation until the file was deleted by hand. `Hex.State.start_link/1` calls `Hex.Config.read/0`, so there was no way to run the command that would have fixed it.

A non-UTF-8 organization name in `sso_reauth_required` gets there, which needs a hostile `HEX_API_URL` since hexpm validates organization names, but the same exposure already applied to `access_token` and `refresh_token`. It now raises the same `Mix.raise` as any other unreadable config.
