### PR TITLE
Create test users through hexpm's test endpoint

### DIFF
--- a/lib/hex/api/user.ex
+++ b/lib/hex/api/user.ex
@@ -17,16 +17,4 @@ defmodule Hex.API.User do
       optional: true
     )
   end
-
-  # NOTE: Only used for testing
-  def new(username, email, password) do
-    config = Client.config()
-
-    :mix_hex_api_user.create(
-      config,
-      to_string(username),
-      to_string(password),
-      to_string(email)
-    )
-  end
 end

--- a/test/hex/api_test.exs
+++ b/test/hex/api_test.exs
@@ -2,7 +2,7 @@ defmodule Hex.APITest do
   use HexTest.IntegrationCase, async: true
 
   test "user" do
-    assert {:ok, {201, _, _}} = Hex.API.User.new("test_user", "test_user@mail.com", "hunter42")
+    Hexpm.new_user("test_user", "test_user@mail.com", "hunter42")
     assert {:ok, {200, _, %{"username" => "test_user"}}} = Hex.API.User.get("test_user")
     assert {:ok, {404, _, _}} = Hex.API.User.get("unknown_user")
   end
@@ -111,7 +111,7 @@ defmodule Hex.APITest do
     auth = Hexpm.new_user("owners_user", "owners_user@mail.com", "hunter42", "key")
 
     Hexpm.new_package("hexpm", "orange", "0.0.1", %{}, %{}, auth)
-    Hex.API.User.new("orange_user", "orange_user@mail.com", "hunter42")
+    Hexpm.new_user("orange_user", "orange_user@mail.com", "hunter42")
 
     assert {:ok, {200, _, [%{"username" => "owners_user"}]}} =
              Hex.API.Package.Owner.get("hexpm", "orange", auth)

--- a/test/support/hexpm.ex
+++ b/test/support/hexpm.ex
@@ -204,9 +204,22 @@ defmodule HexTest.Hexpm do
     :mix_hex_api.post(config, ["repo"], body)
   end
 
+  def new_user(username, email, password) do
+    config = Hex.API.Client.config()
+
+    body = %{
+      "username" => to_string(username),
+      "email" => to_string(email),
+      "password" => to_string(password)
+    }
+
+    {:ok, {201, _, _}} = :mix_hex_api.post(config, ["user"], body)
+    :ok
+  end
+
   def new_user(username, email, password, key) do
     permissions = [%{"domain" => "api"}, %{"domain" => "repositories"}]
-    {:ok, {201, _, _}} = Hex.API.User.new(username, email, password)
+    new_user(username, email, password)
 
     {:ok, {201, _, %{"secret" => secret}}} =
       Hex.API.Key.new(key, permissions, user: username, pass: password)
@@ -290,7 +303,7 @@ defmodule HexTest.Hexpm do
     unique_email = "#{timestamp}_#{random_suffix}_#{email}"
 
     # Create user account
-    {:ok, {201, _, _}} = Hex.API.User.new(unique_username, unique_email, password)
+    new_user(unique_username, unique_email, password)
 
     # Create real OAuth tokens through the test server endpoints
     config = Hex.API.Client.config()


### PR DESCRIPTION
hexpm removes `POST /api/users` in https://github.com/hexpm/hexpm/pull/1885. The integration suite created every test user through it, so each `setup_all` that calls `HexTest.Hexpm.new_user` fails with a 404 against that branch and the whole module is invalidated. hexpm adds `POST /api/user` to its test controller (dev, test and hex environments only), and `new_user/3` here posts to it; `new_user/4` and `new_oauth_user/3` go through it. `Hex.API.User.new/3` was only used by the tests and is removed.

CI here clones hexpm main, so this stays red until the test endpoint lands there. The same change goes to v2.5, v2.4, v2.3 and v2.2 after this merges.
